### PR TITLE
fix(dashboard): incorrect extension import path generation on windows

### DIFF
--- a/packages/dashboard/vite/vite-plugin-dashboard-metadata.ts
+++ b/packages/dashboard/vite/vite-plugin-dashboard-metadata.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { pathToFileURL } from 'url';
+import { pathToFileURL } from 'node:url';
 import { Plugin } from 'vite';
 
 import { CompileResult } from './utils/compiler.js';


### PR DESCRIPTION
# Description

On windows, the `runDashboardExtensions` wrapper generation emitted incorrect absolute path with `\`s resulting in an error. Additionally, absolute path on windows requires `file:` protocol to work. This PR wraps the extension path with `pathToFileURL` function to yield correct path. Closes #3893

# Breaking changes

N/A

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved internal extension loading mechanism for better compatibility and stability, resulting in more reliable extension discovery and execution across environments. This reduces edge-case failures, improves startup consistency when loading extensions, and enhances overall runtime stability without changing public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->