### PR TITLE
fix(dashboard): Fix incorrect currency being displayed in dashboard u…

### DIFF
--- a/packages/dashboard/src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
+++ b/packages/dashboard/src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx
@@ -101,7 +101,10 @@ export function LatestOrdersWidget() {
                         header: t`Total`,
                         cell: OrderMoneyCell,
                     },
-                    totalWithTax: { cell: OrderMoneyCell },
+                    totalWithTax: {
+                        meta: { dependencies: ['currencyCode'] },
+                        cell: OrderMoneyCell,
+                    },
                     state: { cell: OrderStateCell },
                     customer: { cell: CustomerCell },
                 }}


### PR DESCRIPTION
## Description

Fixes #4084

This PR fixes an issue in the Dashboard Insights UI where an incorrect currency was displayed. The root cause was missing dependencies in `Total`, which caused the UI to render prices using a default currency.

By ensuring the correct dependency tracking, the dashboard now consistently displays prices using the active channel currency.

---

## Breaking changes

This PR does not include any breaking changes.

---

## Screenshots

**Before (incorrect currency rendering):**

<img width="1920" height="892" alt="image" src="https://github.com/user-attachments/assets/7f4f167a-67e5-46f8-bbc4-7d6bab3f52f6" />

**After (correct currency rendering):**

<img width="1920" height="892" alt="image" src="https://github.com/user-attachments/assets/9d3377d1-ee4a-45cd-8b69-1f176d5eb670" />

---

## Checklist

### 📌 Always:

* [x] I have set a clear title
* [x] My PR is small and contains a single fix
* [x] I have checked my own PR

### 👍 Most of the time:

* [ ] I have added or updated test cases
* [ ] I have updated the README if needed

