### PR TITLE
fix(dashboard): Register text-form-input component

### DIFF
--- a/packages/dashboard/src/lib/framework/extension-api/input-component-extensions.tsx
+++ b/packages/dashboard/src/lib/framework/extension-api/input-component-extensions.tsx
@@ -9,6 +9,7 @@ import {
     SelectWithOptions,
 } from '@/vdb/components/data-input/index.js';
 import { PasswordFormInput } from '@/vdb/components/data-input/password-form-input.js';
+import { TextInput } from '@/vdb/components/data-input/text-input.js';
 import { TextareaInput } from '@/vdb/components/data-input/textarea-input.js';
 import { DashboardFormComponent } from '@/vdb/framework/form-engine/form-engine-types.js';
 import { globalRegistry } from '../registry/global-registry.js';
@@ -38,6 +39,7 @@ inputComponents.set('relation-form-input', DefaultRelationInput);
 inputComponents.set('select-form-input', SelectWithOptions);
 inputComponents.set('product-multi-form-input', ProductMultiInput);
 inputComponents.set('combination-mode-form-input', CombinationModeInput);
+inputComponents.set('text-form-input', TextInput);
 
 export function getInputComponent(id: string | undefined): DashboardFormComponent | undefined {
     if (!id) {


### PR DESCRIPTION
# Description

Registers the `text-form-input` component in the dashboard's input component registry.

This fixes an issue where custom fields configured with `ui: { component: "text-form-input" }` were not being displayed in the dashboard.

Fixes #4005

# Breaking changes

None

# Screenshots

For testing I used the following config 

```
  {
                name: 'shortName',
                type: 'localeString',
                nullable: true,
                label: [
                    { languageCode: LanguageCode.de, value: 'Kurztitel' },
                    { languageCode: LanguageCode.en, value: 'Short name' },
                ],
                ui: { component: 'text-form-input' },
            },
```


https://github.com/user-attachments/assets/87f02bf2-cf8e-4183-8916-ff1e66212777






# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
