### PR TITLE
fix(dashboard): History entry item destructive icon color

### DIFF
--- a/docs/docs/reference/dashboard/extensions-api/history-entries.md
+++ b/docs/docs/reference/dashboard/extensions-api/history-entries.md
@@ -199,7 +199,7 @@ Optional tailwind classes to apply to the icon. For instance
 
 ```ts
 const success = 'bg-success text-success-foreground';
-const destructive = 'bg-danger text-danger-foreground';
+const destructive = 'bg-destructive text-destructive-foreground';
 ```
 ### actorName
 

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx
@@ -105,7 +105,7 @@ export function orderHistoryUtils(order: OrderHistoryOrderDetail) {
 
     const getIconColor = ({ type, data }: HistoryEntryItem) => {
         const success = 'bg-success text-success-foreground';
-        const destructive = 'bg-danger text-danger-foreground';
+        const destructive = 'bg-destructive text-destructive-foreground';
         const regular = 'bg-muted text-muted-foreground';
 
         if (type === 'ORDER_PAYMENT_TRANSITION' && data.to === 'Settled') {

--- a/packages/dashboard/src/lib/framework/history-entry/history-entry.tsx
+++ b/packages/dashboard/src/lib/framework/history-entry/history-entry.tsx
@@ -34,7 +34,7 @@ export interface HistoryEntryProps {
      *
      * ```ts
      * const success = 'bg-success text-success-foreground';
-     * const destructive = 'bg-danger text-danger-foreground';
+     * const destructive = 'bg-destructive text-destructive-foreground';
      * ```
      */
     timelineIconClassName?: string;


### PR DESCRIPTION
# Description

This PR fixes the icon color of the history entry items. Instead of `danger` we should use `destructive`

# Breaking changes

Does this PR include any breaking changes we should be aware of? No

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [x] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated code examples and documentation to reflect standardized naming conventions for destructive action styling.

* **Style**
  * Consolidated color class naming for destructive UI elements to improve consistency across the dashboard component library.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->