### PR TITLE
fix(dashboard): Show all items in the order details page, clean up fu…

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
@@ -218,8 +218,8 @@ export function FulfillOrderDialog({ order, onSuccess }: Readonly<FulfillOrderDi
             >
                 <Trans>Fulfill order</Trans>
             </Button>
-            <Dialog open={open}>
-                <DialogContent className="sm:max-w-[600px]">
+            <Dialog open={open} onOpenChange={setOpen}>
+                <DialogContent className="sm:max-w-[600px] max-h-[90vh] overflow-hidden flex flex-col">
                     <DialogHeader>
                         <DialogTitle>
                             <Trans>Fulfill order</Trans>
@@ -234,9 +234,9 @@ export function FulfillOrderDialog({ order, onSuccess }: Readonly<FulfillOrderDi
                                 e.stopPropagation();
                                 form.handleSubmit(handleSubmit)(e);
                             }}
-                            className="space-y-4"
+                            className="space-y-4 flex-1 overflow-hidden flex flex-col"
                         >
-                            <div className="space-y-4">
+                            <div className="space-y-4 flex-1 overflow-y-auto">
                                 <div className="font-medium">
                                     <Trans>Order lines</Trans>
                                 </div>

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/components/order-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/components/order-table.tsx
@@ -175,6 +175,7 @@ export function OrderTable({ order, pageId }: Readonly<OrderTableProps>) {
                 columns={columns as any}
                 data={data as any}
                 totalItems={data.length}
+                itemsPerPage={data.length}
                 disableViewOptions={false}
                 defaultColumnVisibility={columnVisibility}
                 onColumnVisibilityChange={(_, columnVisibility) => {


### PR DESCRIPTION
This pull request improves the user interface and usability of the order fulfillment dialog and order table components in the dashboard. The main focus is on enhancing the dialog's layout and scrollability for better handling of large content, and ensuring the order table displays all items per page.

**Order Fulfillment Dialog UI improvements:**

* Updated the `Dialog` component in `fulfill-order-dialog.tsx` to call `setOpen` when the dialog's open state changes, and adjusted `DialogContent` to have a maximum height, hide overflow, and use a flex column layout for better scroll handling.
* Modified the form and inner container within the dialog to use flex layouts and enable vertical scrolling, ensuring the order lines section is scrollable when content exceeds available space.

**Order Table display adjustment:**

* Set the `itemsPerPage` prop of the `OrderTable` component to the full length of the data, ensuring all items are shown on a single page.

# Description

Fixes: The order table is limited to 10 rows in react dashboard #4141

# Breaking changes

No

# Screenshots

<img width="569" height="643" alt="image" src="https://github.com/user-attachments/assets/144e8dc2-cf15-4ad4-97d1-ce7274b3d832" />
<img width="577" height="482" alt="image" src="https://github.com/user-attachments/assets/1a2b3deb-58ef-4e8b-9c62-bf4fbf31bdcd" />


# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
