### PR TITLE
chore: Add Claude Code rules for dashboard i18n

### DIFF
--- a/.claude/rules/dashboard.md
+++ b/.claude/rules/dashboard.md
@@ -1,0 +1,28 @@
+---
+paths:
+  - "packages/dashboard/**/*.tsx"
+  - "packages/dashboard/**/*.ts"
+---
+
+# Dashboard Development
+
+## i18n / Translations
+
+**All user-facing strings MUST be wrapped for translation.** Never hard-code English strings.
+
+```tsx
+import { Trans, useLingui } from '@lingui/react/macro';
+
+// JSX content
+<Trans>Your text here</Trans>
+
+// Dynamic strings (variables, props, toasts)
+const { t } = useLingui();
+toast.success(t`Operation completed`);
+```
+
+**When adding default config values** (dropdown options, reason lists, status labels):
+- Use `t\`...\`` at render time
+- Never hardcode English strings that display to users
+
+Translation files: `packages/dashboard/src/i18n/locales/*.po`


### PR DESCRIPTION
## Summary

Adds `.claude/rules/dashboard.md` with i18n guidelines for the React dashboard.

I noticed multiple times that Claude Code misses adding translations in obvious spots where they should be used. There are also existing places in the codebase where translations are already missing.

The rules file:
- Uses path filtering to only load when working with `packages/dashboard/**` files
- Documents the `<Trans>` and `t\`...\`` patterns from `@lingui/react/macro`
- Reminds to never hardcode English strings in config values (dropdowns, reason lists, etc.)

## Test plan

- [ ] Verify `.claude/rules/dashboard.md` is loaded when editing dashboard files