### PR TITLE
fix(dashboard): Fix incorrect currency being displayed in product variant listing

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_products/components/product-variants-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/components/product-variants-table.tsx
@@ -83,7 +83,7 @@ export function ProductVariantsTable({
                 },
                 price: {
                     meta: {
-                        dependencies: ["currencyCode"]
+                        dependencies: ['currencyCode']
                     },
                     cell: ({ row: { original } }) => (
                         <Money value={original.price} currency={original.currencyCode} />
@@ -91,7 +91,7 @@ export function ProductVariantsTable({
                 },
                 priceWithTax: {
                     meta: {
-                        dependencies: ["currencyCode"]
+                        dependencies: ['currencyCode']
                     },
                     cell: ({ row: { original } }) => (
                         <Money value={original.priceWithTax} currency={original.currencyCode} />


### PR DESCRIPTION
# Description

Fixes #3901


This PR adds missing dependencies between price/priceWithTax and currencyCode so that the correct currency is displayed, even if the currencyCode column itself is hidden.

# Breaking changes

This PR does not include any breaking changes.

# Screenshots

Master branch (incorrectly renders variants in USD):

<img width="1194" height="496" alt="image" src="https://github.com/user-attachments/assets/83d4e1c7-f019-4c98-bbf8-34584a88a3ce" />

Fixed version (correctly renders variants in CZK):

<img width="1194" height="496" alt="image" src="https://github.com/user-attachments/assets/23e3f24d-a8b9-4db3-a744-f7fff7590dbf" />

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Ensured price columns in the product variants table now correctly react to currency changes so displayed prices remain consistent when the selected currency updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->