### PR TITLE
fix: Decimal values in tax rate input

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx
@@ -1,4 +1,4 @@
-import { AffixedInput } from '@/vdb/components/data-input/affixed-input.js';
+import { NumberInput } from '@/vdb/components/data-input/number-input.js';
 import { ErrorPage } from '@/vdb/components/shared/error-page.js';
 import { FormFieldWrapper } from '@/vdb/components/shared/form-field-wrapper.js';
 import { PermissionGuard } from '@/vdb/components/shared/permission-guard.js';
@@ -121,14 +121,7 @@ function TaxRateDetailPage() {
                             name="value"
                             label={<Trans>Rate</Trans>}
                             render={({ field }) => (
-                                <AffixedInput
-                                    {...field}
-                                    type="number"
-                                    suffix="%"
-                                    min={0}
-                                    value={field.value}
-                                    onChange={e => field.onChange(e.target.valueAsNumber)}
-                                />
+                                <NumberInput {...field} value={field.value} min={0} step={0.01} suffix="%" />
                             )}
                         />
                         <FormFieldWrapper


### PR DESCRIPTION
Fixes [#4014](https://github.com/vendure-ecommerce/vendure/issues/4014)

# Description

This PR fixes an issue where decimal values were not accepted for the tax rate. They are now correctly parsed regardless of locale (e.g. both `5.5` for English and `5,5` for German are accepted).

# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced numeric input handling with improved value parsing, validation, and null-state management
  * Added customizable prefix and suffix UI elements for input fields to support flexible field labeling and unit display

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->