### PR TITLE
fix(dashboard): Fix displaying HistoryEntry for CustomerEmailUpdateComponent

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx
@@ -141,36 +141,38 @@ export function CustomerPasswordResetVerifiedComponent(props: Readonly<HistoryEn
     );
 }
 
-export function CustomerEmailUpdateComponent({ entry }: Readonly<HistoryEntryProps>) {
-    const { oldEmailAddress, newEmailAddress } = entry.data || {};
+export function CustomerEmailUpdateComponent(props: Readonly<HistoryEntryProps>) {
+    const { oldEmailAddress, newEmailAddress } = props.entry.data || {};
 
     return (
-        <div className="space-y-2">
-            {(oldEmailAddress || newEmailAddress) && (
-                <details className="text-xs">
-                    <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
-                        <Trans>View details</Trans>
-                    </summary>
-                    <div className="mt-2 space-y-1">
-                        {oldEmailAddress && (
-                            <div>
-                                <span className="font-medium">
-                                    <Trans>Old email:</Trans>
-                                </span>{' '}
-                                {oldEmailAddress}
-                            </div>
-                        )}
-                        {newEmailAddress && (
-                            <div>
-                                <span className="font-medium">
-                                    <Trans>New email:</Trans>
-                                </span>{' '}
-                                {newEmailAddress}
-                            </div>
-                        )}
-                    </div>
-                </details>
-            )}
-        </div>
+        <HistoryEntry {...props}>
+            <div className="space-y-2">
+                {(oldEmailAddress || newEmailAddress) && (
+                    <details className="text-xs">
+                        <summary className="cursor-pointer text-muted-foreground hover:text-foreground">
+                            <Trans>View details</Trans>
+                        </summary>
+                        <div className="mt-2 space-y-1">
+                            {oldEmailAddress && (
+                                <div>
+                                    <span className="font-medium">
+                                        <Trans>Old email:</Trans>
+                                    </span>{' '}
+                                    {oldEmailAddress}
+                                </div>
+                            )}
+                            {newEmailAddress && (
+                                <div>
+                                    <span className="font-medium">
+                                        <Trans>New email:</Trans>
+                                    </span>{' '}
+                                    {newEmailAddress}
+                                </div>
+                            )}
+                        </div>
+                    </details>
+                )}
+            </div>
+        </HistoryEntry>
     );
 }


### PR DESCRIPTION
# Description

When updating the customers e-mail, the history entry is displayed incorrectly.
I simply added the wrapping `<HistoryEntry>`. Review is easy when using "hide whitespace changes".

# Breaking changes

none

# Screenshots

with the issue:
<img width="1145" height="501" alt="Screenshot from 2026-01-28 09-46-22" src="https://github.com/user-attachments/assets/ce25db2f-e953-4312-acfa-bb2044720dcb" />


with the fix:
<img width="1157" height="596" alt="Screenshot from 2026-01-28 09-44-37" src="https://github.com/user-attachments/assets/1fe75f9a-255b-4086-baf0-889213601004" />


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] ~~I have added or updated test cases~~
- [ ] ~~I have updated the README if needed~~
