### PR TITLE
docs: Add to note about custom field type generation for translated entities

### DIFF
--- a/docs/docs/guides/developer-guide/has-custom-fields/index.md
+++ b/docs/docs/guides/developer-guide/has-custom-fields/index.md
@@ -83,7 +83,17 @@ input UpdateProductReviewInput {
 Notice the lack of manually defining `customFields` on the types, this is because Vendure extends the types automatically once your entity implements `HasCustomFields`.
 
 :::important Naming convention
-In order for Vendure to find the correct input types to extend to, they must conform to the naming convention of `Create<EntityName>Input` and `Update<EntityName>Input`.
+In order for Vendure to find the correct input types to extend to, they must conform to the naming convention of:
+
+- `Create<EntityName>Input`
+- `Update<EntityName>Input`
+
+And if your entity is [supporting translations](/guides/developer-guide/translatable):
+
+- `<EntityName>Translation`
+- `<EntityName>TranslationInput`
+- `Create<EntityName>TranslationInput`
+- `Update<EntityName>TranslationInput`
 :::
 
 Following this caveat, codegen will now produce correct types including `customFields`-fields like so:


### PR DESCRIPTION
# Description

Small addition for custom field type generation that I didnt know about yesterday when doing #3794 

# Breaking changes

No.

# Screenshots

<img width="914" height="521" alt="image" src="https://github.com/user-attachments/assets/db2c8cf3-393c-4bee-8e22-0804a64bbd42" />

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the “Has custom fields” developer guide’s Naming convention section to a clear, multi-line bulleted list.
  * Explicitly lists required patterns for Create/Update inputs and, when applicable, translation entities and inputs.
  * Improves clarity for developers implementing custom fields and translations; no code or runtime changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->