### PR TITLE
fix(dashboard): hide "Add channel" button for users without CreateChannel permission

### DIFF
--- a/packages/dashboard/src/lib/components/layout/channel-switcher.tsx
+++ b/packages/dashboard/src/lib/components/layout/channel-switcher.tsx
@@ -1,6 +1,7 @@
 import { ChevronsUpDown, Languages, Plus } from 'lucide-react';
 
 import { ChannelCodeLabel } from '@/vdb/components/shared/channel-code-label.js';
+import { PermissionGuard } from '@/vdb/components/shared/permission-guard.js';
 import {
     DropdownMenu,
     DropdownMenuContent,
@@ -201,17 +202,19 @@ export function ChannelSwitcher() {
                                     )}
                                 </div>
                                 {orderedChannels.map(renderChannel)}
-                                <DropdownMenuSeparator />
-                                <DropdownMenuItem className="gap-2 p-2 cursor-pointer" asChild>
-                                    <Link to={'/channels/new'}>
-                                        <div className="bg-background flex size-6 items-center justify-center rounded-md border">
-                                            <Plus className="size-4" />
-                                        </div>
-                                        <div className="text-muted-foreground font-medium">
-                                            <Trans>Add channel</Trans>
-                                        </div>
-                                    </Link>
-                                </DropdownMenuItem>
+                                <PermissionGuard requires={['CreateChannel']}>
+                                    <DropdownMenuSeparator />
+                                    <DropdownMenuItem className="gap-2 p-2 cursor-pointer" asChild>
+                                        <Link to={'/channels/new'}>
+                                            <div className="bg-background flex size-6 items-center justify-center rounded-md border">
+                                                <Plus className="size-4" />
+                                            </div>
+                                            <div className="text-muted-foreground font-medium">
+                                                <Trans>Add channel</Trans>
+                                            </div>
+                                        </Link>
+                                    </DropdownMenuItem>
+                                </PermissionGuard>
                             </ScrollArea>
                         </DropdownMenuContent>
                     </DropdownMenu>


### PR DESCRIPTION
# Description

  Hide the "Add channel" button in the channel switcher dropdown for users who don't have the `CreateChannel` permission.

  **Problem:** Currently, all users see the "Add channel" option in the channel selector menu, even seller/vendor admins who don't have permission to create channels. This causes confusion as they can access the form but cannot submit it.

  **Solution:** Wrap the "Add channel" menu item (and its separator) with `<PermissionGuard requires={['CreateChannel']}>` to conditionally render it only for users with the appropriate permission. This follows the same pattern used elsewhere in the Dashboard (e.g., `global-views-bar.tsx`).

  Fixes #4056

  # Breaking changes

  No breaking changes.

  # Screenshots

  N/A - The "Add channel" option simply no longer appears for users without the `CreateChannel` permission.

  # Checklist

  📌 Always:
  - [x] I have set a clear title
  - [x] My PR is small and contains a single feature
  - [x] I have checked my own PR
