### PR TITLE
chore(admin-ui): Update tab color

### DIFF
--- a/packages/admin-ui/src/lib/core/src/shared/components/page-header-tabs/page-header-tabs.component.scss
+++ b/packages/admin-ui/src/lib/core/src/shared/components/page-header-tabs/page-header-tabs.component.scss
@@ -5,6 +5,11 @@
 
 .tab-bar {
     display: flex;
+    
+    & a:hover {
+        color: var(--color-text-active);
+        border-bottom-color: var(--color-text-active);
+    }
 }
 
 .tab {

--- a/packages/admin-ui/src/lib/static/styles/theme/default.scss
+++ b/packages/admin-ui/src/lib/static/styles/theme/default.scss
@@ -119,7 +119,7 @@
     --color-text-200: var(--clr-global-font-color-secondary);
     --color-text-300: var(--color-grey-400);
     --color-text-inverse: white;
-    --color-text-active: var(--color-primary-800);
+    --color-text-active: var(--color-primary-600);
 
     // Component-specific colors
     --color-scrollbar-bg: var(--color-weight-150);


### PR DESCRIPTION
I like the Vendure bule, so I did a little color tweak. I wanted to keep this clean feel, without too much color.
Before:
![001518@2x](https://github.com/vendure-ecommerce/vendure/assets/134155599/6a0672c4-4e65-4336-bba7-0cfb434fcfb1)
After:
![002238@2x](https://github.com/vendure-ecommerce/vendure/assets/134155599/58ac3864-1f13-4484-b856-39e3e0899520)
