### PR TITLE
fix(admin-ui): Add dashboard orders summary "supportedWidths"

### DIFF
--- a/packages/admin-ui/src/lib/dashboard/src/default-widgets.ts
+++ b/packages/admin-ui/src/lib/dashboard/src/default-widgets.ts
@@ -21,6 +21,7 @@ export const DEFAULT_WIDGETS: { [id: string]: DashboardWidgetConfig } = {
     orderSummary: {
         title: _('dashboard.orders-summary'),
         loadComponent: () => OrderSummaryWidgetComponent,
+        supportedWidths: [4, 6, 8, 12],
         requiresPermissions: [Permission.ReadOrder],
     },
     latestOrders: {


### PR DESCRIPTION

![134706@2x](https://github.com/vendure-ecommerce/vendure/assets/134155599/9741b175-d6b3-4ba7-a1e9-0139b700d8e2)
