### PR TITLE
fix(dashboard): Fix for custom nav section placement

### DIFF
--- a/packages/dashboard/src/lib/framework/extension-api/logic/navigation.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/logic/navigation.ts
@@ -10,7 +10,7 @@ export function registerNavigationExtensions(
         for (const section of navSections) {
             addNavMenuSection({
                 ...section,
-                placement: 'top',
+                placement: section.placement ?? 'top',
                 order: section.order ?? 999,
                 items: [],
             });

--- a/packages/dashboard/src/lib/framework/extension-api/types/navigation.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/types/navigation.ts
@@ -97,4 +97,9 @@ export interface DashboardNavSectionDefinition {
      * Optional order number to control the position of this section in the sidebar.
      */
     order?: number;
+    /**
+     * @description
+     * Optional placement to control the position of this section in the sidebar.
+     */
+    placement?: 'top' | 'bottom';
 }


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue.

According to the guide at - https://docs.vendure.io/guides/extending-the-dashboard/navigation/#section-placement-and-ordering it should be possible to set where a section should be placed. But today there is no way to define the placement and the placement is default to top.

This fix is to fix so the documentation is more correct and allow the functionality it says

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Navigation sections can now be placed explicitly at the top or bottom of the sidebar.
  * If placement is not specified, sections default to the top position.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->