### PR TITLE
fix(core): Use JSON scalar for customFields input when only relation fields exist

### DIFF
--- a/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
+++ b/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
@@ -282,6 +282,36 @@ type ProductCustomFields {
 }"
 `;
 
+exports[`addGraphQLCustomFields() > uses JSON scalar for input when entity has only relation custom fields 1`] = `
+"scalar JSON
+
+type Promotion {
+  id: ID
+  customFields: PromotionCustomFields
+}
+
+type Customer {
+  id: ID
+}
+
+input CreatePromotionInput {
+  name: String
+  customFields: JSON
+}
+
+input UpdatePromotionInput {
+  id: ID!
+  name: String
+  customFields: JSON
+}
+
+scalar DateTime
+
+type PromotionCustomFields {
+  customer: Customer
+}"
+`;
+
 exports[`addGraphQLCustomFields() > uses JSON scalar if no custom fields defined 1`] = `
 "type Product {
   id: ID

--- a/packages/core/src/api/config/graphql-custom-fields.spec.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.spec.ts
@@ -284,6 +284,42 @@ describe('addGraphQLCustomFields()', () => {
         const result = addGraphQLCustomFields(input, customFieldConfig, false);
         expect(printSchema(result)).toMatchSnapshot();
     });
+
+    // regression test for
+    // https://github.com/vendure-ecommerce/vendure/issues/3990
+    it('uses JSON scalar for input when entity has only relation custom fields', () => {
+        const input = `
+            scalar JSON
+
+            type Promotion {
+                id: ID
+            }
+
+            type Customer {
+                id: ID
+            }
+
+            input CreatePromotionInput {
+                name: String
+            }
+
+            input UpdatePromotionInput {
+                id: ID!
+                name: String
+            }
+        `;
+        const customFieldConfig: CustomFields = {
+            Promotion: [
+                {
+                    name: 'customer',
+                    type: 'relation',
+                    entity: { name: 'Customer' } as any,
+                },
+            ],
+        };
+        const result = addGraphQLCustomFields(input, customFieldConfig, false);
+        expect(printSchema(result)).toMatchSnapshot();
+    });
 });
 
 describe('addOrderLineCustomFieldsInput()', () => {

--- a/packages/core/src/api/config/graphql-custom-fields.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.ts
@@ -92,6 +92,8 @@ export function addGraphQLCustomFields(
         );
         const writeableLocalizedFields = localizedFields.filter(field => !field.readonly);
         const writeableNonLocalizedFields = nonLocalizedFields.filter(field => !field.readonly);
+        // Scalar fields are non-localized fields excluding relations (which are handled separately via IDs)
+        const writeableScalarFields = writeableNonLocalizedFields.filter(field => field.type !== 'relation');
         const sortableFields = customEntityFields.filter(
             field => field.list !== true && field.type !== 'struct',
         );
@@ -145,7 +147,7 @@ export function addGraphQLCustomFields(
         const hasCreateInputType = schema.getType(`Create${entityName}Input`);
         const hasUpdateInputType = schema.getType(`Update${entityName}Input`);
 
-        if ((hasCreateInputType || hasUpdateInputType) && writeableNonLocalizedFields.length) {
+        if ((hasCreateInputType || hasUpdateInputType) && writeableScalarFields.length) {
             // Define any Struct input types that are required by
             // the create and/or update input types.
             for (const structCustomField of structCustomFields) {
@@ -158,7 +160,7 @@ export function addGraphQLCustomFields(
         }
 
         if (hasCreateInputType) {
-            if (writeableNonLocalizedFields.length) {
+            if (writeableScalarFields.length) {
                 const createCustomFieldsInputType = `Create${entityName}CustomFieldsInput`;
                 if (!schema.getType(createCustomFieldsInputType)) {
                     customFieldTypeDefs += `
@@ -196,7 +198,7 @@ export function addGraphQLCustomFields(
         }
 
         if (hasUpdateInputType) {
-            if (writeableNonLocalizedFields.length) {
+            if (writeableScalarFields.length) {
                 const updateCustomFieldsInputType = `Update${entityName}CustomFieldsInput`;
                 if (!schema.getType(updateCustomFieldsInputType)) {
                     customFieldTypeDefs += `


### PR DESCRIPTION
## Summary

- Fixed the GraphQL schema generation to use JSON scalar for `customFields` input when an entity has only relation-type custom fields (no scalar custom fields)
- Added `writeableScalarFields` filter to exclude relation fields when determining whether to create typed input types
- Added regression test for the scenario described in #3990

## Problem

When Promotion entities (or other entities) have only relational custom fields and no scalar custom fields, the dashboard plugin's schema introspection was generating incorrect GraphQL type definitions. The `customFields` property in `CreatePromotionInput` and `UpdatePromotionInput` was being generated as an `INPUT_OBJECT` type when the actual GraphQL API schema defines these fields as `JSON` scalars.

This caused TypeScript type checking failures in admin UI extensions using `gql.tada` when passing `customFields` as JSON objects, despite the API accepting them.

## Solution

The fix introduces a new `writeableScalarFields` filter that excludes relation fields from the check that determines whether to create typed input types. When only relation fields exist (no scalar fields), the input correctly falls back to JSON scalar type.

## Files Changed

- `packages/core/src/api/config/graphql-custom-fields.ts` - Added `writeableScalarFields` filter and updated input type generation logic
- `packages/core/src/api/config/graphql-custom-fields.spec.ts` - Added regression test
- `packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap` - Updated snapshot

## Test Plan

- [x] Added unit test that verifies JSON scalar is used for input when entity has only relation custom fields
- [ ] Manual verification with dashboard plugin build that generates correct `graphql-env.d.ts`

Closes #3990

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Corrected GraphQL API schema generation to properly apply JSON scalars in custom field inputs when entities contain only relation-based custom fields.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->