### PR TITLE
fix(dashboard): show “Create” for new entities, “Update” for edits

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
@@ -74,14 +74,14 @@ function AdministratorDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast(i18n.t('Successfully updated administrator'));
+            toast(i18n.t(creatingNewEntity ? 'Successfully created administrator' : 'Successfully updated administrator'));
             resetForm();
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast(i18n.t('Failed to update administrator'), {
+            toast(i18n.t(creatingNewEntity ? 'Failed to create administrator' : 'Failed to update administrator'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_channels/channels_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_channels/channels_.$id.tsx
@@ -82,20 +82,20 @@ function ChannelDetailPage() {
         params: { id: params.id },
         onSuccess: async data => {
             if (data.__typename === 'Channel') {
-                toast(i18n.t('Successfully updated channel'));
+                toast(i18n.t(creatingNewEntity ? 'Successfully created channel' : 'Successfully updated channel'));
                 refreshChannels();
                 resetForm();
                 if (creatingNewEntity) {
                     await navigate({ to: `../$id`, params: { id: data.id } });
                 }
             } else {
-                toast(i18n.t('Failed to update channel'), {
+                toast(i18n.t(creatingNewEntity ? 'Failed to create channel' : 'Failed to update channel'), {
                     description: data.message,
                 });
             }
         },
         onError: err => {
-            toast(i18n.t('Failed to update channel'), {
+            toast(i18n.t(creatingNewEntity ? 'Failed to create channel' : 'Failed to update channel'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_collections/collections_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_collections/collections_.$id.tsx
@@ -89,14 +89,14 @@ function CollectionDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast(i18n.t('Successfully updated collection'));
+            toast(i18n.t(creatingNewEntity ? 'Successfully created collection' : 'Successfully updated collection'));
             resetForm();
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast(i18n.t('Failed to update collection'), {
+            toast(i18n.t(creatingNewEntity ? 'Failed to create collection' : 'Failed to update collection'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_countries/countries_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_countries/countries_.$id.tsx
@@ -61,14 +61,14 @@ function CountryDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast(i18n.t('Successfully updated country'));
+            toast(i18n.t(creatingNewEntity ? 'Successfully created country' : 'Successfully updated country'));
             form.reset(form.getValues());
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast(i18n.t('Failed to update country'), {
+            toast(i18n.t(creatingNewEntity ? 'Failed to create country' : 'Failed to update country'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx
@@ -61,14 +61,14 @@ function CustomerGroupDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast.success(i18n.t('Successfully updated customer group'));
+            toast.success(i18n.t(creatingNewEntity ? 'Successfully created customer group' : 'Successfully updated customer group'));
             resetForm();
             if (creatingNewEntity && data?.id) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update customer group'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create customer group' : 'Failed to update customer group'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_customers/customers_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customers/customers_.$id.tsx
@@ -89,19 +89,19 @@ function CustomerDetailPage() {
         params: { id: params.id },
         onSuccess: async data => {
             if (data.__typename === 'Customer') {
-                toast.success(i18n.t('Successfully updated customer'));
+                toast.success(i18n.t(creatingNewEntity ? 'Successfully created customer' : 'Successfully updated customer'));
                 resetForm();
                 if (creatingNewEntity) {
                     await navigate({ to: `../$id`, params: { id: data.id } });
                 }
             } else {
-                toast.error(i18n.t('Failed to update customer'), {
+                toast.error(i18n.t(creatingNewEntity ? 'Failed to create customer' : 'Failed to update customer'), {
                     description: data.message,
                 });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update customer'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create customer' : 'Failed to update customer'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx
@@ -81,7 +81,7 @@ function FacetValueDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast(i18n.t('Successfully updated facet value'));
+            toast(i18n.t(creatingNewEntity ? 'Successfully created facet value' : 'Successfully updated facet value'));
             resetForm();
             const created = Array.isArray(data) ? data[0] : data;
             if (creatingNewEntity && created) {
@@ -89,7 +89,7 @@ function FacetValueDetailPage() {
             }
         },
         onError: err => {
-            toast(i18n.t('Failed to update facet value'), {
+            toast(i18n.t(creatingNewEntity ? 'Failed to create facet value' : 'Failed to update facet value'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_facets/facets_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_facets/facets_.$id.tsx
@@ -72,14 +72,14 @@ function FacetDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast(i18n.t('Successfully updated facet'));
+            toast(i18n.t(creatingNewEntity ? 'Successfully created facet' : 'Successfully updated facet'));
             resetForm();
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast(i18n.t('Failed to update facet'), {
+            toast(i18n.t(creatingNewEntity ? 'Failed to create facet' : 'Failed to update facet'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx
@@ -95,14 +95,14 @@ function PaymentMethodDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast.success(i18n.t('Successfully updated payment method'));
+            toast.success(i18n.t(creatingNewEntity ? 'Successfully created payment method' : 'Successfully updated payment method'));
             resetForm();
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update payment method'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create payment method' : 'Failed to update payment method'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
@@ -97,14 +97,14 @@ function ProductVariantDetailPage() {
         },
         params: { id: params.id },
         onSuccess: data => {
-            toast.success(i18n.t('Successfully updated product'));
+            toast.success(i18n.t(creatingNewEntity ? 'Successfully created product variant' : 'Successfully updated product variant'));
             resetForm();
             if (creatingNewEntity) {
                 navigate({ to: `../${(data as any)?.[0]?.id}`, from: Route.id });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update product'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create product variant' : 'Failed to update product variant'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id.tsx
@@ -81,14 +81,14 @@ function ProductDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast.success(i18n.t('Successfully updated product'));
+            toast.success(i18n.t(creatingNewEntity ? 'Successfully created product' : 'Successfully updated product'));
             resetForm();
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update product'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create product' : 'Failed to update product'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
@@ -99,19 +99,19 @@ function PromotionDetailPage() {
         params: { id: params.id },
         onSuccess: async data => {
             if (data.__typename === 'Promotion') {
-                toast.success(i18n.t('Successfully updated promotion'));
+                toast.success(i18n.t(creatingNewEntity ? 'Successfully created promotion' : 'Successfully updated promotion'));
                 resetForm();
                 if (creatingNewEntity) {
                     await navigate({ to: `../$id`, params: { id: data.id } });
                 }
             } else {
-                toast.error(i18n.t('Failed to update promotion'), {
+                toast.error(i18n.t(creatingNewEntity ? 'Failed to create promotion' : 'Failed to update promotion'), {
                     description: data.message,
                 });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update promotion'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create promotion' : 'Failed to update promotion'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_roles/roles_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_roles/roles_.$id.tsx
@@ -61,14 +61,14 @@ function RoleDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast.success(i18n.t('Successfully updated role'));
+            toast.success(i18n.t(creatingNewEntity ? 'Successfully created role' : 'Successfully updated role'));
             resetForm();
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update role'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create role' : 'Failed to update role'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_sellers/sellers_.$id.tsx
@@ -55,14 +55,14 @@ function SellerDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast(i18n.t('Successfully updated seller'));
+            toast(i18n.t(creatingNewEntity ? 'Successfully created seller' : 'Successfully updated seller'));
             form.reset(form.getValues());
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast(i18n.t('Failed to update seller'), {
+            toast(i18n.t(creatingNewEntity ? 'Failed to create seller' : 'Failed to update seller'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
@@ -84,14 +84,14 @@ function ShippingMethodDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast.success(i18n.t('Successfully updated shipping method'));
+            toast.success(i18n.t(creatingNewEntity ? 'Successfully created shipping method' : 'Successfully updated shipping method'));
             resetForm();
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update shipping method'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create shipping method' : 'Failed to update shipping method'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx
@@ -64,14 +64,14 @@ function StockLocationDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast.success(i18n.t('Successfully updated stock location'));
+            toast.success(i18n.t(creatingNewEntity ? 'Successfully created stock location' : 'Successfully updated stock location'));
             resetForm();
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update stock location'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create stock location' : 'Failed to update stock location'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx
@@ -63,14 +63,14 @@ function TaxCategoryDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast.success(i18n.t('Successfully updated tax category'));
+            toast.success(i18n.t(creatingNewEntity ? 'Successfully created tax category' : 'Successfully updated tax category'));
             form.reset(form.getValues());
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update tax category'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create tax category' : 'Failed to update tax category'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
@@ -67,14 +67,14 @@ function TaxRateDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast.success(i18n.t('Successfully updated tax rate'));
+            toast.success(i18n.t(creatingNewEntity ? 'Successfully created tax rate' : 'Successfully updated tax rate'));
             resetForm();
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update tax rate'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create tax rate' : 'Failed to update tax rate'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },

--- a/packages/dashboard/src/app/routes/_authenticated/_zones/zones_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_zones/zones_.$id.tsx
@@ -56,14 +56,14 @@ function ZoneDetailPage() {
         },
         params: { id: params.id },
         onSuccess: async data => {
-            toast.success(i18n.t('Successfully updated zone'));
+            toast.success(i18n.t(creatingNewEntity ? 'Successfully created zone' : 'Successfully updated zone'));
             resetForm();
             if (creatingNewEntity) {
                 await navigate({ to: `../$id`, params: { id: data.id } });
             }
         },
         onError: err => {
-            toast.error(i18n.t('Failed to update zone'), {
+            toast.error(i18n.t(creatingNewEntity ? 'Failed to create zone' : 'Failed to update zone'), {
                 description: err instanceof Error ? err.message : 'Unknown error',
             });
         },


### PR DESCRIPTION
* Update primary action button labels across entity detail pages
* **Update success toast messages** to reflect create vs update state (e.g., “Successfully **created** Product” vs “Successfully **updated** Product”)
* Toggle based on `creatingNewEntity` to reflect create vs update state
* **Affects:** administrators, channels, collections, countries, customer groups, customers, facets, facet values, payment methods, product variants, products, promotions, roles, sellers, shipping methods, stock locations, tax categories, tax rates, zones

---

# Description

Show **“Create”** when adding a new entity and **“Update”** when editing an existing one.
Additionally, ensure the success toast message matches the action:

* On create: **“Successfully created \<Entity>”**
* On update: **“Successfully updated \<Entity>”**

This fixes cases like products where a creation flow previously showed “Successfully updated product.”
Related issue: add reference here (e.g. closes #1234).

---

# Breaking changes

None.

---

# Checklist

📌 Always:

* [x] I have set a clear title
* [x] My PR is small and contains a single feature
* [x] I have checked my own PR

👍 Most of the time:

* [ ] I have added or updated test cases
* [ ] I have updated the README if needed