### PR TITLE
fix(admin-ui): Administrator's customField don't show up in profile if requiresPermission is Owner

### DIFF
--- a/packages/admin-ui/src/lib/core/src/common/base-detail.component.ts
+++ b/packages/admin-ui/src/lib/core/src/common/base-detail.component.ts
@@ -150,10 +150,13 @@ export abstract class BaseDetailComponent<Entity extends { id: string; updatedAt
         }
     }
 
-    protected getCustomFieldConfig(key: Exclude<keyof CustomFields, '__typename'>): CustomFieldConfig[] {
+    protected getCustomFieldConfig(
+        key: Exclude<keyof CustomFields, '__typename'>,
+        isOwner = false,
+    ): CustomFieldConfig[] {
         return this.serverConfigService.getCustomFieldsFor(key).filter(f => {
             if (f.requiresPermission?.length) {
-                return this.permissionsService.userHasPermissions(f.requiresPermission);
+                return this.permissionsService.userHasPermissions(f.requiresPermission, isOwner);
             }
             return true;
         });

--- a/packages/admin-ui/src/lib/core/src/providers/permissions/permissions.service.ts
+++ b/packages/admin-ui/src/lib/core/src/providers/permissions/permissions.service.ts
@@ -30,9 +30,9 @@ export class PermissionsService {
         this._currentUserPermissions$.next(permissions);
     }
 
-    userHasPermissions(requiredPermissions: Array<string | Permission>): boolean {
+    userHasPermissions(requiredPermissions: Array<string | Permission>, isOwner = false): boolean {
         for (const perm of requiredPermissions) {
-            if (this.currentUserPermissions.includes(perm)) {
+            if (this.currentUserPermissions.includes(perm) || (perm === Permission.Owner && isOwner)) {
                 return true;
             }
         }

--- a/packages/admin-ui/src/lib/settings/src/components/profile/profile.component.ts
+++ b/packages/admin-ui/src/lib/settings/src/components/profile/profile.component.ts
@@ -40,13 +40,13 @@ export const GET_PROFILE_DETAIL = gql`
     templateUrl: './profile.component.html',
     styleUrls: ['./profile.component.scss'],
     changeDetection: ChangeDetectionStrategy.OnPush,
-    standalone: false
+    standalone: false,
 })
 export class ProfileComponent
     extends TypedBaseDetailComponent<typeof GetProfileDetailDocument, 'activeAdministrator'>
     implements OnInit, OnDestroy
 {
-    customFields = this.getCustomFieldConfig('Administrator');
+    customFields = this.getCustomFieldConfig('Administrator', true);
     detailForm = this.formBuilder.group({
         emailAddress: ['', Validators.required],
         firstName: ['', Validators.required],


### PR DESCRIPTION
# Description

A custom field in the Administrator entity wouldn't show up in the Administrator's profile if the requiresPermission included `Permission.Owner`. This fix assumes that whoever is in the profile view is the owner so checking for the Owner permission should return true.

# Breaking changes

Does this PR include any breaking changes we should be aware of? No.

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Profile: Custom fields now honor owner-specific permissions. Users can view and edit fields designated for “Owner” when managing their own profile, while non-owners won’t see these fields.
  * Permissions: Enhanced permission checks to support owner-aware access across custom fields, expanding what eligible users can see without affecting existing non-owner visibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->