### PR TITLE
fix(core): Let InitializerService hook OnApplicationBootstrap instead of OnModuleInit

### DIFF
--- a/packages/core/e2e/lifecycle-init-order.e2e-spec.ts
+++ b/packages/core/e2e/lifecycle-init-order.e2e-spec.ts
@@ -1,5 +1,11 @@
 import { Injectable, OnModuleInit } from '@nestjs/common';
-import { AutoIncrementIdStrategy, Injector, PluginCommonModule, VendurePlugin } from '@vendure/core';
+import {
+    AutoIncrementIdStrategy,
+    Injector,
+    PluginCommonModule,
+    ProductService,
+    VendurePlugin,
+} from '@vendure/core';
 import { createTestEnvironment } from '@vendure/testing';
 import path from 'path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
@@ -7,26 +13,30 @@ import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { initialData } from '../../../e2e-common/e2e-initial-data';
 import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
 
-let strategyInitedAt: number | null = null;
-let consumerOnModuleInitAt: number | null = null;
+let strategyInitialized = false;
+let strategyResolvedDependency = false;
 let consumerSawStrategyInitialized = false;
 
 class OrderingTestStrategy extends AutoIncrementIdStrategy {
-    async init(_: Injector) {
-        // Small delay so that, were ConfigModule to initialize strategies after
-        // other modules' onModuleInit, the consumer below would observe a still-
-        // null strategyInitedAt. With the correct ordering the delay does not
-        // matter — strategy init must complete before any onModuleInit fires.
+    async init(injector: Injector) {
+        // Locks down the other half of the contract: by the time a strategy's
+        // init() runs, its own dependencies must already be resolvable via the
+        // Injector.
+        const productService = injector.get(ProductService);
+        strategyResolvedDependency = productService.constructor.name === 'ProductService';
+        // The delay is not for synchronisation — it is purely to amplify the
+        // failure signal of a regression. If ConfigModule reverts to running
+        // strategy init at onApplicationBootstrap, this 50ms gap makes sure the
+        // consumer's onModuleInit observes strategyInitialized as still false.
         await new Promise(resolve => setTimeout(resolve, 50));
-        strategyInitedAt = Date.now();
+        strategyInitialized = true;
     }
 }
 
 @Injectable()
 class StrategyConsumerService implements OnModuleInit {
     onModuleInit() {
-        consumerOnModuleInitAt = Date.now();
-        consumerSawStrategyInitialized = strategyInitedAt !== null;
+        consumerSawStrategyInitialized = strategyInitialized;
     }
 }
 
@@ -73,10 +83,9 @@ describe('strategy init order', () => {
         await server.destroy();
     });
 
-    it('strategy init() completes before plugin service onModuleInit', () => {
-        expect(strategyInitedAt).not.toBeNull();
-        expect(consumerOnModuleInitAt).not.toBeNull();
+    it('resolves dependencies in strategy init() and runs it before plugin onModuleInit', () => {
+        expect(strategyInitialized).toBe(true);
+        expect(strategyResolvedDependency).toBe(true);
         expect(consumerSawStrategyInitialized).toBe(true);
-        expect(strategyInitedAt ?? Infinity).toBeLessThanOrEqual(consumerOnModuleInitAt ?? -Infinity);
     });
 });

--- a/packages/core/e2e/lifecycle-init-order.e2e-spec.ts
+++ b/packages/core/e2e/lifecycle-init-order.e2e-spec.ts
@@ -1,0 +1,82 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { AutoIncrementIdStrategy, Injector, PluginCommonModule, VendurePlugin } from '@vendure/core';
+import { createTestEnvironment } from '@vendure/testing';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
+
+let strategyInitedAt: number | null = null;
+let consumerOnModuleInitAt: number | null = null;
+let consumerSawStrategyInitialized = false;
+
+class OrderingTestStrategy extends AutoIncrementIdStrategy {
+    async init(_: Injector) {
+        // Small delay so that, were ConfigModule to initialize strategies after
+        // other modules' onModuleInit, the consumer below would observe a still-
+        // null strategyInitedAt. With the correct ordering the delay does not
+        // matter — strategy init must complete before any onModuleInit fires.
+        await new Promise(resolve => setTimeout(resolve, 50));
+        strategyInitedAt = Date.now();
+    }
+}
+
+@Injectable()
+class StrategyConsumerService implements OnModuleInit {
+    onModuleInit() {
+        consumerOnModuleInitAt = Date.now();
+        consumerSawStrategyInitialized = strategyInitedAt !== null;
+    }
+}
+
+@VendurePlugin({
+    imports: [PluginCommonModule],
+    providers: [StrategyConsumerService],
+})
+class StrategyConsumerPlugin {
+    // The constructor injection is required so that Nest instantiates the
+    // service (and thus runs its onModuleInit). Without a reference, an
+    // unused provider in an otherwise-empty plugin module is not exercised.
+    constructor(_consumer: StrategyConsumerService) {
+        // intentionally empty
+    }
+}
+
+/**
+ * Regression test for the contract that an InjectableStrategy's `init()` is
+ * always invoked before any other module's `onModuleInit` runs, so that
+ * strategies can be safely consumed via the `Injector` during module
+ * initialization. This is implemented by having `ConfigModule` perform its
+ * strategy initialization in `onModuleInit` rather than `onApplicationBootstrap`.
+ *
+ * NOTE: this test lives in its own file because the AppModule statically reads
+ * `getConfig().plugins` once via `PluginModule.forRoot()`, so plugins added by
+ * later test envs in the same file are not picked up.
+ */
+describe('strategy init order', () => {
+    const { server } = createTestEnvironment({
+        ...testConfig(),
+        entityOptions: { entityIdStrategy: new OrderingTestStrategy() },
+        plugins: [StrategyConsumerPlugin],
+    });
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-empty.csv'),
+            customerCount: 1,
+        });
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    it('strategy init() completes before plugin service onModuleInit', () => {
+        expect(strategyInitedAt).not.toBeNull();
+        expect(consumerOnModuleInitAt).not.toBeNull();
+        expect(consumerSawStrategyInitialized).toBe(true);
+        expect(strategyInitedAt ?? Infinity).toBeLessThanOrEqual(consumerOnModuleInitAt ?? -Infinity);
+    });
+});

--- a/packages/core/src/config/config.module.ts
+++ b/packages/core/src/config/config.module.ts
@@ -1,4 +1,4 @@
-import { Module, OnApplicationBootstrap, OnApplicationShutdown } from '@nestjs/common';
+import { Module, OnApplicationShutdown, OnModuleInit } from '@nestjs/common';
 import { ModuleRef } from '@nestjs/core';
 
 import { ConfigurableOperationDef } from '../common/configurable-operation';
@@ -12,13 +12,13 @@ import { ConfigService } from './config.service';
     providers: [ConfigService],
     exports: [ConfigService],
 })
-export class ConfigModule implements OnApplicationBootstrap, OnApplicationShutdown {
+export class ConfigModule implements OnModuleInit, OnApplicationShutdown {
     constructor(
         private configService: ConfigService,
         private moduleRef: ModuleRef,
     ) {}
 
-    async onApplicationBootstrap() {
+    async onModuleInit() {
         await this.initInjectableStrategies();
         await this.initConfigurableOperations();
     }

--- a/packages/core/src/config/config.module.ts
+++ b/packages/core/src/config/config.module.ts
@@ -18,6 +18,12 @@ export class ConfigModule implements OnModuleInit, OnApplicationShutdown {
         private moduleRef: ModuleRef,
     ) {}
 
+    /**
+     * Strategies are initialized at `onModuleInit` rather than `onApplicationBootstrap`
+     * so they are guaranteed to be ready before any other module's `onModuleInit` fires.
+     * This lets services that need configured strategies via the `Injector` use them
+     * during the module-init phase.
+     */
     async onModuleInit() {
         await this.initInjectableStrategies();
         await this.initConfigurableOperations();

--- a/packages/core/src/service/initializer.service.ts
+++ b/packages/core/src/service/initializer.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
 
 import { Logger } from '../config/logger/vendure-logger';
 import { TransactionalConnection } from '../connection/transactional-connection';
@@ -24,7 +24,7 @@ import { ZoneService } from './services/zone.service';
  * @docsCategory services
  */
 @Injectable()
-export class InitializerService {
+export class InitializerService implements OnApplicationBootstrap {
     constructor(
         private connection: TransactionalConnection,
         private zoneService: ZoneService,
@@ -39,7 +39,7 @@ export class InitializerService {
         private stockLocationService: StockLocationService,
     ) {}
 
-    async onModuleInit() {
+    async onApplicationBootstrap() {
         await this.awaitDbSchemaGeneration();
         // IMPORTANT - why manually invoke these init methods rather than just relying on
         // Nest's "onModuleInit" lifecycle hook within each individual service class?


### PR DESCRIPTION
While working on something else I found this logic bug, copying over [from here](https://github.com/vendure-ecommerce/vendure/pull/3222#issuecomment-3033144407) so that this PR stays self contained:

In #3222 I am trying to introduce a new strategy which is needed during the intitialization phase of Vendure but due to the order of nest module life cycle hooks, Vendure currently fails to get injectables during initialization.

1. I did include the strategy in the config modules `private getInjectableStrategies()` - This is important because the strategies get initialized in the above `initInjectableStrategies()` which gets called in the config modules `onApplicationBootstrap` hook. This is correct, but keyword being this specific lifecycle hook.
2. The `InitializerService` which is responsible for calling Vendure-essential initializations sequentially, hooks into `onModuleInit` which runs **BEFORE** `onApplicationBootstrap`-hooks i.e. before the config module.
3. So after nest boots up and starts calling all the needed hooked in modules, `InitializerService` starts initializing multiple things like channels, roles, admins, etc. **BEFORE** the config module was able to call `initInjectableStrategies()` - which only gets called after, at application bootstrap.
4. This results in strategies not having their `init(injector: Injector)` function called in time, making essential dependencies like `TransactionalConnection` and other services undefined.

I quickly skimmed through all the initializer functions and this bug has been hiding until today because none of the essential services used injectable strategies in their initialization. As soon as Vendure introduces some strategy, thats needed when initializing, this bug will occur.

# Description

For testing purposes I swapped the hooks so that config module injects before initializerservice runs.

# Breaking changes

Since this touches the very core of Vendure we must check thoroughly - are there further things to consider? I think nest calls the hooks concurrently through promise.all so a good solution must make sure the strategies and operations are **always** initialized before initialization-service runs, hence me swapping their hooks. `initInjectableStrategies()` must run after all the plugins had the chance to alter the config.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Adjusted the timing of certain initialization processes to improve application startup behavior. No user-facing changes or impact on functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->