### PR TITLE
fix(dashboard): Respect authTokenHeaderKey config

### DIFF
--- a/packages/dashboard/src/lib/graphql/api.ts
+++ b/packages/dashboard/src/lib/graphql/api.ts
@@ -60,7 +60,7 @@ const awesomeClient = new AwesomeGraphQLClient({
             credentials: 'include',
             mode: 'cors',
         }).then(res => {
-            const authToken = res.headers.get('vendure-auth-token');
+            const authToken = res.headers.get(uiConfig.api.authTokenHeaderKey);
             if (authToken) {
                 localStorage.setItem(LS_KEY_SESSION_TOKEN, authToken);
             }


### PR DESCRIPTION
# Description

Fixes #3923

Dashboard hardcoded `'vendure-auth-token'` instead of using configured `authTokenHeaderKey`. Changed line 63 in `api.ts` to use `uiConfig.api.authTokenHeaderKey`.

# Breaking changes

None.

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases
- [x] I have updated the README if needed