### PR TITLE
fix(core): Prevent duplicate GraphQL custom field input type definitions

### DIFF
--- a/packages/core/src/api/config/graphql-custom-fields.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.ts
@@ -159,17 +159,31 @@ export function addGraphQLCustomFields(
 
         if (hasCreateInputType) {
             if (writeableNonLocalizedFields.length) {
+                const createCustomFieldsInputType = `Create${entityName}CustomFieldsInput`;
+                if (!schema.getType(createCustomFieldsInputType)) {
+                    customFieldTypeDefs += `
+                        input ${createCustomFieldsInputType} {
+                           ${mapToFields(
+                               writeableNonLocalizedFields,
+                               wrapListType(getGraphQlInputType(entityName)),
+                               getGraphQlInputName,
+                           )}
+                        }
+                    `;
+                } else {
+                    customFieldTypeDefs += `
+                        extend input ${createCustomFieldsInputType} {
+                           ${mapToFields(
+                               writeableNonLocalizedFields,
+                               wrapListType(getGraphQlInputType(entityName)),
+                               getGraphQlInputName,
+                           )}
+                        }
+                    `;
+                }
                 customFieldTypeDefs += `
-                    input Create${entityName}CustomFieldsInput {
-                       ${mapToFields(
-                           writeableNonLocalizedFields,
-                           wrapListType(getGraphQlInputType(entityName)),
-                           getGraphQlInputName,
-                       )}
-                    }
-
                     extend input Create${entityName}Input {
-                        customFields: Create${entityName}CustomFieldsInput
+                        customFields: ${createCustomFieldsInputType}
                     }
                 `;
             } else {
@@ -183,17 +197,31 @@ export function addGraphQLCustomFields(
 
         if (hasUpdateInputType) {
             if (writeableNonLocalizedFields.length) {
+                const updateCustomFieldsInputType = `Update${entityName}CustomFieldsInput`;
+                if (!schema.getType(updateCustomFieldsInputType)) {
+                    customFieldTypeDefs += `
+                        input ${updateCustomFieldsInputType} {
+                           ${mapToFields(
+                               writeableNonLocalizedFields,
+                               wrapListType(getGraphQlInputType(entityName)),
+                               getGraphQlInputName,
+                           )}
+                        }
+                    `;
+                } else {
+                    customFieldTypeDefs += `
+                        extend input ${updateCustomFieldsInputType} {
+                           ${mapToFields(
+                               writeableNonLocalizedFields,
+                               wrapListType(getGraphQlInputType(entityName)),
+                               getGraphQlInputName,
+                           )}
+                        }
+                    `;
+                }
                 customFieldTypeDefs += `
-                    input Update${entityName}CustomFieldsInput {
-                       ${mapToFields(
-                           writeableNonLocalizedFields,
-                           wrapListType(getGraphQlInputType(entityName)),
-                           getGraphQlInputName,
-                       )}
-                    }
-
                     extend input Update${entityName}Input {
-                        customFields: Update${entityName}CustomFieldsInput
+                        customFields: ${updateCustomFieldsInputType}
                     }
                 `;
             } else {


### PR DESCRIPTION
# Description

Fixes duplicate GraphQL type definition errors that occur when plugins define custom field input types before the core schema generation runs.

Relates to:
- #3887


# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced GraphQL custom fields handling by dynamically generating input types based on schema state, replacing static hardcoded definitions for improved flexibility and maintainability in custom field management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->