### PR TITLE
fix(dashboard): Display shipping method in order summary

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/components/order-table-totals.tsx
@@ -66,7 +66,7 @@ export function OrderTableTotals({ order, columnCount }: Readonly<OrderTableTota
                             <Trans>Shipping</Trans>
                         </div>
                         {order.shippingLines.map(sl => (
-                            <Badge variant="outline">
+                            <Badge variant="outline" key={sl.id}>
                                 {sl.shippingMethod.name}
                                 {order.shippingLines.length > 1
                                     ? ` (${formatCurrency(sl.discountedPriceWithTax, order.currencyCode)})`


### PR DESCRIPTION
Fixes #4021

# Description

Adds a Badge component with the name of each shipping method on an order.

If there are more than 1, then the price of each shipping method is also displayed.


# Breaking changes

nope

# Screenshots

<img width="821" height="419" alt="image" src="https://github.com/user-attachments/assets/217bd22d-d739-428d-9ced-de5e1024d12c" />

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Order table now shows individual shipping methods as distinct badges.
  * For orders with multiple shipping lines, each badge includes the method’s formatted price for clearer totals.
  * Shipping prices are displayed using localized currency formatting for improved clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->