### PR TITLE
perf(core): disable lastLogin update as an option

### DIFF
--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -99,6 +99,7 @@ export const defaultConfig: RuntimeVendureConfig = {
         sessionCacheStrategy: new InMemorySessionCacheStrategy(),
         sessionCacheTTL: 300,
         requireVerification: true,
+        disableLastLoginUpdate: false,
         verificationTokenDuration: '7d',
         superadminCredentials: {
             identifier: SUPER_ADMIN_USER_IDENTIFIER,

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -473,6 +473,13 @@ export interface AuthOptions {
      * @default DefaultPasswordValidationStrategy
      */
     passwordValidationStrategy?: PasswordValidationStrategy;
+    /**
+     * @description
+     * Disable the last login update (prevent a save on user entity) when a user logs in.
+     * This can be useful when there is a lot of authentication in a short period of time and get lock on the user table.
+     * @since 3.0.7
+     */
+    disableLastLoginUpdate?: boolean
 }
 
 /**

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -476,7 +476,7 @@ export interface AuthOptions {
     /**
      * @description
      * Disable the last login update (prevent a save on user entity) when a user logs in.
-     * This can be useful when there is a lot of authentication in a short period of time and get lock on the user table.
+     * This can be useful when there are a lot of authentication in a short period of time and there are locks on the user table.
      * @since 3.0.7
      */
     disableLastLoginUpdate?: boolean

--- a/packages/core/src/service/services/auth.service.ts
+++ b/packages/core/src/service/services/auth.service.ts
@@ -97,8 +97,10 @@ export class AuthService {
         if (ctx.session && ctx.session.activeOrderId) {
             await this.sessionService.deleteSessionsByActiveOrderId(ctx, ctx.session.activeOrderId);
         }
-        user.lastLogin = new Date();
-        await this.connection.getRepository(ctx, User).save(user, { reload: false });
+        if (user.roles || !this.configService.authOptions.disableLastLoginUpdate) {
+            user.lastLogin = new Date();
+            await this.connection.getRepository(ctx, User).save(user, { reload: false });
+        }
         const session = await this.sessionService.createNewAuthenticatedSession(
             ctx,
             user,


### PR DESCRIPTION
# Description

Disable the last login update (prevent a save on user entity) when a user logs in.

# Breaking changes
No

# Screenshots

context: our users need to be authenticated to view our products.
We receive a lots of request on the authenticate endpoint, and we have a bottleneck on this endpoint.

When we have too much traffic, we have locks on the ‘user’ table

<img width="1311" alt="Capture d’écran 2024-11-29 à 15 47 49" src="https://github.com/user-attachments/assets/f6965dec-04ef-4743-95fa-70f82e652b8b">

<img width="1080" alt="Capture d’écran 2024-11-29 à 15 48 16" src="https://github.com/user-attachments/assets/1b464955-ce34-4419-a4df-3c33c8925b4f">

Here is the request `UPDATE "user" SET "lastLogin" = $1, "updatedAt" = CURRENT_TIMESTAMP WHERE "id" IN ($2)`
This query is not useful for us. This PR proposes a solution to deactivate it and avoid a lock on the user table.
In terms of volume, this represents more than 250k updates of the lastLogin field per day, often at the same connection time.

Not sure where to write the tests, please let me know. 

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
