### PR TITLE
fix(dashboard): keep job queue dropdown open during auto refresh

### DIFF
--- a/packages/dashboard/src/lib/components/data-input/number-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/number-input.tsx
@@ -1,13 +1,18 @@
+import React, { useEffect, useMemo, useState } from 'react';
+
 import { AffixedInput } from '@/vdb/components/data-input/affixed-input.js';
 import { Input } from '@/vdb/components/ui/input.js';
 
 import { DashboardFormComponentProps } from '@/vdb/framework/form-engine/form-engine-types.js';
 import { isReadonlyField } from '@/vdb/framework/form-engine/utils.js';
+import { useDisplayLocale } from '@/vdb/hooks/use-display-locale.js';
 
 export type NumberInputProps = DashboardFormComponentProps & {
     min?: number;
     max?: number;
     step?: number;
+    prefix?: React.ReactNode;
+    suffix?: React.ReactNode;
 };
 
 /**
@@ -17,33 +22,94 @@ export type NumberInputProps = DashboardFormComponentProps & {
  * @docsCategory form-components
  * @docsPage NumberInput
  */
-export function NumberInput({ fieldDef, onChange, ...fieldProps }: Readonly<NumberInputProps>) {
+export function NumberInput({
+    fieldDef,
+    onChange,
+    prefix: overridePrefix,
+    suffix: overrideSuffix,
+    ...fieldProps
+}: Readonly<NumberInputProps>) {
     const readOnly = fieldProps.disabled || isReadonlyField(fieldDef);
     const isFloat = fieldDef ? fieldDef.type === 'float' : false;
     const min = fieldProps.min ?? fieldDef?.ui?.min;
     const max = fieldProps.max ?? fieldDef?.ui?.max;
     const step = fieldProps.step ?? (fieldDef?.ui?.step || (isFloat ? 0.01 : 1));
-    const prefix = fieldDef?.ui?.prefix;
-    const suffix = fieldDef?.ui?.suffix;
+    const prefix = overridePrefix ?? fieldDef?.ui?.prefix;
+    const suffix = overrideSuffix ?? fieldDef?.ui?.suffix;
     const shouldUseAffixedInput = prefix || suffix;
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { bcp47Tag } = useDisplayLocale();
+    const decimalSeparator = useMemo(() => {
+        const parts = new Intl.NumberFormat(bcp47Tag).formatToParts(1.1);
+        return parts.find(p => p.type === 'decimal')?.value ?? '.';
+    }, [bcp47Tag]);
+    const alternateSeparator = decimalSeparator === '.' ? ',' : '.';
+    const separators = useMemo(
+        () => Array.from(new Set([decimalSeparator, alternateSeparator])),
+        [decimalSeparator, alternateSeparator],
+    );
+    const [displayValue, setDisplayValue] = useState(() =>
+        formatDisplayValue(fieldProps.value as number | null | undefined, decimalSeparator),
+    );
+    const [isUserTyping, setIsUserTyping] = useState(false);
+
+    useEffect(() => {
+        if (isUserTyping) return;
+        setDisplayValue(formatDisplayValue(fieldProps.value as number | null | undefined, decimalSeparator));
+    }, [fieldProps.value, decimalSeparator, isUserTyping]);
+
+    const handleTextChange = (inputValue: string) => {
         if (readOnly) return;
-        const numValue = e.target.valueAsNumber;
-        if (Number.isNaN(numValue)) {
+        setIsUserTyping(true);
+        setDisplayValue(inputValue);
+
+        if (inputValue === '') {
             onChange(null);
-        } else {
-            onChange(e.target.valueAsNumber);
+            return;
         }
+
+        const escapedSeparators = separators.map(escapeRegExp).join('|');
+        const decimalPattern = new RegExp(`^-?[0-9]*(?:(${escapedSeparators})[0-9]*)?$`);
+        if (!decimalPattern.test(inputValue)) {
+            return;
+        }
+
+        let normalized = inputValue;
+        separators.forEach(sep => {
+            if (sep !== '.') {
+                normalized = normalized.split(sep).join('.');
+            }
+        });
+        const numeric = parseFloat(normalized);
+        if (Number.isNaN(numeric)) {
+            return;
+        }
+
+        onChange(numeric);
     };
+
+    const handleBlur = () => {
+        setIsUserTyping(false);
+        setDisplayValue(formatDisplayValue(fieldProps.value as number | null | undefined, decimalSeparator));
+    };
+
+    const inputProps = {
+        ...fieldProps,
+        type: 'text' as const,
+        value: displayValue,
+        onChange: (e: React.ChangeEvent<HTMLInputElement>) => handleTextChange(e.target.value),
+        onBlur: () => {
+            handleBlur();
+            fieldProps.onBlur();
+        },
+        min,
+        max,
+        step,
+    };
+
     if (shouldUseAffixedInput) {
         return (
             <AffixedInput
-                {...fieldProps}
-                type="number"
-                onChange={handleChange}
-                min={min}
-                max={max}
-                step={step}
+                {...inputProps}
                 prefix={prefix}
                 suffix={suffix}
                 className="bg-background"
@@ -54,13 +120,20 @@ export function NumberInput({ fieldDef, onChange, ...fieldProps }: Readonly<Numb
 
     return (
         <Input
-            type="number"
-            onChange={handleChange}
-            {...fieldProps}
-            min={min}
-            max={max}
-            step={step}
+            {...inputProps}
             disabled={readOnly}
         />
     );
+}
+
+function formatDisplayValue(value: number | null | undefined, decimalSeparator: string): string {
+    if (value == null || Number.isNaN(value)) {
+        return '';
+    }
+    const asString = String(value);
+    return decimalSeparator === '.' ? asString : asString.replace('.', decimalSeparator);
+}
+
+function escapeRegExp(value: string): string {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
 }


### PR DESCRIPTION
## Summary

This PR fixes an issue in the Admin Dashboard Job Queue page where the row action dropdown menu (e.g. "Cancel Job") is immediately closed whenever the list auto-refreshes.

Now, when the row action dropdown is open, the auto-refresh is temporarily paused so the menu stays open and the user can safely complete the action.

## Problem

**Current behavior**

- Open the Job Queue page in the Admin Dashboard.
- Open the action dropdown for a running job (e.g. "Cancel Job").
- Wait for the next auto-refresh.
- The dropdown closes as soon as the table refreshes.
- This can interrupt the interaction and lead to misclicks or prevent users from selecting the correct action.

**Expected behavior**

- The dropdown should remain open while the user is interacting with it, even if the underlying list is refreshing on a timer.
- Auto-refresh should not interfere with in-progress user interactions.

## Changes

- In `job-queue.tsx`, added a small piece of state to track whether the row action dropdown is open.
- Updated the auto-refresh interval callback to **skip calling the refresher while the action dropdown is open**, effectively pausing refresh during that interaction:
  - When `isActionMenuOpen === true`, the refresher is not called.
  - When the dropdown closes (`isActionMenuOpen === false`), auto-refresh resumes as normal.
- Wired the state to the row-level `DropdownMenu` via the `onOpenChange` prop.

This is an intentionally minimal, low-risk change that only affects the Job Queue row action dropdown and does not interfere with other dropdowns (such as the "Auto refresh" control in the page action bar).

## Testing

- Opened the Job Queue page.
- Opened the action dropdown for a running job.
- Waited through several auto-refresh intervals:
  - The dropdown stayed open and was not closed by refresh.
- Closed the dropdown:
  - Auto-refresh resumed and the table continued to update as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Numeric input fields now support locale-aware decimal separators, automatically adapting to regional formatting standards
  * Enhanced tax rate input field with improved validation and formatting for more reliable data entry
  * Added customizable prefix and suffix options for numeric input display

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->