### PR TITLE
fix: Management of BullMQ queue prefixes

### DIFF
--- a/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
+++ b/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
@@ -54,17 +54,18 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
 
     private initOptions(injector: Injector): BullMQPluginOptions {
         const options = injector.get<BullMQPluginOptions>(BULLMQ_PLUGIN_OPTIONS);
-        if (!options.workerOptions) {
-            options.workerOptions = {};
+        options.workerOptions = {
+            ...(options.workerOptions ?? {
+                removeOnComplete: {
+                    age: 60 * 60 * 24 * 30,
+                    count: 5000,
+                },
+                removeOnFail: {
+                    age: 60 * 60 * 24 * 30,
+                    count: 5000,
+                },
+            })
         }
-        options.workerOptions.removeOnComplete = options.workerOptions.removeOnComplete || {
-            age: 60 * 60 * 24 * 30,
-            count: 5000,
-        };
-        options.workerOptions.removeOnFail = options.workerOptions.removeOnFail || {
-            age: 60 * 60 * 24 * 30,
-            count: 5000,
-        };
         return options
     }
 


### PR DESCRIPTION


# Description

In my project i planned to use same Redis for multiple Vendure instances, and wanted to separate BullMQ queus using worker/queue prefixes. However, current implementation had 2 issues:

1. replacing ALL passed worker options by default values
2. assuming that all redis scripts should be executed vs 'bull:*' queues, which contradicts with worker/queue options

NB: I know that passing in a `db` to the `connection` options would be a viable way to achieve my goal as stated in https://github.com/vendure-ecommerce/vendure/issues/2645, however making worker/queue prefixes work as they should be IMO is a nice thing.

# Breaking changes

None

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
