### PR TITLE
fix(dashboard): Fix port:auto for api requests

### DIFF
--- a/packages/dashboard/src/lib/utils/config-utils.ts
+++ b/packages/dashboard/src/lib/utils/config-utils.ts
@@ -13,7 +13,7 @@ export function getApiBaseUrl(): string {
             : `${globalThis.location.protocol}//${globalThis.location.hostname}`;
 
     const locationPortPart = globalThis.location.port ? `:${globalThis.location.port}` : '';
-    const portPart = uiConfig.api.port !== 'auto' ? `:${uiConfig.api.port}` : locationPortPart;
+    const portPart = uiConfig.api.port === 'auto' ? locationPortPart : `:${uiConfig.api.port}`;
 
     return schemeAndHost + portPart;
 }


### PR DESCRIPTION
# Description

When the API port is configured to be 'auto' (which is the default) and we are using a non-standard (443,80) port, we cannot login as the API client does not honor the port of the currently accessed page.

This is a regression introduced in #3919. The healthcheck endpoint did not respect `window.location.port` as it was building a relative URL. The extracted utility is always building an absolute URL and therefore needs to respect `window.location`.

# Breaking changes

no, fixes regression.

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved API base URL logic: when the API port is set to "auto", the app now uses the browser's current port when available, preventing mismatched connections and improving reliability.

* **Documentation**
  * Added inline documentation clarifying how the API base URL and port are determined.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->