### PR TITLE
fix(dashboard): Allow the option "enableColumnFilter" for additionalColumns in ListPage

### DIFF
--- a/packages/dashboard/src/lib/components/data-table/use-generated-columns.tsx
+++ b/packages/dashboard/src/lib/components/data-table/use-generated-columns.tsx
@@ -163,7 +163,7 @@ export function useGeneratedColumns<T extends TypedDocumentNode<any, any>>({
             if (!id) {
                 throw new Error('Column id is required');
             }
-            finalColumns.push(columnHelper.accessor(id as any, { ...column, id, enableColumnFilter: false }));
+            finalColumns.push(columnHelper.accessor(id as any, { enableColumnFilter: false, ...column, id }));
         }
 
         if (defaultColumnOrder) {


### PR DESCRIPTION
# Description
When following the guide on "https://docs.vendure.io/guides/how-to/paginated-list/" it describes how to create custom properties filters, that works great.

When trying to add that filter to a List page in dashboard by using the component `<ListPage>` and that will most likely be displayed by using an additional column.

But additional columns at the moment won't allow the option "enableColumnFilter" for it's forced to false, without anyway to allow it.

# Breaking changes
There should not be any breaking changes

# Checklist

📌 Always:
- [ yes ] I have set a clear title
- [ yes ] My PR is small and contains a single feature
- [ yes ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ no ] I have added or updated test cases
- [ no ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed column filtering so custom column settings can override defaults.
  * Ensured explicitly provided column IDs are reliably applied.
  * Improved predictability when adding and configuring extra columns in data tables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->