### PR TITLE
feat(ci): Add GitHub Actions workflow to publish master branch to NPM

### DIFF
--- a/.github/workflows/publish_master_to_npm.yml
+++ b/.github/workflows/publish_master_to_npm.yml
@@ -10,6 +10,7 @@ jobs:
     publish:
         runs-on: ubuntu-latest
         permissions:
+            contents: read
             id-token: write
 
         # Only allow workflow to run on master branch


### PR DESCRIPTION
# Description

Adds a workflow that deploys that latest changes from `master` to npm. The workflow bumps the version before publishing the package to the the following format: `<next-patch-version>-master-YYYYMMDDHHMM`

Example version: `3.3.4-master-202506181014`

# Breaking changes

no

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
