### PR TITLE
fix: Dashboard typechecking fails

### DIFF
--- a/packages/dashboard/src/lib/components/data-input/datetime-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/datetime-input.tsx
@@ -185,7 +185,7 @@ function bcpTagToDatePickerLocale(
         case 'pt-BR':
             return module.ptBR;
         default: {
-            const lang = tag.split('-').at(0);
+            const lang = tag.split('-')[0];
             return lang ? module[lang as keyof typeof module] : undefined;
         }
     }

--- a/packages/dashboard/src/lib/components/data-input/relation-selector.tsx
+++ b/packages/dashboard/src/lib/components/data-input/relation-selector.tsx
@@ -28,7 +28,7 @@ export interface RelationSelectorConfig<T = any> {
     /** Number of items to load per page */
     pageSize?: number;
     /** Placeholder text for the search input */
-    placeholder?: React.ReactNode;
+    placeholder?: string;
     /** Whether to enable multi-select mode */
     multiple?: boolean;
     /** Custom filter function for search */

--- a/packages/dashboard/src/lib/components/data-input/struct-form-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/struct-form-input.tsx
@@ -20,7 +20,7 @@ import {
     StructCustomFieldConfig,
     StructField,
 } from '@/vdb/framework/form-engine/form-engine-types.js';
-import { isStructFieldConfig } from '@/vdb/framework/form-engine/utils.js';
+import { isReadonlyField, isStructFieldConfig } from '@/vdb/framework/form-engine/utils.js';
 import { useUserSettings } from '@/vdb/hooks/use-user-settings.js';
 import { CustomFieldListInput } from './custom-field-list-input.js';
 import { DateTimeInput } from './datetime-input.js';
@@ -82,6 +82,11 @@ export function StructFormInput({ fieldDef, ...field }: Readonly<DashboardFormCo
     const { control } = useFormContext();
     const { value, name } = field;
 
+    // Early return if not a struct field config
+    if (!fieldDef || !isStructFieldConfig(fieldDef)) {
+        return null;
+    }
+
     // Watch the struct field for changes to update display mode
     const watchedStructValue =
         useWatch({
@@ -98,7 +103,7 @@ export function StructFormInput({ fieldDef, ...field }: Readonly<DashboardFormCo
         return input?.find(t => t.languageCode === displayLanguage)?.value;
     };
 
-    const isReadonly = fieldDef?.readonly === true;
+    const isReadonly = isReadonlyField(fieldDef);
 
     // Helper function to render individual struct field inputs
     const renderStructFieldInput = (
@@ -243,7 +248,7 @@ export function StructFormInput({ fieldDef, ...field }: Readonly<DashboardFormCo
                         </Button>
                     </div>
                 )}
-                {fieldDef?.fields?.map(structField => (
+                {fieldDef.fields.map(structField => (
                     <FormField
                         key={structField.name}
                         control={control}
@@ -276,10 +281,6 @@ export function StructFormInput({ fieldDef, ...field }: Readonly<DashboardFormCo
         ),
         [fieldDef, control, field.name, getTranslation, renderStructFieldInput, isReadonly],
     );
-
-    if (!fieldDef || !isStructFieldConfig(fieldDef)) {
-        return null;
-    }
 
     // Helper function to format field value for display
     const formatFieldValue = (value: any, structField: StructField) => {


### PR DESCRIPTION
#3921

Fixed errors from typescript check on new dashboard
- dateTime - array 0 element getter
- placeholder datatype
- readonly on fields

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved form field validation in struct form inputs to prevent rendering with invalid configurations.
  * Enhanced detection and handling of read-only form fields for more reliable form behavior.

* **Refactor**
  * Minor internal code improvements to component implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->