### PR TITLE
chore(admin-ui): Link-visited color tweak

### DIFF
--- a/packages/admin-ui/src/lib/static/styles/global/_sass-overrides.scss
+++ b/packages/admin-ui/src/lib/static/styles/global/_sass-overrides.scss
@@ -1,3 +1,4 @@
 // Note: variables defined in this file should use the !default flag so they can be
 // overridden by custom Admin UI applications
 $clr-sidenav-width: 10.8rem !default;
+$clr-link-visited-color: var(--clr-list-item-color);

--- a/packages/admin-ui/src/lib/static/styles/theme/dark.scss
+++ b/packages/admin-ui/src/lib/static/styles/theme/dark.scss
@@ -110,7 +110,7 @@
     --clr-link-active-color: hsl(198, 65%, 57%);
     --clr-link-color: hsl(198, 65%, 57%);
     --clr-link-hover-color: hsl(198, 65%, 57%);
-    --clr-link-visited-color: hsl(228, 55%, 75%);
+    --clr-link-visited-color: var(--clr-list-item-color);
 
     --clr-theme-alert-font-color: hsl(210, 16%, 93%);
     --clr-theme-app-alert-font-color: hsl(0, 0%, 0%);

--- a/packages/admin-ui/src/lib/static/styles/theme/default.scss
+++ b/packages/admin-ui/src/lib/static/styles/theme/default.scss
@@ -236,4 +236,7 @@
 
     // spacing
     --space-unit: 8px;
+
+    // clarity styles
+    --clr-link-visited-color: var(--clr-list-item-color);
 }


### PR DESCRIPTION
# Screenshots

Before:
<img width="718" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/5d8c6a02-fc06-4ba0-9527-3c9d55c9599f">
<img width="724" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/1d71f053-7852-4f5f-84fc-a0e888b58fb7">

After:
<img width="736" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/046df8b4-983e-4ed7-8981-ff448377395c">
<img width="749" alt="image" src="https://github.com/vendure-ecommerce/vendure/assets/134155599/a02995b2-fc73-4e85-a85a-ec7e4a82fd50">