### PR TITLE
feat(core) Add CreateUser method to ExternalAuthenticationService Helper

### DIFF
--- a/packages/core/src/entity/administrator/administrator.entity.ts
+++ b/packages/core/src/entity/administrator/administrator.entity.ts
@@ -1,40 +1,267 @@
-import { DeepPartial } from '@vendure/common/lib/shared-types';
-import { Column, Entity, JoinColumn, OneToOne } from 'typeorm';
+import { Injectable } from '@nestjs/common';
+import { HistoryEntryType } from '@vendure/common/lib/generated-types';
 
-import { SoftDeletable } from '../../common/types/common-types';
-import { HasCustomFields } from '../../config/custom-field/custom-field-types';
-import { VendureEntity } from '../base/base.entity';
-import { CustomAdministratorFields } from '../custom-entity-fields';
-import { User } from '../user/user.entity';
+import { RequestContext } from '../../../api/common/request-context';
+import { TransactionalConnection } from '../../../connection/transactional-connection';
+import { Administrator } from '../../../entity/administrator/administrator.entity';
+import { ExternalAuthenticationMethod } from '../../../entity/authentication-method/external-authentication-method.entity';
+import { Customer } from '../../../entity/customer/customer.entity';
+import { Role } from '../../../entity/role/role.entity';
+import { User } from '../../../entity/user/user.entity';
+import { AdministratorService } from '../../services/administrator.service';
+import { ChannelService } from '../../services/channel.service';
+import { CustomerService } from '../../services/customer.service';
+import { HistoryService } from '../../services/history.service';
+import { RoleService } from '../../services/role.service';
 
 /**
  * @description
- * An administrative user who has access to the Admin UI and Admin API. The
- * specific permissions of the Administrator are determined by the assigned
- * {@link Role}s.
+ * This is a helper service which exposes methods related to looking up and creating Users based on an
+ * external {@link AuthenticationStrategy}.
  *
- * @docsCategory entities
+ * @docsCategory auth
  */
-@Entity()
-export class Administrator extends VendureEntity implements SoftDeletable, HasCustomFields {
-    constructor(input?: DeepPartial<Administrator>) {
-        super(input);
+@Injectable()
+export class ExternalAuthenticationService {
+    constructor(
+        private connection: TransactionalConnection,
+        private roleService: RoleService,
+        private historyService: HistoryService,
+        private customerService: CustomerService,
+        private administratorService: AdministratorService,
+        private channelService: ChannelService,
+    ) {}
+
+    /**
+     * @description
+     * Looks up a User based on their identifier from an external authentication
+     * provider, ensuring this User is associated with a Customer account.
+     *
+     * By default, only customers in the currently-active Channel will be checked.
+     * By passing `false` as the `checkCurrentChannelOnly` argument, _all_ channels
+     * will be checked.
+     */
+    async findCustomerUser(
+        ctx: RequestContext,
+        strategy: string,
+        externalIdentifier: string,
+        checkCurrentChannelOnly = true,
+    ): Promise<User | undefined> {
+        const user = await this.findUser(ctx, strategy, externalIdentifier);
+
+        if (user) {
+            // Ensure this User is associated with a Customer
+            const customer = await this.customerService.findOneByUserId(
+                ctx,
+                user.id,
+                checkCurrentChannelOnly,
+            );
+            if (customer) {
+                return user;
+            }
+        }
     }
 
-    @Column({ type: Date, nullable: true })
-    deletedAt: Date | null;
+    /**
+     * @description
+     * Looks up a User based on their identifier from an external authentication
+     * provider, ensuring this User is associated with an Administrator account.
+     */
+    async findAdministratorUser(
+        ctx: RequestContext,
+        strategy: string,
+        externalIdentifier: string,
+    ): Promise<User | undefined> {
+        const user = await this.findUser(ctx, strategy, externalIdentifier);
+        if (user) {
+            // Ensure this User is associated with an Administrator
+            const administrator = await this.administratorService.findOneByUserId(ctx, user.id);
+            if (administrator) {
+                return user;
+            }
+        }
+    }
 
-    @Column() firstName: string;
+    /**
+     * @description
+     * If a customer has been successfully authenticated by an external authentication provider, yet cannot
+     * be found using `findCustomerUser`, then we need to create a new User and
+     * Customer record in Vendure for that user. This method encapsulates that logic as well as additional
+     * housekeeping such as adding a record to the Customer's history.
+     */
+    async createCustomerAndUser(
+        ctx: RequestContext,
+        config: {
+            strategy: string;
+            externalIdentifier: string;
+            verified: boolean;
+            emailAddress: string;
+            firstName?: string;
+            lastName?: string;
+        },
+    ): Promise<User> {
+        let user: User;
 
-    @Column() lastName: string;
+        const existingUser = await this.findExistingCustomerUserByEmailAddress(ctx, config.emailAddress);
 
-    @Column({ unique: true })
-    emailAddress: string;
+        if (existingUser) {
+            user = existingUser;
+        } else {
+            const customerRole = await this.roleService.getCustomerRole(ctx);
+            user = new User({
+                identifier: config.emailAddress,
+                roles: [customerRole],
+                verified: config.verified || false,
+                authenticationMethods: [],
+            });
+        }
+        const authMethod = await this.connection.getRepository(ctx, ExternalAuthenticationMethod).save(
+            new ExternalAuthenticationMethod({
+                externalIdentifier: config.externalIdentifier,
+                strategy: config.strategy,
+            }),
+        );
 
-    @OneToOne(type => User)
-    @JoinColumn()
-    user: User;
+        user.authenticationMethods = [...(user.authenticationMethods || []), authMethod];
+        const savedUser = await this.connection.getRepository(ctx, User).save(user);
 
-    @Column(type => CustomAdministratorFields)
-    customFields: CustomAdministratorFields;
+        let customer: Customer;
+        const existingCustomer = await this.customerService.findOneByUserId(ctx, savedUser.id);
+        if (existingCustomer) {
+            customer = existingCustomer;
+        } else {
+            customer = new Customer({
+                emailAddress: config.emailAddress,
+                firstName: config.firstName,
+                lastName: config.lastName,
+                user: savedUser,
+            });
+        }
+        await this.channelService.assignToCurrentChannel(customer, ctx);
+        await this.connection.getRepository(ctx, Customer).save(customer);
+
+        await this.historyService.createHistoryEntryForCustomer({
+            customerId: customer.id,
+            ctx,
+            type: HistoryEntryType.CUSTOMER_REGISTERED,
+            data: {
+                strategy: config.strategy,
+            },
+        });
+
+        if (config.verified) {
+            await this.historyService.createHistoryEntryForCustomer({
+                customerId: customer.id,
+                ctx,
+                type: HistoryEntryType.CUSTOMER_VERIFIED,
+                data: {
+                    strategy: config.strategy,
+                },
+            });
+        }
+
+        return savedUser;
+    }
+
+    /**
+     * @description
+     * If an administrator has been successfully authenticated by an external authentication provider, yet cannot
+     * be found using `findAdministratorUser`, then we need to create a new User and
+     * Administrator record in Vendure for that user.
+     */
+    async createAdministratorAndUser(
+        ctx: RequestContext,
+        config: {
+            strategy: string;
+            externalIdentifier: string;
+            identifier: string;
+            emailAddress?: string;
+            firstName?: string;
+            lastName?: string;
+            roles: Role[];
+        },
+    ): Promise<User> {
+        const newUser = new User({
+            identifier: config.identifier,
+            roles: config.roles,
+            verified: true,
+        });
+
+        const authMethod = await this.connection.getRepository(ctx, ExternalAuthenticationMethod).save(
+            new ExternalAuthenticationMethod({
+                externalIdentifier: config.externalIdentifier,
+                strategy: config.strategy,
+            }),
+        );
+
+        newUser.authenticationMethods = [authMethod];
+        const savedUser = await this.connection.getRepository(ctx, User).save(newUser);
+
+        const administrator = await this.connection.getRepository(ctx, Administrator).save(
+            new Administrator({
+                emailAddress: config.emailAddress,
+                firstName: config.firstName,
+                lastName: config.lastName,
+                user: savedUser,
+            }),
+        );
+
+        return savedUser;
+    }
+    /**
+     * @description
+     * Creates a new User with the given strategy and external identifier.
+       This method is used when a user is authenticated by an external provider without email.
+     */
+
+    async createUser(
+        ctx: RequestContext,
+        config: {
+            strategy: string;
+            externalIdentifier: string;
+        },
+    ): Promise<User> {
+        const newUser = new User();
+        const authMethod = await this.connection.getRepository(ctx, ExternalAuthenticationMethod).save(
+            new ExternalAuthenticationMethod({
+                externalIdentifier: config.externalIdentifier,
+                strategy: config.strategy,
+            }),
+        );
+        newUser.identifier = config.externalIdentifier;
+        newUser.authenticationMethods = [authMethod];
+        const savedUser = await this.connection.getRepository(ctx, User).save(newUser);
+        return savedUser;
+    }
+
+    async findUser(
+        ctx: RequestContext,
+        strategy: string,
+        externalIdentifier: string,
+    ): Promise<User | undefined> {
+        const user = await this.connection
+            .getRepository(ctx, User)
+            .createQueryBuilder('user')
+            .leftJoinAndSelect('user.authenticationMethods', 'aums')
+            .leftJoin('user.authenticationMethods', 'authMethod')
+            .andWhere('authMethod.externalIdentifier = :externalIdentifier', { externalIdentifier })
+            .andWhere('authMethod.strategy = :strategy', { strategy })
+            .andWhere('user.deletedAt IS NULL')
+            .getOne();
+        return user || undefined;
+    }
+
+    private async findExistingCustomerUserByEmailAddress(ctx: RequestContext, emailAddress: string) {
+        const customer = await this.connection
+            .getRepository(ctx, Customer)
+            .createQueryBuilder('customer')
+            .leftJoinAndSelect('customer.user', 'user')
+            .leftJoin('customer.channels', 'channel')
+            .leftJoinAndSelect('user.authenticationMethods', 'authMethod')
+            .andWhere('customer.emailAddress = :emailAddress', { emailAddress })
+            .andWhere('user.deletedAt IS NULL')
+            .getOne();
+
+        return customer?.user;
+    }
 }


### PR DESCRIPTION
# Description

Added createUser method to external authentication helper to support the case where user is authenticated via external provider without email. There is a case (ie mobile app only store) where we only want authenticated users to see products and and be able to add to carts. This is also useful for anti-scraping.

I also returned savedUser from all methods for consistency and added type for missing method.
# Breaking changes

Nope

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [XI have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

I added code description which will auto update readme
👍 Most of the time:
- [X] I have added or updated test cases
- [X] I have updated the README if needed

I have read the CLA Document and I hereby sign the CLA

AHMET TOK
ARRRRNY