### PR TITLE
fix(dashboard): Custom fields in shipping methods view were not visible

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
@@ -169,7 +169,7 @@ function ShippingMethodDetailPage() {
                         />
                     </DetailFormGrid>
                 </PageBlock>
-                <CustomFieldsPageBlock column="main" entityType="Promotion" control={form.control} />
+                <CustomFieldsPageBlock column="main" entityType="ShippingMethod" control={form.control} />
                 <PageBlock column="main" blockId="conditions" title={<Trans>Conditions</Trans>}>
                     <FormFieldWrapper
                         control={form.control}


### PR DESCRIPTION
# Description

Custom fields in shipping methods view were not visible due to copy & paste mistake.

fixes #3846

# Breaking changes

no

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single ~feature~ bug fix
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected the custom fields displayed on the Shipping Method detail page. The page now shows custom fields specific to the selected Shipping Method rather than unrelated entries, ensuring accurate information is presented.
  - Improves consistency across the dashboard and reduces confusion when viewing or editing Shipping Method details. No changes to existing workflows or navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->