### PR TITLE
fix(email-plugin): Escape recipient's HTML entities in dev mailbox

### DIFF
--- a/packages/email-plugin/dev-mailbox.html
+++ b/packages/email-plugin/dev-mailbox.html
@@ -155,15 +155,10 @@
             .then((res) => renderList(res));
     }
 
-    const ESCAPE_ENTITIES = {
-      '&': '&amp;',
-      '<': '&lt;',
-      '>': '&gt;',
-      '"': '&quot;',
-    };
-    
+    const ESCAPE_ENTITIES = { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' };
     const escapeChar = char => ESCAPE_ENTITIES[char] || char;
     const escapeHTMLEntities = value => String(value).replace(/[<>"&]/g, escapeChar);
+
     function renderList(items) {
         const list = document.querySelector('.list');
         list.innerHTML = '';


### PR DESCRIPTION
# Description

This fixes the recipient property on the development mailbox so the name and email shows property in all kinds of accepted formats like `"John Doe" <john.doe@test.com>`.

# Breaking changes

Does this PR include any breaking changes we should be aware of? No.

# Screenshots

Before:
<img width="757" height="116" alt="before" src="https://github.com/user-attachments/assets/8b3f0a7a-5a2f-4ac4-a1ed-59714e5088d7" />

After:
<img width="760" height="118" alt="after" src="https://github.com/user-attachments/assets/d8dd55cd-be51-4bdc-a1d6-8d79dd5556c4" />

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Special characters in recipient fields are now escaped, preventing unintended HTML rendering in the dev mailbox. Fix applies to both the message list and the email detail view, avoiding visual glitches or injected markup from crafted recipient values.

* **Chores**
  * Added a centralized HTML-escaping helper to standardize recipient sanitization across the dev mailbox.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->