### PR TITLE
fix(dashboard): Enable dashboard React JSX compilation

### DIFF
--- a/packages/dashboard/vite/utils/compiler.ts
+++ b/packages/dashboard/vite/utils/compiler.ts
@@ -154,6 +154,7 @@ async function compileTypeScript({
         target: ts.ScriptTarget.ES2020,
         module: ts.ModuleKind.CommonJS,
         moduleResolution: ts.ModuleResolutionKind.Node10, // More explicit CJS resolution
+        jsx: ts.JsxEmit.ReactJSX, // Emit React JSX optimized for production
         experimentalDecorators: true,
         emitDecoratorMetadata: true,
         esModuleInterop: true,


### PR DESCRIPTION
# Description

Dashboard compilation is failing because React JSX templates from Vendure plugins are not being emitted during the build process. This prevents the dashboard from loading the necessary React JSX modules.

# Breaking changes

# Screenshots

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compilation settings to improve React JSX code output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->