### PR TITLE
Include Node.js V24 in docs as supported verison

### DIFF
--- a/docs/docs/guides/getting-started/installation/index.md
+++ b/docs/docs/guides/getting-started/installation/index.md
@@ -8,7 +8,7 @@ import TabItem from '@theme/TabItem';
 
 ## Requirements
 
-- [Node.js](https://nodejs.org/en/) **v20** or above, with support for **even-numbered Node.js versions**. (Odd-numbered versions should still work but are not officially supported.)
+- [Node.js](https://nodejs.org/en/) **v20**, **v22** and **v24** - these versions are tested and supported. (Odd-numbered versions above v20 should still work but are not officially supported.)
 
 ### Optional
 


### PR DESCRIPTION
# Description

Update docs to specifiy supported versions clearly.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide to specify supported Node.js versions (v20, v22, v24).
  * Improved formatting for bullet points and code block indentation in the troubleshooting section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->