### PR TITLE
fix(dashboard): keep job queue dropdown open during auto refresh

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_system/components/payload-dialog.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_system/components/payload-dialog.tsx
@@ -14,11 +14,18 @@ type PayloadDialogProps = {
     trigger: React.ReactNode;
     title?: string | React.ReactNode;
     description?: string | React.ReactNode;
+    onOpenChange?: (open: boolean) => void;
 };
 
-export function PayloadDialog({ payload, trigger, title, description }: Readonly<PayloadDialogProps>) {
+export function PayloadDialog({
+    payload,
+    trigger,
+    title,
+    description,
+    onOpenChange,
+}: Readonly<PayloadDialogProps>) {
     return (
-        <Dialog>
+        <Dialog onOpenChange={open => onOpenChange?.(open)}>
             <DialogTrigger asChild>{trigger}</DialogTrigger>
             <DialogContent>
                 <DialogHeader>

--- a/packages/dashboard/src/app/routes/_authenticated/_system/job-queue.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_system/job-queue.tsx
@@ -78,20 +78,21 @@ function JobQueuePage() {
     const refreshRef = useRef<() => void>(() => {});
     const { t } = useLingui();
     const [refreshInterval, setRefreshInterval] = useState(10000);
-    const [isActionMenuOpen, setIsActionMenuOpen] = useState(false);
+    const isActionMenuOpenRef = useRef(false);
 
     useEffect(() => {
         if (refreshInterval === 0) return;
 
         const interval = setInterval(() => {
-            // Pause auto-refresh while the row action dropdown is open to avoid closing it mid-interaction
-            if (!isActionMenuOpen) {
+            // Pause auto-refresh while the row action dropdown is open
+            // to avoid closing it mid-interaction
+            if (!isActionMenuOpenRef.current) {
                 refreshRef.current();
             }
         }, refreshInterval);
 
         return () => clearInterval(interval);
-    }, [refreshInterval, isActionMenuOpen]);
+    }, [refreshInterval]);
 
     const currentInterval = REFRESH_INTERVALS.find(i => i.value === refreshInterval);
 
@@ -115,6 +116,7 @@ function JobQueuePage() {
                         <PayloadDialog
                             payload={row.original.data}
                             title={<Trans>View job data</Trans>}
+                            onOpenChange={open => (isActionMenuOpenRef.current = open)}
                             description={<Trans>The data that has been passed to the job</Trans>}
                             trigger={
                                 <Button size="sm" variant="secondary">
@@ -133,6 +135,7 @@ function JobQueuePage() {
                             <PayloadDialog
                                 payload={row.original.result}
                                 title={<Trans>View job result</Trans>}
+                                onOpenChange={open => (isActionMenuOpenRef.current = open)}
                                 description={<Trans>The result of the job</Trans>}
                                 trigger={
                                     <Button size="sm" variant="secondary">
@@ -172,7 +175,9 @@ function JobQueuePage() {
                                 {row.original.state}
                                 {row.original.state === 'RUNNING' ? (
                                     <div className="flex items-center gap-2">
-                                        <DropdownMenu onOpenChange={setIsActionMenuOpen}>
+                                        <DropdownMenu
+                                            onOpenChange={open => (isActionMenuOpenRef.current = open)}
+                                        >
                                             <DropdownMenuTrigger asChild>
                                                 <Button variant="ghost" size="sm" className="h-6 w-6 p-0">
                                                     <MoreVertical className="h-4 w-4" />


### PR DESCRIPTION
## Summary

This PR fixes an issue in the Admin Dashboard Job Queue page where the row action dropdown menu (e.g. "Cancel Job") is immediately closed whenever the list auto-refreshes.

Now, when the row action dropdown is open, the auto-refresh is temporarily paused so the menu stays open and the user can safely complete the action.

## Problem

**Current behavior**

- Open the Job Queue page in the Admin Dashboard.
- Open the action dropdown for a running job (e.g. "Cancel Job").
- Wait for the next auto-refresh.
- The dropdown closes as soon as the table refreshes.
- This can interrupt the interaction and lead to misclicks or prevent users from selecting the correct action.

**Expected behavior**

- The dropdown should remain open while the user is interacting with it, even if the underlying list is refreshing on a timer.
- Auto-refresh should not interfere with in-progress user interactions.

## Changes

- In `job-queue.tsx`, added a small piece of state to track whether the row action dropdown is open.
- Updated the auto-refresh interval callback to **skip calling the refresher while the action dropdown is open**, effectively pausing refresh during that interaction:
  - When `isActionMenuOpen === true`, the refresher is not called.
  - When the dropdown closes (`isActionMenuOpen === false`), auto-refresh resumes as normal.
- Wired the state to the row-level `DropdownMenu` via the `onOpenChange` prop.

This is an intentionally minimal, low-risk change that only affects the Job Queue row action dropdown and does not interfere with other dropdowns (such as the "Auto refresh" control in the page action bar).

## Testing

- Opened the Job Queue page.
- Opened the action dropdown for a running job.
- Waited through several auto-refresh intervals:
  - The dropdown stayed open and was not closed by refresh.
- Closed the dropdown:
  - Auto-refresh resumed and the table continued to update as before.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Job queue auto-refresh now pauses while viewing row action menus, preventing disruptive UI updates during user interaction.


<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->