### PR TITLE
fix(dashboard): Hide bulk action bar when no selected items are visible

### DIFF
--- a/packages/dashboard/src/lib/components/data-table/data-table-bulk-actions.tsx
+++ b/packages/dashboard/src/lib/components/data-table/data-table-bulk-actions.tsx
@@ -27,6 +27,7 @@ export function DataTableBulkActions<TData>({
     // Cache to store selected items across page changes
     const selectedItemsCache = useRef<Map<string, TData>>(new Map());
     const selectedRowIds = Object.keys(table.getState().rowSelection);
+    const visibleSelectedCount = table.getRowModel().rows.filter(row => row.getIsSelected()).length;
 
     // Get selection from cache instead of trying to get from table
     const selection = selectedRowIds
@@ -49,7 +50,7 @@ export function DataTableBulkActions<TData>({
         .filter((item): item is TData => item !== undefined);
 
     const { position, shouldShow } = useFloatingBulkActions({
-        selectionCount: selection.length,
+        selectionCount: visibleSelectedCount,
         containerSelector: '[data-table-root], .data-table-container, table',
         bottomOffset: 40,
     });


### PR DESCRIPTION
Fixes #4007

## Problem

When users select items in a data table and then apply a filter that hides those items, the floating action bar ("X selected") remains visible even though none of the selected items are displayed. This creates a confusing UX.

## Solution

Hide the bulk action bar when no selected items are currently visible in the filtered view, while preserving the selection state internally.

This approach is better than clearing selection on filter change because it preserves a common workflow: selecting items from different parts of a large list by using filters to navigate. For example, with 260 countries, a user might select Argentina first, then filter to "Zimbabwe" to avoid scrolling—clearing the selection would break this.

## Changes

- Added `visibleSelectedCount` derived from `table.getRowModel().rows` to track how many selected items are currently visible
- Use `visibleSelectedCount` instead of `selection.length` for the floating action bar visibility check

## Demo

https://github.com/user-attachments/assets/0e2f9b20-7e84-46a6-8459-db4bbd5fb48b
