### PR TITLE
fix(dashboard): get the right vite __status on the starting page

### DIFF
--- a/packages/dashboard/plugin/default-page.html
+++ b/packages/dashboard/plugin/default-page.html
@@ -148,8 +148,13 @@
         let pollInterval;
         let statusElement = document.getElementById('status');
 
+        function statusUrlForCurrentPath() {
+            const segments = location.pathname.split('/').filter(Boolean);
+            return segments.length === 0 ? '/__status' : `/${segments[0]}/__status`;
+        }
+
         function pollStatus() {
-            fetch('__status')
+            fetch(statusUrlForCurrentPath())
                 .then(response => response.json())
                 .then(data => {
                     if (data.mode === 'vite') {


### PR DESCRIPTION
# Description

This pull request updates the way the dashboard plugin determines the status endpoint to poll for updates. Instead of always using the root `__status` endpoint, it now dynamically selects the endpoint based on the current path, improving compatibility with nested routes.

Improvements to status polling logic:

* Added a new `statusUrlForCurrentPath` function in `default-page.html` to generate the appropriate status endpoint based on the current URL path.
* Updated the `pollStatus` function to use the new dynamic status endpoint, ensuring correct status polling for both root and nested routes.d issue.

# Breaking changes

No

# Screenshots

Fixes __status failure:
<img width="2557" height="1379" alt="image" src="https://github.com/user-attachments/assets/5b82c6f0-b837-48c2-b7f3-8f7a6b9dd277" />

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
