### PR TITLE
fix(dashboard): Fix healthcheck view when api endpoint is auto

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_system/healthchecks.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_system/healthchecks.tsx
@@ -1,12 +1,12 @@
 import { Button } from '@/vdb/components/ui/button.js';
 import { Card, CardContent, CardHeader, CardTitle } from '@/vdb/components/ui/card.js';
 import { Page, PageActionBar, PageTitle } from '@/vdb/framework/layout-engine/page-layout.js';
+import { getApiBaseUrl } from '@/vdb/utils/config-utils.js';
 import { Trans } from '@lingui/react/macro';
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute } from '@tanstack/react-router';
 import { formatRelative } from 'date-fns';
 import { CheckCircle2Icon, CircleXIcon } from 'lucide-react';
-import { uiConfig } from 'virtual:vendure-ui-config';
 
 export const Route = createFileRoute('/_authenticated/_system/healthchecks')({
     component: HealthchecksPage,
@@ -28,11 +28,7 @@ function HealthchecksPage() {
     const { data, refetch, dataUpdatedAt } = useQuery({
         queryKey: ['healthchecks'],
         queryFn: async () => {
-            const host =
-                uiConfig.api.host !== 'auto'
-                    ? uiConfig.api.host
-                    : `${window.location.protocol}//${window.location.hostname}`;
-            const schemeAndHost = host + (uiConfig.api.port !== 'auto' ? `:${uiConfig.api.port}` : '');
+            const schemeAndHost = getApiBaseUrl();
 
             const res = await fetch(`${schemeAndHost}/health`);
             return res.json() as Promise<HealthcheckResponse>;

--- a/packages/dashboard/src/lib/graphql/api.ts
+++ b/packages/dashboard/src/lib/graphql/api.ts
@@ -8,14 +8,9 @@ import { AwesomeGraphQLClient } from 'awesome-graphql-client';
 import { DocumentNode, print } from 'graphql';
 import { uiConfig } from 'virtual:vendure-ui-config';
 
-const host =
-    uiConfig.api.host !== 'auto'
-        ? uiConfig.api.host
-        : `${window.location.protocol}//${window.location.hostname}`;
-const API_URL =
-    host +
-    `:${uiConfig.api.port !== 'auto' ? uiConfig.api.port : window.location.port}` +
-    `/${uiConfig.api.adminApiPath}`;
+import { getApiBaseUrl } from '../utils/config-utils.js';
+
+const API_URL = getApiBaseUrl() + `/${uiConfig.api.adminApiPath}`;
 
 export type Variables = object;
 export type RequestDocument = string | DocumentNode;

--- a/packages/dashboard/src/lib/utils/config-utils.ts
+++ b/packages/dashboard/src/lib/utils/config-utils.ts
@@ -1,0 +1,11 @@
+import { uiConfig } from 'virtual:vendure-ui-config';
+
+export function getApiBaseUrl(): string {
+    const schemeAndHost =
+        uiConfig.api.host !== 'auto'
+            ? uiConfig.api.host
+            : `${window.location.protocol}//${window.location.hostname}`;
+    const portPart = uiConfig.api.port !== 'auto' ? `:${uiConfig.api.port}` : '';
+
+    return schemeAndHost + portPart;
+}


### PR DESCRIPTION
# Description

When the API endpoint is configured to be `'auto'` (which is the default), the healthcheck view reports that some resources are down.
This is due to the fact that the dashboard tries to request `/dashboard/auto/health`, where `auto`  is not the host but rather a special configuration action indicating that it should request on the same domain.

# Breaking changes

n/a

# Screenshots

<img width="1643" height="289" alt="Screenshot from 2025-10-29 15-23-51" src="https://github.com/user-attachments/assets/f973623e-639e-48cb-8526-a3ad1a9ff203" />


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Health checks now reliably resolve the API base URL, correctly handling automatic host detection by falling back to the current page location.
* **Chores**
  * Centralized API base URL resolution so all dashboard API calls use the same derived base URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->