### PR TITLE
Elasticsearch: use correct exception text for hits aggregation

### DIFF
--- a/packages/elasticsearch-plugin/src/elasticsearch.service.ts
+++ b/packages/elasticsearch-plugin/src/elasticsearch.service.ts
@@ -274,7 +274,7 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
         const { aggregations } = body;
         if (!aggregations) {
             throw new InternalServerError(
-                'An error occurred when querying Elasticsearch for priceRange aggregations',
+                'An error occurred when querying Elasticsearch for total hits aggregation',
             );
         }
         return aggregations.total ? aggregations.total.value : 0;


### PR DESCRIPTION
This fixes a wrong exception message text: the given exception is not related to priceRange, but rather to total hits by a given product