### PR TITLE
fix(dashboard): Use null instead of undefined when clearing single relation selector

### DIFF
--- a/packages/dashboard/src/lib/components/data-input/relation-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/relation-input.tsx
@@ -1,5 +1,6 @@
 import { DashboardFormComponent, DashboardFormComponentProps } from '@/vdb/framework/form-engine/form-engine-types.js';
 import { graphql } from '@/vdb/graphql/graphql.js';
+
 import { createRelationSelectorConfig, RelationSelector } from './relation-selector.js';
 
 /**
@@ -35,7 +36,7 @@ export function SingleRelationInput<T>({
             config={singleConfig}
             value={value}
             selectorLabel={selectorLabel}
-            onChange={newValue => onChange(newValue as string)}
+            onChange={newValue => onChange(newValue as string | null)}
             disabled={disabled}
             className={className}
         />

--- a/packages/dashboard/src/lib/components/data-input/relation-selector.tsx
+++ b/packages/dashboard/src/lib/components/data-input/relation-selector.tsx
@@ -48,7 +48,7 @@ export interface RelationSelectorProps<T = any> {
      */
     selectorLabel?: React.ReactNode;
     value?: string | string[];
-    onChange: (value: string | string[] | undefined) => void;
+    onChange: (value: string | string[] | null) => void;
     disabled?: boolean;
     className?: string;
 }
@@ -344,7 +344,7 @@ export function RelationSelector<T>({
         } else {
             // Clear cache for single select
             setSelectedItemsCache([]);
-            onChange(undefined);
+            onChange(null);
         }
     };
 


### PR DESCRIPTION
## Summary

- Fixed the `RelationSelector` component to use `onChange(null)` instead of `onChange(undefined)` when clearing a single-select relation
- Updated the `onChange` type signature from `string | string[] | undefined` to `string | string[] | null`
- Updated `SingleRelationInput` to properly type the onChange callback

## Problem

When clearing a single-select relation field in the Dashboard, the component was calling `onChange(undefined)`. Since `undefined` values don't serialize in JSON, the GraphQL API would ignore the clearing request, causing previously selected values to persist on the server.

## Solution

Changed `onChange(undefined)` to `onChange(null)` which properly serializes to JSON and allows the GraphQL API to receive and process the null value, effectively clearing the relation field.

## Files Changed

- `packages/dashboard/src/lib/components/data-input/relation-selector.tsx` - Changed handleRemove to use `null` instead of `undefined`, updated type signature
- `packages/dashboard/src/lib/components/data-input/relation-input.tsx` - Updated SingleRelationInput onChange typing

## Test Plan

- [x] Create a custom field with a single-select relation (e.g., Customer relation on Product)
- [x] Select a relation value
- [x] Click the × button to clear the selection
- [x] Save the form and refresh the page
- [x] Verify the relation is properly cleared and doesn't reappear

Closes #4032

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal handling of empty relation selection states in the dashboard for improved consistency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->