### PR TITLE
Fix(Admin UI): Display error message when default tax zone is missing

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
@@ -21,6 +21,7 @@ import {
     createProductVariantsDocument,
 } from '../products.graphql.js';
 import { CreateProductVariants, VariantConfiguration } from './create-product-variants.js';
+import { toast } from 'sonner';
 
 export function CreateProductVariantsDialog({
     productId,
@@ -128,7 +129,13 @@ export function CreateProductVariantsDialog({
             onSuccess?.();
         } catch (error) {
             console.error('Error creating variants:', error);
-            // Handle error (show toast notification, etc.)
+
+            const fieldErrors = (error as any)?.fieldErrors;
+            const errorMessage =
+                fieldErrors?.[0]?.message ??
+                'An unexpected error occurred while creating variants.';
+
+            toast.error(errorMessage);
         }
     }
 
@@ -175,8 +182,8 @@ export function CreateProductVariantsDialog({
                             }
                         >
                             {createOptionGroupMutation.isPending ||
-                            addOptionGroupToProductMutation.isPending ||
-                            createProductVariantsMutation.isPending ? (
+                                addOptionGroupToProductMutation.isPending ||
+                                createProductVariantsMutation.isPending ? (
                                 <Trans>Creating...</Trans>
                             ) : (
                                 <Trans>Create {createCount} variants</Trans>


### PR DESCRIPTION
# Description
### This PR resolves issue **#3924**

### Bug Description

When creating a product variant, if the channel’s `defaultTaxZone` is `NULL`, the backend responds with:

> `The active tax zone could not be determined. Ensure a default tax zone is set for the current channel.`

In the Admin UI, this error was only visible in the browser console.
The UI did not show any feedback, so the user had no idea why the variant wasn’t being saved.

### What this PR changes
* Added proper error handling in the product variant creation flow.

# Breaking changes
No.

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error messaging when creating product variants with clearer, context-specific error details displayed to users.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->