### PR TITLE
fix(dashboard): Add vite plugin support for type:module & nodenext

### DIFF
--- a/packages/dashboard/vite/utils/config-loader.ts
+++ b/packages/dashboard/vite/utils/config-loader.ts
@@ -78,7 +78,7 @@ export async function loadVendureConfig(options: ConfigLoaderOptions): Promise<L
         /.ts$/,
         '.js',
     );
-    // create package.json with type commonjs and save it to the output dir
+    // create package.json with type module and save it to the output dir
     await fs.writeFile(path.join(outputPath, 'package.json'), JSON.stringify({ type: 'module' }, null, 2));
 
     // We need to figure out the symbol exported by the config file by
@@ -370,7 +370,7 @@ export async function compileFile({
         const compilerOptions: ts.CompilerOptions = {
             // Base options
             target: ts.ScriptTarget.ES2020,
-            module: ts.ModuleKind.NodeNext, // Output CommonJS for Node compatibility
+            module: ts.ModuleKind.NodeNext, // Support both CommonJS and ES modules based on package.json
             experimentalDecorators: true,
             emitDecoratorMetadata: true,
             esModuleInterop: true,


### PR DESCRIPTION
# Description

fix dashboard vite plugin available both for commonjs & type:module nodenext support

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved detection of TypeScript path mappings to ignore empty configurations.

- **Refactor**
  - Updated module output to use ES modules for better compatibility with modern Node.js environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->