### PR TITLE
feat(dashboard): Custom icons in data table faceted filters

### DIFF
--- a/packages/dashboard/src/lib/components/data-table/data-table.tsx
+++ b/packages/dashboard/src/lib/components/data-table/data-table.tsx
@@ -254,6 +254,7 @@ export function DataTable<TData>({
                                     title={filter?.title}
                                     options={filter?.options}
                                     optionsFn={filter?.optionsFn}
+                                    icon={filter?.icon}
                                 />
                             ))}
                         </Suspense>


### PR DESCRIPTION
# Description

This PR adds the ability to set custom icons in the data table faceted filter.
Although you could specify an icon in the facetedFilters array, it was not being passed down as a prop to DataTableFacetedFilter, which meant you couldn’t actually use a custom icon — the default one was always used.

# Breaking changes

No breaking changes

# Screenshots

<img width="330" height="68" alt="image" src="https://github.com/user-attachments/assets/4720e6e4-808d-461f-afb9-ba388787c8c0" />
<img width="331" height="59" alt="image" src="https://github.com/user-attachments/assets/ac020344-50dc-408b-b727-da8a999914c6" />

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data table filters now display icons alongside filter options for clearer visual identification.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->