### PR TITLE
fix(core): Use previously unused relations filter in findByCustomerId

### DIFF
--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -335,7 +335,7 @@ export class OrderService {
         );
         return this.listQueryBuilder
             .build(Order, options, {
-                relations: relations ?? ['lines', 'customer', 'channels', 'shippingLines'],
+                relations: effectiveRelations,
                 channelId: ctx.channelId,
                 ctx,
             })


### PR DESCRIPTION
# Description

Addresses Issue #3373

effectiveRelations was first added in this [commit](https://github.com/vendurehq/vendure/commit/b98220b6a) where it does seem like it was just accidentally not used.

I also think I found the original related Issue that lead to this change.
https://github.com/vendurehq/vendure/issues/1508

Included in the fix to the issue this [commit](https://github.com/vendurehq/vendure/commit/5061dd923f25bcae43fccf4602022d790a790795) removed the relations from the fallback which of course still leads to the issue that the passed relations can include the productVariant relation which was addressed in the commit mentioned above.

Now while testing before and after adding `effectiveRelations` I never found anything wrong with the price calculations like mentioned in the comment but I also don't know what the specific edge case is so I would say it still makes sense to add it to make sure the issue doesn't come up again.

# Breaking changes

no

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
