### PR TITLE
feat: Expose ProductVariantPrice entity to price calculation strategy

### DIFF
--- a/packages/core/src/config/catalog/product-variant-price-calculation-strategy.ts
+++ b/packages/core/src/config/catalog/product-variant-price-calculation-strategy.ts
@@ -1,6 +1,7 @@
 import { RequestContext } from '../../api/common/request-context';
 import { PriceCalculationResult } from '../../common/types/common-types';
 import { InjectableStrategy } from '../../common/types/injectable-strategy';
+import { ProductVariantPrice } from '../../entity/product-variant/product-variant-price.entity';
 import { ProductVariant } from '../../entity/product-variant/product-variant.entity';
 import { TaxCategory } from '../../entity/tax-category/tax-category.entity';
 import { Zone } from '../../entity/zone/zone.entity';
@@ -34,6 +35,7 @@ export interface ProductVariantPriceCalculationStrategy extends InjectableStrate
  */
 export interface ProductVariantPriceCalculationArgs {
     inputPrice: number;
+    productVariantPrice?: ProductVariantPrice;
     productVariant: ProductVariant;
     taxCategory: TaxCategory;
     activeTaxZone: Zone;

--- a/packages/core/src/service/helpers/product-price-applicator/product-price-applicator.ts
+++ b/packages/core/src/service/helpers/product-price-applicator/product-price-applicator.ts
@@ -91,6 +91,7 @@ export class ProductPriceApplicator {
 
         const { price, priceIncludesTax } = await productVariantPriceCalculationStrategy.calculate({
             inputPrice: channelPrice?.price ?? 0,
+            productVariantPrice: channelPrice,
             taxCategory: variant.taxCategory,
             productVariant: variant,
             activeTaxZone,


### PR DESCRIPTION
## Summary

Adds the full `ProductVariantPrice` entity to `ProductVariantPriceCalculationArgs`, enabling custom price calculation strategies to access price-specific custom fields and metadata.

## Motivation

Custom implementations of `ProductVariantPriceCalculationStrategy` previously only had access to the numeric `inputPrice` value. This prevented strategies from making pricing decisions based on price-specific custom fields (e.g., promotional flags, margin data, pricing tiers) that may be defined on the `ProductVariantPrice` entity.

## Changes

- Added optional `productVariantPrice?: ProductVariantPrice` field to `ProductVariantPriceCalculationArgs` interface
- Updated `ProductPriceApplicator` to pass the selected channel price entity to the strategy
- Tests updated to reflect the new optional parameter

## Breaking Changes

None - this is a backward-compatible addition. The field is optional and the default `DefaultProductVariantPriceCalculationStrategy` implementation continues to work unchanged.

## Example Usage

```typescript
export class CustomPriceStrategy implements ProductVariantPriceCalculationStrategy {
  async calculate(args: ProductVariantPriceCalculationArgs): Promise<PriceCalculationResult> {
    const { inputPrice, productVariantPrice } = args;

    // Access custom fields from the price entity
    const isPromotional = productVariantPrice?.customFields?.isPromotional;

    // Apply custom pricing logic based on metadata
    // ...
  }
}
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the product pricing calculation mechanism to provide additional context to the pricing strategy, enabling more comprehensive price determination.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->