### PR TITLE
feat(dashboard): Provide entity object to draft-order-detail Page component

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
@@ -290,7 +290,7 @@ function DraftOrderPage() {
     };
 
     return (
-        <Page pageId="draft-order-detail" form={form}>
+        <Page pageId="draft-order-detail" form={form} entity={entity}>
             <PageTitle>
                 <Trans>Draft order</Trans>: {entity?.code ?? ''}
             </PageTitle>


### PR DESCRIPTION
# Description

The `draft-order-detail` page doesn't have the `entity` prop set for its <Page> component, resulting in the draft order not being accessible from e.g. custom PageBlocks.

While this might have been intentionally left out, I could not find any reason.
I have a use-case for accessing the current order data in a custom PageBlock to update some UI based on the order state/specific order lines being present. Without passing this prop, the PageBlock is not able to dynamically react to changes made in the order data.

# Breaking changes

None afaik.

# Screenshots

-

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal rendering context handling for draft order pages.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->