### PR TITLE
fix(core): Respect publishConfig.directory in npm publish workflow

### DIFF
--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -127,17 +127,22 @@ jobs:
       # Publish to npm with appropriate dist-tag
       # Note: we do not use `lerna publish` because at the time of writing, it fails to publish
       # using the Trusted Publishing workflow for some reason.
+      # We use a custom script to handle publishConfig.directory for packages like @vendure/admin-ui
+      # that need to publish from a nested directory.
       - name: Publish to NPM (release)
         if: matrix.type == 'release'
-        run: npx lerna exec --no-private -- npm publish --access public
+        run: |
+          npx lerna exec --no-private -- 'publish_dir=$(node -p "require(\"./package.json\").publishConfig?.directory || \".\"") && cd "$publish_dir" && npm publish --access public'
 
       - name: Publish to NPM (master-nightly)
         if: matrix.type == 'master-nightly' && steps.commit_check.outputs.should_publish == 'true'
-        run: npx lerna exec --no-private -- npm publish --access public --tag master
+        run: |
+          npx lerna exec --no-private -- 'publish_dir=$(node -p "require(\"./package.json\").publishConfig?.directory || \".\"") && cd "$publish_dir" && npm publish --access public --tag master'
 
       - name: Publish to NPM (minor-nightly)
         if: matrix.type == 'minor-nightly' && steps.commit_check.outputs.should_publish == 'true'
-        run: npx lerna exec --no-private -- npm publish --dd --access public --tag minor
+        run: |
+          npx lerna exec --no-private -- 'publish_dir=$(node -p "require(\"./package.json\").publishConfig?.directory || \".\"") && cd "$publish_dir" && npm publish --access public --tag minor'
 
       - name: Skip publish (no new commits)
         if: matrix.type != 'release' && steps.commit_check.outputs.should_publish == 'false'


### PR DESCRIPTION
## Summary

- Fixes the npm publish workflow to respect `publishConfig.directory` in package.json
- This restores correct publishing behavior for `@vendure/admin-ui` which needs to publish from its nested `package/` directory

Fixes #4079

## Background

When we switched from `lerna publish` to `lerna exec -- npm publish` for Trusted Publishing support, the `@vendure/admin-ui` package broke because:

- `lerna publish` respects `publishConfig.directory` 
- `npm publish` via `lerna exec` does NOT

The fix reads each package's `publishConfig.directory` and `cd`s into it before running `npm publish`.

## Test plan

- [ ] Verify the workflow syntax is correct by running a dry-run or manual dispatch
- [ ] After next publish, verify `@vendure/admin-ui` tarball contains files at root level (not under `package/` prefix)
- [ ] Verify imports like `@vendure/admin-ui/core` work correctly