### PR TITLE
fix: Sync package-lock.json with package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -678,7 +678,6 @@
             "integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "8.52.0",
                 "@typescript-eslint/visitor-keys": "8.52.0"
@@ -712,7 +711,6 @@
             "integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/project-service": "8.52.0",
                 "@typescript-eslint/tsconfig-utils": "8.52.0",
@@ -741,7 +739,6 @@
             "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -780,7 +777,6 @@
             "integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "8.52.0",
                 "eslint-visitor-keys": "^4.2.1"
@@ -827,7 +823,6 @@
             "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -838,7 +833,6 @@
             "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -862,7 +856,6 @@
             "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -912,6 +905,7 @@
             "integrity": "sha512-pQiOg+se1AU/ncMlnJ9V6xYnMQ84qI1BGWuJpbU6A99VTXJg90scg0+T7DWmKssR1YjP5qmmBtrZfKsHEcLW/A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@angular-eslint/bundled-angular-compiler": "19.8.1",
                 "eslint-scope": "^8.0.2"
@@ -943,6 +937,7 @@
             "resolved": "https://registry.npmjs.org/@angular/animations/-/animations-19.2.18.tgz",
             "integrity": "sha512-c76x1t+OiSstPsvJdHmV8Q4taF+8SxWKqiY750fOjpd01it4jJbU6YQqIroC6Xie7154zZIxOTHH2uTj+nm5qA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1309,6 +1304,7 @@
             "resolved": "https://registry.npmjs.org/@angular/cdk/-/cdk-19.2.19.tgz",
             "integrity": "sha512-PCpJagurPBqciqcq4Z8+3OtKLb7rSl4w/qBJoIMua8CgnrjvA1i+SWawhdtfI1zlY8FSwhzLwXV0CmWWfFzQPg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "parse5": "^7.1.2",
                 "tslib": "^2.3.0"
@@ -1419,6 +1415,7 @@
             "resolved": "https://registry.npmjs.org/@angular/common/-/common-19.2.18.tgz",
             "integrity": "sha512-CrV02Omzw/QtfjlEVXVPJVXipdx83NuA+qSASZYrxrhKFusUZyK3P/Zznqg+wiAeNDbedQwMUVqoAARHf0xQrw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1435,6 +1432,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler/-/compiler-19.2.18.tgz",
             "integrity": "sha512-3MscvODxRVxc3Cs0ZlHI5Pk5rEvE80otfvxZTMksOZuPlv1B+S8MjWfc3X3jk9SbyUEzODBEH55iCaBHD48V3g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1447,6 +1445,7 @@
             "resolved": "https://registry.npmjs.org/@angular/compiler-cli/-/compiler-cli-19.2.18.tgz",
             "integrity": "sha512-N4TMtLfImJIoMaRL6mx7885UBeQidywptHH6ACZj71Ar6++DBc1mMlcwuvbeJCd3r3y8MQ5nLv5PZSN/tHr13w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "7.26.9",
                 "@jridgewell/sourcemap-codec": "^1.4.14",
@@ -1548,6 +1547,7 @@
             "resolved": "https://registry.npmjs.org/@angular/core/-/core-19.2.18.tgz",
             "integrity": "sha512-+QRrf0Igt8ccUWXHA+7doK5W6ODyhHdqVyblSlcQ8OciwkzIIGGEYNZom5OZyWMh+oI54lcSeyV2O3xaDepSrQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1564,6 +1564,7 @@
             "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-19.2.18.tgz",
             "integrity": "sha512-pe40934jWhoS7DyGl7jyZdoj1gvBgur2t1zrJD+csEkTitYnW14+La2Pv6SW1pNX5nIzFsgsS9Nex1KcH5S6Tw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1591,6 +1592,7 @@
             "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-19.2.18.tgz",
             "integrity": "sha512-eahtsHPyXTYLARs9YOlXhnXGgzw0wcyOcDkBvNWK/3lA0NHIgIHmQgXAmBo+cJ+g9skiEQTD2OmSrrwbFKWJkw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -1675,6 +1677,7 @@
             "resolved": "https://registry.npmjs.org/@apollo/client/-/client-3.14.0.tgz",
             "integrity": "sha512-0YQKKRIxiMlIou+SekQqdCo0ZTHxOcES+K8vKB53cIDpwABNR0P0yRzPgsbgcj3zRJniD93S/ontsnZsCLZrxQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@graphql-typed-document-node/core": "^3.1.1",
                 "@wry/caches": "^1.0.0",
@@ -1743,6 +1746,7 @@
             "integrity": "sha512-jKRlf+sBMMdKYrjMoiWKne42Eb6paBfDOr08KJnUaeaiyWFj+/040FjVPQI7YGLfdwnYIsl1NUUqS2UdgezJDg==",
             "deprecated": "Apollo Server v4 is deprecated and will transition to end-of-life on January 26, 2026. As long as you are already using a non-EOL version of Node.js, upgrading to v5 should take only a few minutes. See https://www.apollographql.com/docs/apollo-server/previous-versions for details.",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@apollo/cache-control-types": "^1.0.3",
                 "@apollo/server-gateway-interface": "^1.1.1",
@@ -2551,6 +2555,7 @@
             "integrity": "sha512-BTeaaU1iK0BfatTCrtYjNkIHCoZH256qOI18l9bK4z6mVOgpHkYN4RvOu+NnKgyX58n+HWfOuhtKUD4OE33Vdw==",
             "dev": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@aws-crypto/sha1-browser": "5.2.0",
                 "@aws-crypto/sha256-browser": "5.2.0",
@@ -3336,12 +3341,12 @@
             }
         },
         "node_modules/@babel/code-frame": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
-            "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.28.6.tgz",
+            "integrity": "sha512-JYgintcMjRiCvS8mMECzaEn+m3PfoQiyqukOMCCVQtoJGYJw8j/8LBJEiqkHLkfwCcs74E3pbAUFNg7d9VNJ+Q==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-validator-identifier": "^7.27.1",
+                "@babel/helper-validator-identifier": "^7.28.5",
                 "js-tokens": "^4.0.0",
                 "picocolors": "^1.1.1"
             },
@@ -3350,9 +3355,9 @@
             }
         },
         "node_modules/@babel/compat-data": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.5.tgz",
-            "integrity": "sha512-6uFXyCayocRbqhZOB+6XcuZbkMNimwfVGFji8CTZnCzOHVGvDqzvitu1re2AU5LROliz7eQPhB8CpAMvnx9EjA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.6.tgz",
+            "integrity": "sha512-2lfu57JtzctfIrcGMz992hyLlByuzgIk58+hhGCxjKZ3rWI82NnVLjXcaTqkI2NvlcvOskZaiZ5kjUALo3Lpxg==",
             "license": "MIT",
             "engines": {
                 "node": ">=6.9.0"
@@ -3363,6 +3368,7 @@
             "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.26.10.tgz",
             "integrity": "sha512-vMqyb7XCDMPvJFFOaT9kxtiRh42GwlZEg1/uIgtZshS5a/8OaduUfCi7kynKgc3Tw/6Uo2D+db9qBttghhmxwQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ampproject/remapping": "^2.2.0",
                 "@babel/code-frame": "^7.26.2",
@@ -3432,12 +3438,12 @@
             }
         },
         "node_modules/@babel/helper-compilation-targets": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
-            "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
+            "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/compat-data": "^7.27.2",
+                "@babel/compat-data": "^7.28.6",
                 "@babel/helper-validator-option": "^7.27.1",
                 "browserslist": "^4.24.0",
                 "lru-cache": "^5.1.1",
@@ -3575,27 +3581,27 @@
             }
         },
         "node_modules/@babel/helper-module-imports": {
-            "version": "7.27.1",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
-            "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
+            "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/traverse": "^7.27.1",
-                "@babel/types": "^7.27.1"
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/helper-module-transforms": {
-            "version": "7.28.3",
-            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
-            "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
+            "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
             "license": "MIT",
             "dependencies": {
-                "@babel/helper-module-imports": "^7.27.1",
-                "@babel/helper-validator-identifier": "^7.27.1",
-                "@babel/traverse": "^7.28.3"
+                "@babel/helper-module-imports": "^7.28.6",
+                "@babel/helper-validator-identifier": "^7.28.5",
+                "@babel/traverse": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
@@ -3738,25 +3744,25 @@
             }
         },
         "node_modules/@babel/helpers": {
-            "version": "7.28.4",
-            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
-            "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.6.tgz",
+            "integrity": "sha512-xOBvwq86HHdB7WUDTfKfT/Vuxh7gElQ+Sfti2Cy6yIWNW05P8iUslOVcZ4/sKbE+/jQaukQAdz/gf3724kYdqw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.4"
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/parser": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.5.tgz",
-            "integrity": "sha512-KKBU1VGYR7ORr3At5HAtUQ+TV3SzRCXmA/8OdDZiLDBIZxVyzXuztPjfLd3BV1PRAQGCMWWSHYhL0F8d5uHBDQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.6.tgz",
+            "integrity": "sha512-TeR9zWR18BvbfPmGbLampPMW+uW1NZnJlRuuHso8i87QZNq2JRF9i6RgxRqtEq+wQGsS19NNTWr2duhnE49mfQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/types": "^7.28.5"
+                "@babel/types": "^7.28.6"
             },
             "bin": {
                 "parser": "bin/babel-parser.js"
@@ -5082,31 +5088,31 @@
             }
         },
         "node_modules/@babel/template": {
-            "version": "7.27.2",
-            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
-            "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
+            "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/parser": "^7.27.2",
-                "@babel/types": "^7.27.1"
+                "@babel/code-frame": "^7.28.6",
+                "@babel/parser": "^7.28.6",
+                "@babel/types": "^7.28.6"
             },
             "engines": {
                 "node": ">=6.9.0"
             }
         },
         "node_modules/@babel/traverse": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
-            "integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.6.tgz",
+            "integrity": "sha512-fgWX62k02qtjqdSNTAGxmKYY/7FSL9WAS1o2Hu5+I5m9T0yxZzr4cnrfXQ/MX0rIifthCSs6FKTlzYbJcPtMNg==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.5",
+                "@babel/code-frame": "^7.28.6",
+                "@babel/generator": "^7.28.6",
                 "@babel/helper-globals": "^7.28.0",
-                "@babel/parser": "^7.28.5",
-                "@babel/template": "^7.27.2",
-                "@babel/types": "^7.28.5",
+                "@babel/parser": "^7.28.6",
+                "@babel/template": "^7.28.6",
+                "@babel/types": "^7.28.6",
                 "debug": "^4.3.1"
             },
             "engines": {
@@ -5114,13 +5120,13 @@
             }
         },
         "node_modules/@babel/traverse/node_modules/@babel/generator": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-            "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
+            "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.28.5",
-                "@babel/types": "^7.28.5",
+                "@babel/parser": "^7.28.6",
+                "@babel/types": "^7.28.6",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -5130,9 +5136,9 @@
             }
         },
         "node_modules/@babel/types": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.5.tgz",
-            "integrity": "sha512-qQ5m48eI/MFLQ5PxQj4PFaprjyCTLI37ElWMmNs0K8Lk3dVeOdNpB3ks8jc7yM5CDmVC73eMVk/trk3fgmrUpA==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.6.tgz",
+            "integrity": "sha512-0ZrskXVEHSWIqZM/sQZ4EV3jZJXRkio/WCxaqKZP1g//CEWEPSfeZFcms4XeKBCHU0ZKnIkdJeU/kF+eRp5lBg==",
             "license": "MIT",
             "dependencies": {
                 "@babel/helper-string-parser": "^7.27.1",
@@ -5196,6 +5202,7 @@
             "resolved": "https://registry.npmjs.org/@cds/core/-/core-6.16.1.tgz",
             "integrity": "sha512-skEie8NvnSwjnY3lufKMOtKoHG5V2B5cWA8+tH7LB7zXlq8cLkK6VPeQy15Wm/3oXaVzGhN283e8Z8+cRSLQqg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "lit": "^2.1.3",
                 "ramda": "^0.29.0",
@@ -5233,7 +5240,6 @@
         },
         "node_modules/@clack/prompts/node_modules/is-unicode-supported": {
             "version": "1.3.0",
-            "extraneous": true,
             "inBundle": true,
             "license": "MIT",
             "engines": {
@@ -5307,6 +5313,7 @@
             "resolved": "https://registry.npmjs.org/@clr/ui/-/ui-17.12.1.tgz",
             "integrity": "sha512-ctFGeOcwRGmppG0/jIUxDwWTp76kGOlg1Razxnv5Z+p8yNdHWehUXb7+8etV/Dmup97SMj64pyLqgdtyEDvBqQ==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@cds/core": "^6.9.2"
             }
@@ -5333,7 +5340,6 @@
             "integrity": "sha512-MerMzJzlXogk2fxWFU1nKp36bY5orBG59HnPiz0G9nLRebWa0zXuv2siH6PLIHBvv5TH8CkQRqjBs0MlxCZu+A==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@marijn/find-cluster-break": "^1.0.0"
             }
@@ -5344,7 +5350,6 @@
             "integrity": "sha512-miGSIfBOKC1s2oHoa80dp+BjtsL8sXsrgGlQnQuOcfvaedcQUtqddTmKbJSDkLl4mkgPvZyXuKic2HDNYcJLYA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@codemirror/state": "^6.5.0",
                 "crelt": "^1.0.6",
@@ -5729,6 +5734,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             },
@@ -5752,6 +5758,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18"
             }
@@ -5788,6 +5795,7 @@
             "resolved": "https://registry.npmjs.org/@dnd-kit/core/-/core-6.3.1.tgz",
             "integrity": "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@dnd-kit/accessibility": "^3.1.1",
                 "@dnd-kit/utilities": "^3.2.2",
@@ -6547,6 +6555,7 @@
             "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.4.tgz",
             "integrity": "sha512-OOchDgh4F2CchOX94cRVqhvy7b3AFb+/rQXyswmzmGakRfkMgoWVjfnLWkRirfLEfuD4ysVW16eXzwt3jHIzKA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@floating-ui/core": "^1.7.3",
                 "@floating-ui/utils": "^0.2.10"
@@ -9231,6 +9240,7 @@
             "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-7.3.2.tgz",
             "integrity": "sha512-G1ytyOoHh5BphmEBxSwALin3n1KGNYB6yImbICcRQdzXfOGbuJ9Jske/Of5Sebk339NSGGNfUshnzK8YWkTPsQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@inquirer/checkbox": "^4.1.2",
                 "@inquirer/confirm": "^5.1.6",
@@ -11005,8 +11015,7 @@
             "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.0.tgz",
             "integrity": "sha512-PNGcolp9hr4PJdXR4ix7XtixDrClScvtSCYW3rQG106oVMOOI+jFb+0+J3mbeL/53g1Zd6s0kJzaw6Ri68GmAA==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@lezer/highlight": {
             "version": "1.2.3",
@@ -11014,7 +11023,6 @@
             "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@lezer/common": "^1.3.0"
             }
@@ -11025,7 +11033,6 @@
             "integrity": "sha512-wNIFWdSUfX9Jc6ePMzxSPVgTVB4EOfDIwLQLWASyiUdHKaMsiilj9bYiGkGQCKVodd0x6bgQCV207PILGFCF9Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@lezer/common": "^1.0.0"
             }
@@ -11044,6 +11051,7 @@
             "resolved": "https://registry.npmjs.org/@lingui/babel-plugin-lingui-macro/-/babel-plugin-lingui-macro-5.7.0.tgz",
             "integrity": "sha512-LoyRpvcocdKfkfill3VOYtyDYclnrB+c/IOS0D0i+xmBvNDjtG28gOVU81brg2w07Hzi6TKhNf3+YSi2UXsILQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/core": "^7.20.12",
                 "@babel/runtime": "^7.20.13",
@@ -11640,8 +11648,7 @@
             "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.2.tgz",
             "integrity": "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@mdx-js/react": {
             "version": "3.1.1",
@@ -11666,6 +11673,7 @@
             "resolved": "https://registry.npmjs.org/@messageformat/core/-/core-3.4.0.tgz",
             "integrity": "sha512-NgCFubFFIdMWJGN5WuQhHCNmzk7QgiVfrViFxcS99j7F5dDS5EP6raR54I+2ydhe4+5/XTn/YIEppFaqqVWHsw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@messageformat/date-skeleton": "^1.0.0",
                 "@messageformat/number-skeleton": "^1.0.0",
@@ -12343,6 +12351,7 @@
             "integrity": "sha512-H9i+zT3RvHi7tDc+lCmWHJ3ustXveABCr+Vcpl96dNOxgmrx4elQSTC4W93Mlav2opfLV+p0UTHY6L+bpUA4zA==",
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@nuxt/opencollective": "0.4.1",
                 "fast-safe-stringify": "2.1.1",
@@ -12383,6 +12392,7 @@
             "resolved": "https://registry.npmjs.org/@nestjs/graphql/-/graphql-13.1.0.tgz",
             "integrity": "sha512-frjUJOPJNEZVqiFynhDs/+rEor3ySAj4pITTa/szAWRfdPhAxIJzOtZnn+eCLubr4lymlK/q71azFwTFyeVShg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@graphql-tools/merge": "9.0.24",
                 "@graphql-tools/schema": "10.0.23",
@@ -12534,6 +12544,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.1.tgz",
             "integrity": "sha512-RKW2aJZMXeMxVpnZ6bck+RswznaxmzdULiBr6KY7XkTnW8uvt0iT9H5DkHUChXrc+uurzwa0rVI16n/Xzjdz1w==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -12575,6 +12586,7 @@
             "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-11.1.11.tgz",
             "integrity": "sha512-kyABSskdMRIAMWL0SlbwtDy4yn59RL4HDdwHDz/fxWuv7/53YP8Y2DtV3/sHqY5Er0msMVTZrM38MjqXhYL7gw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "cors": "2.8.5",
                 "express": "5.2.1",
@@ -12694,6 +12706,7 @@
             "resolved": "https://registry.npmjs.org/@nestjs/typeorm/-/typeorm-11.0.0.tgz",
             "integrity": "sha512-SOeUQl70Lb2OfhGkvnh4KXWlsd+zA08RuuQgT7kKbzivngxzSo1Oc7Usu5VxCxACQC9wc2l9esOHILSJeK7rJA==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@nestjs/common": "^10.0.0 || ^11.0.0",
                 "@nestjs/core": "^10.0.0 || ^11.0.0",
@@ -12741,6 +12754,7 @@
             "resolved": "https://registry.npmjs.org/@ngx-translate/core/-/core-16.0.4.tgz",
             "integrity": "sha512-s8llTL2SJvROhqttxvEs7Cg+6qSf4kvZPFYO+cTOY1d8DWTjlutRkWAleZcPPoeX927Dm7ALfL07G7oYDJ7z6w==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "tslib": "^2.3.0"
             },
@@ -14021,6 +14035,7 @@
             "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@octokit/auth-token": "^4.0.0",
                 "@octokit/graphql": "^7.1.0",
@@ -14190,6 +14205,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -14274,6 +14290,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/context-async-hooks/-/context-async-hooks-2.3.0.tgz",
             "integrity": "sha512-hGcsT0qDP7Il1L+qT3JFpiGl1dCjF794Bb4yCRCYdr7XC0NwHtOF3ngF86Gk6TUnsakbyQsDQ0E/S4CU0F4d4g==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": "^18.19.0 || >=20.6.0"
             },
@@ -14286,6 +14303,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/core/-/core-2.3.0.tgz",
             "integrity": "sha512-PcmxJQzs31cfD0R2dE91YGFcLxOSN4Bxz7gez5UwSUjCai8BwH/GI5HchfVshHkWdTkUs0qcaPJgVHKXUp7I3A==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/semantic-conventions": "^1.29.0"
             },
@@ -15821,6 +15839,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/resources/-/resources-2.3.0.tgz",
             "integrity": "sha512-shlr2l5g+87J8wqYlsLyaUsgKVRO7RtX70Ckd5CtDOWtImZgaUDmf4Z2ozuSKQLM2wPDR0TE/3bPVBNJtRm/cQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.3.0",
                 "@opentelemetry/semantic-conventions": "^1.29.0"
@@ -18969,6 +18988,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.208.0.tgz",
             "integrity": "sha512-Eju0L4qWcQS+oXxi6pgh7zvE2byogAkcsVv0OjHF/97iOz1N/aKE6etSGowYkie+YA1uo6DNwdSxaaNnLvcRlA==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/api-logs": "0.208.0",
                 "import-in-the-middle": "^2.0.0",
@@ -19371,6 +19391,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/sdk-trace-base/-/sdk-trace-base-2.3.0.tgz",
             "integrity": "sha512-B0TQ2e9h0ETjpI+eGmCz8Ojb+lnYms0SE3jFwEKrN/PK4aSVHU28AAmnOoBmfub+I3jfgPwvDJgomBA5a7QehQ==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@opentelemetry/core": "2.3.0",
                 "@opentelemetry/resources": "2.3.0",
@@ -19388,6 +19409,7 @@
             "resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.38.0.tgz",
             "integrity": "sha512-kocjix+/sSggfJhwXqClZ3i9Y/MI0fp7b+g7kCRm6psy2dsf8uApTRclwG18h8Avm7C9+fnt+O36PspJ/OzoWg==",
             "license": "Apache-2.0",
+            "peer": true,
             "engines": {
                 "node": ">=14"
             }
@@ -20673,6 +20695,7 @@
             "devOptional": true,
             "hasInstallScript": true,
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "@swc/counter": "^0.1.3",
                 "@swc/types": "^0.1.25"
@@ -21328,9 +21351,9 @@
             }
         },
         "node_modules/@tanstack/history": {
-            "version": "1.145.7",
-            "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.145.7.tgz",
-            "integrity": "sha512-gMo/ReTUp0a3IOcZoI3hH6PLDC2R/5ELQ7P2yu9F6aEkA0wSQh+Q4qzMrtcKvF2ut0oE+16xWCGDo/TdYd6cEQ==",
+            "version": "1.154.14",
+            "resolved": "https://registry.npmjs.org/@tanstack/history/-/history-1.154.14.tgz",
+            "integrity": "sha512-xyIfof8eHBuub1CkBnbKNKQXeRZC4dClhmzePHVOEel4G7lk/dW+TQ16da7CFdeNLv6u6Owf5VoBQxoo6DFTSA==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -21365,6 +21388,7 @@
             "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.16.tgz",
             "integrity": "sha512-bpMGOmV4OPmif7TNMteU/Ehf/hoC0Kf98PDc0F4BZkFrEapRMEqI/V6YS0lyzwSV6PQpY1y4xxArUIfBW5LVxQ==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@tanstack/query-core": "5.90.16"
             },
@@ -21394,14 +21418,15 @@
             }
         },
         "node_modules/@tanstack/react-router": {
-            "version": "1.146.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.146.2.tgz",
-            "integrity": "sha512-Oq/shGk5nCNyK/YhB9SGByeU3wgjNVzpGoDovuOvIacE9hsicZYOv9EnII1fEku8xavqWtN8D9wr21z2CDanjA==",
+            "version": "1.157.16",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-router/-/react-router-1.157.16.tgz",
+            "integrity": "sha512-xwFQa7S7dhBhm3aJYwU79cITEYgAKSrcL6wokaROIvl2JyIeazn8jueWqUPJzFjv+QF6Q8euKRlKUEyb5q2ymg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@tanstack/history": "1.145.7",
+                "@tanstack/history": "1.154.14",
                 "@tanstack/react-store": "^0.8.0",
-                "@tanstack/router-core": "1.146.2",
+                "@tanstack/router-core": "1.157.16",
                 "isbot": "^5.1.22",
                 "tiny-invariant": "^1.3.3",
                 "tiny-warning": "^1.0.3"
@@ -21419,12 +21444,12 @@
             }
         },
         "node_modules/@tanstack/react-router-devtools": {
-            "version": "1.146.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/react-router-devtools/-/react-router-devtools-1.146.2.tgz",
-            "integrity": "sha512-svUw0KM9e4SjpFtsNfYsFO5y9KqfZIc7r5cTdsfletx/gOb7cF3bekPPx/JUiAu2RU7vME9R8Rs1hlJ9kraJXA==",
+            "version": "1.157.16",
+            "resolved": "https://registry.npmjs.org/@tanstack/react-router-devtools/-/react-router-devtools-1.157.16.tgz",
+            "integrity": "sha512-g6ekyzumfLBX6T5e+Vu2r37Z2CFJKrWRFqIy3vZ6A3x7OcuPV8uXNjyrLSiT/IsGTiF8YzwI4nWJa4fyd7NlCw==",
             "license": "MIT",
             "dependencies": {
-                "@tanstack/router-devtools-core": "1.146.2"
+                "@tanstack/router-devtools-core": "1.157.16"
             },
             "engines": {
                 "node": ">=12"
@@ -21434,8 +21459,8 @@
                 "url": "https://github.com/sponsors/tannerlinsley"
             },
             "peerDependencies": {
-                "@tanstack/react-router": "^1.146.2",
-                "@tanstack/router-core": "^1.146.2",
+                "@tanstack/react-router": "^1.157.16",
+                "@tanstack/router-core": "^1.157.16",
                 "react": ">=18.0.0 || >=19.0.0",
                 "react-dom": ">=18.0.0 || >=19.0.0"
             },
@@ -21502,16 +21527,17 @@
             }
         },
         "node_modules/@tanstack/router-core": {
-            "version": "1.146.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.146.2.tgz",
-            "integrity": "sha512-MmTDiT6fpe+WBWYAuhp8oyzULBJX4oblm1kCqHDngf9mK3qcnNm5nkKk4d3Fk80QZmHS4DcRNFaFHKbLUVlZog==",
+            "version": "1.157.16",
+            "resolved": "https://registry.npmjs.org/@tanstack/router-core/-/router-core-1.157.16.tgz",
+            "integrity": "sha512-eJuVgM7KZYTTr4uPorbUzUflmljMVcaX2g6VvhITLnHmg9SBx9RAgtQ1HmT+72mzyIbRSlQ1q0fY/m+of/fosA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
-                "@tanstack/history": "1.145.7",
+                "@tanstack/history": "1.154.14",
                 "@tanstack/store": "^0.8.0",
                 "cookie-es": "^2.0.0",
-                "seroval": "^1.4.1",
-                "seroval-plugins": "^1.4.0",
+                "seroval": "^1.4.2",
+                "seroval-plugins": "^1.4.2",
                 "tiny-invariant": "^1.3.3",
                 "tiny-warning": "^1.0.3"
             },
@@ -21524,12 +21550,12 @@
             }
         },
         "node_modules/@tanstack/router-devtools": {
-            "version": "1.146.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/router-devtools/-/router-devtools-1.146.2.tgz",
-            "integrity": "sha512-bK9r2kmr4FUvv6g4CQbWVG1Y3QD4j4cmQZdBYHyRiSTLqYgPO4WW1zkB+w4OfzjD3YEorZRKzzkqWLJsJHKf4Q==",
+            "version": "1.157.16",
+            "resolved": "https://registry.npmjs.org/@tanstack/router-devtools/-/router-devtools-1.157.16.tgz",
+            "integrity": "sha512-szVmsVNp3b4WQWbZiTO8YSYYGPRMh5o2syPmt8YoKgSnQ5CmwyEOY3Y0ko0irCzHZxVq/TKC6eqWnIRS3VnWQA==",
             "license": "MIT",
             "dependencies": {
-                "@tanstack/react-router-devtools": "1.146.2",
+                "@tanstack/react-router-devtools": "1.157.16",
                 "clsx": "^2.1.1",
                 "goober": "^2.1.16"
             },
@@ -21541,7 +21567,7 @@
                 "url": "https://github.com/sponsors/tannerlinsley"
             },
             "peerDependencies": {
-                "@tanstack/react-router": "^1.146.2",
+                "@tanstack/react-router": "^1.157.16",
                 "csstype": "^3.0.10",
                 "react": ">=18.0.0 || >=19.0.0",
                 "react-dom": ">=18.0.0 || >=19.0.0"
@@ -21553,9 +21579,9 @@
             }
         },
         "node_modules/@tanstack/router-devtools-core": {
-            "version": "1.146.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/router-devtools-core/-/router-devtools-core-1.146.2.tgz",
-            "integrity": "sha512-rIo5TEyM6uex1Zr0kHtBZu9Mwo0Aj2A84hk+UaLIBLCRpqaen6tuzjxmgNDSZ4YrgZOmixfowLObdlsuMyXTsQ==",
+            "version": "1.157.16",
+            "resolved": "https://registry.npmjs.org/@tanstack/router-devtools-core/-/router-devtools-core-1.157.16.tgz",
+            "integrity": "sha512-XBJTs/kMZYK6J2zhbGucHNuypwDB1t2vi8K5To+V6dUnLGBEyfQTf01fegiF4rpL1yXgomdGnP6aTiOFgldbVg==",
             "license": "MIT",
             "dependencies": {
                 "clsx": "^2.1.1",
@@ -21570,9 +21596,8 @@
                 "url": "https://github.com/sponsors/tannerlinsley"
             },
             "peerDependencies": {
-                "@tanstack/router-core": "^1.146.2",
-                "csstype": "^3.0.10",
-                "solid-js": ">=1.9.5"
+                "@tanstack/router-core": "^1.157.16",
+                "csstype": "^3.0.10"
             },
             "peerDependenciesMeta": {
                 "csstype": {
@@ -21581,14 +21606,14 @@
             }
         },
         "node_modules/@tanstack/router-generator": {
-            "version": "1.146.2",
-            "resolved": "https://registry.npmjs.org/@tanstack/router-generator/-/router-generator-1.146.2.tgz",
-            "integrity": "sha512-0eO/iL50OrNLtG613iHLmps8AVJC7WChDz+njFViTiWCf20RMEjeUlKTffdrREx3v/QeaLVuxlBvLkXRqSW0yg==",
+            "version": "1.157.16",
+            "resolved": "https://registry.npmjs.org/@tanstack/router-generator/-/router-generator-1.157.16.tgz",
+            "integrity": "sha512-Ae2M00VTFjjED7glSCi/mMLENRzhEym6NgjoOx7UVNbCC/rLU/5ASDe5VIlDa8QLEqP5Pj088Gi51gjmRuICvQ==",
             "license": "MIT",
             "dependencies": {
-                "@tanstack/router-core": "1.146.2",
-                "@tanstack/router-utils": "1.143.11",
-                "@tanstack/virtual-file-routes": "1.145.4",
+                "@tanstack/router-core": "1.157.16",
+                "@tanstack/router-utils": "1.154.7",
+                "@tanstack/virtual-file-routes": "1.154.7",
                 "prettier": "^3.5.0",
                 "recast": "^0.23.11",
                 "source-map": "^0.7.4",
@@ -21604,9 +21629,9 @@
             }
         },
         "node_modules/@tanstack/router-plugin": {
-            "version": "1.146.3",
-            "resolved": "https://registry.npmjs.org/@tanstack/router-plugin/-/router-plugin-1.146.3.tgz",
-            "integrity": "sha512-2YCieC5UbFBEf3d1Up6Q2IeGqRjc+qmxbCvVxSONnitK6aDFKpRoxltlhMyeQyeIhFsIyhqxaIADOkO+fMrFRQ==",
+            "version": "1.157.16",
+            "resolved": "https://registry.npmjs.org/@tanstack/router-plugin/-/router-plugin-1.157.16.tgz",
+            "integrity": "sha512-YQg7L06xyCJAYyrEJNZGAnDL8oChILU+G/eSDIwEfcWn5iLk+47x1Gcdxr82++47PWmOPhzuTo8edDQXWs7kAA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.28.5",
@@ -21615,10 +21640,10 @@
                 "@babel/template": "^7.27.2",
                 "@babel/traverse": "^7.28.5",
                 "@babel/types": "^7.28.5",
-                "@tanstack/router-core": "1.146.2",
-                "@tanstack/router-generator": "1.146.2",
-                "@tanstack/router-utils": "1.143.11",
-                "@tanstack/virtual-file-routes": "1.145.4",
+                "@tanstack/router-core": "1.157.16",
+                "@tanstack/router-generator": "1.157.16",
+                "@tanstack/router-utils": "1.154.7",
+                "@tanstack/virtual-file-routes": "1.154.7",
                 "babel-dead-code-elimination": "^1.0.11",
                 "chokidar": "^3.6.0",
                 "unplugin": "^2.1.2",
@@ -21633,7 +21658,7 @@
             },
             "peerDependencies": {
                 "@rsbuild/core": ">=1.0.2",
-                "@tanstack/react-router": "^1.146.2",
+                "@tanstack/react-router": "^1.157.16",
                 "vite": ">=5.0.0 || >=6.0.0 || >=7.0.0",
                 "vite-plugin-solid": "^2.11.10",
                 "webpack": ">=5.92.0"
@@ -21718,9 +21743,9 @@
             }
         },
         "node_modules/@tanstack/router-utils": {
-            "version": "1.143.11",
-            "resolved": "https://registry.npmjs.org/@tanstack/router-utils/-/router-utils-1.143.11.tgz",
-            "integrity": "sha512-N24G4LpfyK8dOlnP8BvNdkuxg1xQljkyl6PcrdiPSA301pOjatRT1y8wuCCJZKVVD8gkd0MpCZ0VEjRMGILOtA==",
+            "version": "1.154.7",
+            "resolved": "https://registry.npmjs.org/@tanstack/router-utils/-/router-utils-1.154.7.tgz",
+            "integrity": "sha512-61bGx32tMKuEpVRseu2sh1KQe8CfB7793Mch/kyQt0EP3tD7X0sXmimCl3truRiDGUtI0CaSoQV1NPjAII1RBA==",
             "license": "MIT",
             "dependencies": {
                 "@babel/core": "^7.28.5",
@@ -21740,20 +21765,20 @@
             }
         },
         "node_modules/@tanstack/router-utils/node_modules/@babel/core": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
-            "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.6.tgz",
+            "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/code-frame": "^7.27.1",
-                "@babel/generator": "^7.28.5",
-                "@babel/helper-compilation-targets": "^7.27.2",
-                "@babel/helper-module-transforms": "^7.28.3",
-                "@babel/helpers": "^7.28.4",
-                "@babel/parser": "^7.28.5",
-                "@babel/template": "^7.27.2",
-                "@babel/traverse": "^7.28.5",
-                "@babel/types": "^7.28.5",
+                "@babel/code-frame": "^7.28.6",
+                "@babel/generator": "^7.28.6",
+                "@babel/helper-compilation-targets": "^7.28.6",
+                "@babel/helper-module-transforms": "^7.28.6",
+                "@babel/helpers": "^7.28.6",
+                "@babel/parser": "^7.28.6",
+                "@babel/template": "^7.28.6",
+                "@babel/traverse": "^7.28.6",
+                "@babel/types": "^7.28.6",
                 "@jridgewell/remapping": "^2.3.5",
                 "convert-source-map": "^2.0.0",
                 "debug": "^4.1.0",
@@ -21770,13 +21795,13 @@
             }
         },
         "node_modules/@tanstack/router-utils/node_modules/@babel/generator": {
-            "version": "7.28.5",
-            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.5.tgz",
-            "integrity": "sha512-3EwLFhZ38J4VyIP6WNtt2kUdW9dokXA9Cr4IVIFHuCpZ3H8/YFOl5JjZHisrn1fATPBmKKqXzDFvh9fUwHz6CQ==",
+            "version": "7.28.6",
+            "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.6.tgz",
+            "integrity": "sha512-lOoVRwADj8hjf7al89tvQ2a1lf53Z+7tiXMgpZJL3maQPDxh0DgLMN62B2MKUOFcoodBHLMbDM6WAbKgNy5Suw==",
             "license": "MIT",
             "dependencies": {
-                "@babel/parser": "^7.28.5",
-                "@babel/types": "^7.28.5",
+                "@babel/parser": "^7.28.6",
+                "@babel/types": "^7.28.6",
                 "@jridgewell/gen-mapping": "^0.3.12",
                 "@jridgewell/trace-mapping": "^0.3.28",
                 "jsesc": "^3.0.2"
@@ -21835,9 +21860,9 @@
             }
         },
         "node_modules/@tanstack/virtual-file-routes": {
-            "version": "1.145.4",
-            "resolved": "https://registry.npmjs.org/@tanstack/virtual-file-routes/-/virtual-file-routes-1.145.4.tgz",
-            "integrity": "sha512-CI75JrfqSluhdGwLssgVeQBaCphgfkMQpi8MCY3UJX1hoGzXa8kHYJcUuIFMOLs1q7zqHy++EVVtMK03osR5wQ==",
+            "version": "1.154.7",
+            "resolved": "https://registry.npmjs.org/@tanstack/virtual-file-routes/-/virtual-file-routes-1.154.7.tgz",
+            "integrity": "sha512-cHHDnewHozgjpI+MIVp9tcib6lYEQK5MyUr0ChHpHFGBl8Xei55rohFK0I0ve/GKoHeioaK42Smd8OixPp6CTg==",
             "license": "MIT",
             "engines": {
                 "node": ">=12"
@@ -21853,6 +21878,7 @@
             "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.10.4",
                 "@babel/runtime": "^7.12.5",
@@ -21932,6 +21958,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/core/-/core-3.15.3.tgz",
             "integrity": "sha512-bmXydIHfm2rEtGju39FiQNfzkFx9CDvJe+xem1dgEZ2P6Dj7nQX9LnA1ZscW7TuzbBRkL5p3dwuBIi3f62A66A==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -22166,6 +22193,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extension-list/-/extension-list-3.15.3.tgz",
             "integrity": "sha512-n7y/MF9lAM5qlpuH5IR4/uq+kJPEJpe9NrEiH+NmkO/5KJ6cXzpJ6F4U17sMLf2SNCq+TWN9QK8QzoKxIn50VQ==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -22298,6 +22326,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/extensions/-/extensions-3.15.3.tgz",
             "integrity": "sha512-ycx/BgxR4rc9tf3ZyTdI98Z19yKLFfqM3UN+v42ChuIwkzyr9zyp7kG8dB9xN2lNqrD+5y/HyJobz/VJ7T90gA==",
             "license": "MIT",
+            "peer": true,
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/ueberdosis"
@@ -22312,6 +22341,7 @@
             "resolved": "https://registry.npmjs.org/@tiptap/pm/-/pm-3.15.3.tgz",
             "integrity": "sha512-Zm1BaU1TwFi3CQiisxjgnzzIus+q40bBKWLqXf6WEaus8Z6+vo1MT2pU52dBCMIRaW9XNDq3E5cmGtMc1AlveA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-changeset": "^2.3.0",
                 "prosemirror-collab": "^1.3.1",
@@ -23132,6 +23162,7 @@
             "integrity": "sha512-7QFsywoE5URbuVnG3loe03QXuGajrnotr3gQkXcEBShORai23MePfFYdhz90FEtBBpkyIYQbVD+evKtloCgX3g==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/accepts": "*",
                 "@types/content-disposition": "*",
@@ -23390,6 +23421,7 @@
             "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
             "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "csstype": "^3.2.2"
             }
@@ -23399,6 +23431,7 @@
             "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
             "license": "MIT",
+            "peer": true,
             "peerDependencies": {
                 "@types/react": "^19.2.0"
             }
@@ -23680,6 +23713,7 @@
             "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
             "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
             "license": "BSD-2-Clause",
+            "peer": true,
             "dependencies": {
                 "@typescript-eslint/scope-manager": "5.62.0",
                 "@typescript-eslint/types": "5.62.0",
@@ -24202,6 +24236,7 @@
             "integrity": "sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@testing-library/dom": "^10.4.0",
                 "@testing-library/user-event": "^14.6.1",
@@ -24339,6 +24374,7 @@
             "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@vitest/utils": "3.2.4",
                 "pathe": "^2.0.3",
@@ -24677,7 +24713,8 @@
             "version": "1.6.0",
             "resolved": "https://registry.npmjs.org/@webcomponents/custom-elements/-/custom-elements-1.6.0.tgz",
             "integrity": "sha512-CqTpxOlUCPWRNUPZDxT5v2NnHXA4oox612iUGnmTUGQFhZ1Gkj8kirtl/2wcF6MqX7+PqqicZzOCBKKfIn0dww==",
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/@webcomponents/shadycss": {
             "version": "1.11.2",
@@ -24936,6 +24973,7 @@
             "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -25049,6 +25087,7 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
             "integrity": "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -25942,6 +25981,7 @@
             "devOptional": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "bindings": "^1.5.0",
                 "prebuild-install": "^7.1.1"
@@ -26271,6 +26311,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -27215,7 +27256,8 @@
             "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.65.20.tgz",
             "integrity": "sha512-i5dLDDxwkFCbhjvL2pNjShsojoL3XHyDwsGv1jqETUoW+lzpBKKqNTUWgQwVAOa0tUm4BwekT455ujafi8payA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/codemirror-graphql": {
             "version": "2.2.4",
@@ -28428,6 +28470,7 @@
             "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
             "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "env-paths": "^2.2.1",
                 "import-fresh": "^3.3.0",
@@ -28688,7 +28731,8 @@
             "version": "3.2.3",
             "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
             "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/csv-parse": {
             "version": "5.6.0",
@@ -29378,7 +29422,8 @@
             "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1107588.tgz",
             "integrity": "sha512-yIR+pG9x65Xko7bErCUSQaDLrO/P1p3JUzEk7JCU4DowPcGHkTGUGQapcfcLc4qj0UaALwZ+cr0riFgiqpixcg==",
             "dev": true,
-            "license": "BSD-3-Clause"
+            "license": "BSD-3-Clause",
+            "peer": true
         },
         "node_modules/di": {
             "version": "0.0.1",
@@ -29694,7 +29739,8 @@
             "version": "8.6.0",
             "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
             "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/embla-carousel-react": {
             "version": "8.6.0",
@@ -30257,6 +30303,7 @@
             "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -31124,6 +31171,7 @@
             "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
             "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "accepts": "^2.0.0",
                 "body-parser": "^2.2.1",
@@ -32869,6 +32917,7 @@
             "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.11.0.tgz",
             "integrity": "sha512-mS1lbMsxgQj6hge1XZ6p7GPhbrtFwUFYi3wRzXAC/FmYnyXMTvvI3td3rjmQ2u8ewXueaSvRPWaEcgVVOT9Jnw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": "^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0"
             }
@@ -33064,6 +33113,7 @@
             "integrity": "sha512-zgfER9s+ftkGKUZgc0xbx8T7/HMO4AV5/YuYiFc+AtgcO5T0v8AxYYNQ+ltzuzDZgNkYJaFspm5MMYLjQzrkmw==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=20"
             },
@@ -34387,6 +34437,7 @@
             "resolved": "https://registry.npmjs.org/intl-messageformat/-/intl-messageformat-10.7.18.tgz",
             "integrity": "sha512-m3Ofv/X/tV8Y3tHXLohcuVuhWKo7BBq62cqY15etqmLxg2DZ34AGGgQDeR+SCta2+zICb1NX83af0GJmbQ1++g==",
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "@formatjs/ecma402-abstract": "2.3.6",
                 "@formatjs/fast-memoize": "2.2.7",
@@ -34410,6 +34461,7 @@
             "integrity": "sha512-BXNqFQ66oOsR82g9ajFFsR8ZKrjVvYCLyeML9IvSMAsP56XH2VXBdZjmI11p65nXXJxTEt1hie3J2QeFJVgrtQ==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@ioredis/commands": "1.5.0",
                 "cluster-key-slot": "^1.1.0",
@@ -35422,7 +35474,8 @@
             "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-5.6.0.tgz",
             "integrity": "sha512-niVlkeYVRwKFpmfWg6suo6H9CrNnydfBLEqefM5UjibYS+UoTjZdmvPJSiuyrRLGnFj1eYRhFd/ch+5hSlsFVA==",
             "dev": true,
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/jasmine-spec-reporter": {
             "version": "7.0.0",
@@ -36177,6 +36230,7 @@
             "integrity": "sha512-LrtUxbdvt1gOpo3gxG+VAJlJAEMhbWlM4YrFQgql98FwF7+K8K12LYO4hnDdUkNjeztYrOXEMqgTajSWgmtI/w==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@colors/colors": "1.5.0",
                 "body-parser": "^1.19.0",
@@ -37990,6 +38044,7 @@
             "resolved": "https://registry.npmjs.org/less/-/less-4.2.2.tgz",
             "integrity": "sha512-tkuLHQlvWUTeQ3doAqnHbNn8T6WX1KA8yvbKG9x4VtKtIjHsVKQZCH11zRgAfbDAXC2UNIg/K9BYAAcEzUIrNg==",
             "license": "Apache-2.0",
+            "peer": true,
             "dependencies": {
                 "copy-anything": "^2.0.1",
                 "parse-node-version": "^1.0.1",
@@ -41561,6 +41616,7 @@
             "integrity": "sha512-bDyB9tmXMCL/4IhKcX84zGQlQrZhPhdCaomdJocz6EN57cZWdTP7SGhrswzpdGJY+y89855detet27oJLgR3IQ==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@rollup/plugin-json": "^6.1.0",
                 "@rollup/wasm-node": "^4.24.0",
@@ -42501,6 +42557,7 @@
             "dev": true,
             "hasInstallScript": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@napi-rs/wasm-runtime": "0.2.4",
                 "@yarnpkg/lockfile": "^1.1.0",
@@ -44404,6 +44461,7 @@
             "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
             "devOptional": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.9.1",
                 "pg-pool": "^3.10.1",
@@ -44618,7 +44676,6 @@
             "os": [
                 "darwin"
             ],
-            "peer": true,
             "engines": {
                 "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
             }
@@ -44667,6 +44724,7 @@
                 }
             ],
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "nanoid": "^3.3.8",
                 "picocolors": "^1.1.1",
@@ -44880,6 +44938,7 @@
             "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.7.4.tgz",
             "integrity": "sha512-v6UNi1+3hSlVvv8fSaoUbggEM5VErKmmpGA7Pl3HF8V6uKY7rvClBOJlH6yNwQtfTueNkGVpOv/mtWL9L4bgRA==",
             "license": "MIT",
+            "peer": true,
             "bin": {
                 "prettier": "bin/prettier.cjs"
             },
@@ -45168,6 +45227,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-model/-/prosemirror-model-1.25.4.tgz",
             "integrity": "sha512-PIM7E43PBxKce8OQeezAs9j4TP+5yDpZVbuurd1h5phUxEKIu+G2a+EUZzIC5nS1mJktDJWzbqS23n1tsAf5QA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "orderedmap": "^2.0.0"
             }
@@ -45197,6 +45257,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-state/-/prosemirror-state-1.4.4.tgz",
             "integrity": "sha512-6jiYHH2CIGbCfnxdHbXZ12gySFY/fz/ulZE333G6bPqIZ4F+TXo9ifiR86nAHpWnfoNjOb3o5ESi7J8Uz1jXHw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.0.0",
                 "prosemirror-transform": "^1.0.0",
@@ -45245,6 +45306,7 @@
             "resolved": "https://registry.npmjs.org/prosemirror-view/-/prosemirror-view-1.41.4.tgz",
             "integrity": "sha512-WkKgnyjNncri03Gjaz3IFWvCAE94XoiEgvtr0/r2Xw7R8/IjK3sKLSiDoCHWcsXSAinVaKlGRZDvMCsF1kbzjA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "prosemirror-model": "^1.20.0",
                 "prosemirror-state": "^1.0.0",
@@ -45769,6 +45831,7 @@
             "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
             "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -45906,6 +45969,7 @@
             "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
             "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -45935,6 +45999,7 @@
             "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.70.0.tgz",
             "integrity": "sha512-COOMajS4FI3Wuwrs3GPpi/Jeef/5W1DRR84Yl5/ShlT3dKVFUfoGiEZ/QE6Uw8P4T2/CLJdcTVYKvWBMQTEpvw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=18.0.0"
             },
@@ -46863,6 +46928,7 @@
             "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.55.1.tgz",
             "integrity": "sha512-wDv/Ht1BNHB4upNbK74s9usvl7hObDnvVzknxqY/E/O3X6rW1U1rV1aENEfJ54eFZDTNo7zv1f5N4edCluH7+A==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/estree": "1.0.8"
             },
@@ -47520,18 +47586,19 @@
             }
         },
         "node_modules/seroval": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.4.2.tgz",
-            "integrity": "sha512-N3HEHRCZYn3cQbsC4B5ldj9j+tHdf4JZoYPlcI4rRYu0Xy4qN8MQf1Z08EibzB0WpgRG5BGK08FTrmM66eSzKQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.5.0.tgz",
+            "integrity": "sha512-OE4cvmJ1uSPrKorFIH9/w/Qwuvi/IMcGbv5RKgcJ/zjA/IohDLU6SVaxFN9FwajbP7nsX0dQqMDes1whk3y+yw==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10"
             }
         },
         "node_modules/seroval-plugins": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.4.2.tgz",
-            "integrity": "sha512-X7p4MEDTi+60o2sXZ4bnDBhgsUYDSkQEvzYZuJyFqWg9jcoPsHts5nrg5O956py2wyt28lUrBxk0M0/wU8URpA==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.5.0.tgz",
+            "integrity": "sha512-EAHqADIQondwRZIdeW2I636zgsODzoBDwb3PT/+7TLDWyw1Dy/Xv7iGUIEXXav7usHDE9HVhOU61irI3EnyyHA==",
             "license": "MIT",
             "engines": {
                 "node": ">=10"
@@ -48279,41 +48346,6 @@
                 "node": ">= 14"
             }
         },
-        "node_modules/solid-js": {
-            "version": "1.9.10",
-            "resolved": "https://registry.npmjs.org/solid-js/-/solid-js-1.9.10.tgz",
-            "integrity": "sha512-Coz956cos/EPDlhs6+jsdTxKuJDPT7B5SVIWgABwROyxjY7Xbr8wkzD68Et+NxnV7DLJ3nJdAC2r9InuV/4Jew==",
-            "license": "MIT",
-            "peer": true,
-            "dependencies": {
-                "csstype": "^3.1.0",
-                "seroval": "~1.3.0",
-                "seroval-plugins": "~1.3.0"
-            }
-        },
-        "node_modules/solid-js/node_modules/seroval": {
-            "version": "1.3.2",
-            "resolved": "https://registry.npmjs.org/seroval/-/seroval-1.3.2.tgz",
-            "integrity": "sha512-RbcPH1n5cfwKrru7v7+zrZvjLurgHhGyso3HTyGtRivGWgYjbOmGuivCQaORNELjNONoK35nj28EoWul9sb1zQ==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            }
-        },
-        "node_modules/solid-js/node_modules/seroval-plugins": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/seroval-plugins/-/seroval-plugins-1.3.3.tgz",
-            "integrity": "sha512-16OL3NnUBw8JG1jBLUoZJsLnQq0n5Ua6aHalhJK4fMQkz1lqR7Osz1sA30trBtd9VUDc2NgkuRCn8+/pBwqZ+w==",
-            "license": "MIT",
-            "peer": true,
-            "engines": {
-                "node": ">=10"
-            },
-            "peerDependencies": {
-                "seroval": "^1.0"
-            }
-        },
         "node_modules/sonner": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/sonner/-/sonner-2.0.7.tgz",
@@ -48537,6 +48569,7 @@
             "devOptional": true,
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
+            "peer": true,
             "dependencies": {
                 "bindings": "^1.5.0",
                 "node-addon-api": "^7.0.0",
@@ -49078,6 +49111,7 @@
             "integrity": "sha512-pKP5jXJYM4OjvNklGuHKO53wOCAwfx79KvZyOWHoi9zXUH5WVMFUe/ZfWyxXG/GTcj0maRgHGUjq/0I43r0dDQ==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@storybook/global": "^5.0.0",
                 "@storybook/icons": "^2.0.0",
@@ -49539,8 +49573,7 @@
             "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
             "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
             "dev": true,
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/subscriptions-transport-ws": {
             "version": "0.11.0",
@@ -49548,6 +49581,7 @@
             "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
             "deprecated": "The `subscriptions-transport-ws` package is no longer maintained. We recommend you use `graphql-ws` instead. For help migrating Apollo software to `graphql-ws`, see https://www.apollographql.com/docs/apollo-server/data/subscriptions/#switching-from-subscriptions-transport-ws    For general help using `graphql-ws`, see https://github.com/enisdenjo/graphql-ws/blob/master/README.md",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "backo2": "^1.0.2",
                 "eventemitter3": "^3.1.0",
@@ -49713,7 +49747,8 @@
             "version": "4.1.18",
             "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.1.18.tgz",
             "integrity": "sha512-4+Z+0yiYyEtUVCScyfHCxOYP06L5Ne+JiHhY2IjR2KWMIWhJOYZKLSGZaP5HkZ8+bY0cxfzwDE5uOmzFXyIwxw==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/tailwindcss-animate": {
             "version": "1.0.7",
@@ -50639,7 +50674,8 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "license": "0BSD"
+            "license": "0BSD",
+            "peer": true
         },
         "node_modules/tsscmp": {
             "version": "1.0.6",
@@ -51296,6 +51332,7 @@
             "resolved": "https://registry.npmjs.org/typeorm/-/typeorm-0.3.28.tgz",
             "integrity": "sha512-6GH7wXhtfq2D33ZuRXYwIsl/qM5685WZcODZb7noOOcRMteM9KF2x2ap3H0EBjnSV0VO4gNAfJT5Ukp0PkOlvg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@sqltools/formatter": "^1.2.5",
                 "ansis": "^4.2.0",
@@ -52078,6 +52115,7 @@
             "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.1.tgz",
             "integrity": "sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "esbuild": "^0.25.0",
                 "fdir": "^6.4.4",
@@ -52238,6 +52276,7 @@
             "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
             "dev": true,
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/chai": "^5.2.2",
                 "@vitest/expect": "3.2.4",
@@ -52550,6 +52589,7 @@
             "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.98.0.tgz",
             "integrity": "sha512-UFynvx+gM44Gv9qFgj0acCQK2VE1CtdfwFdimkapco3hlPCJ/zeq73n2yVKimVbtm+TnApIugGhLJnkU6gjYXA==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/eslint-scope": "^3.7.7",
                 "@types/estree": "^1.0.6",
@@ -52625,6 +52665,7 @@
             "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.2.tgz",
             "integrity": "sha512-QcQ72gh8a+7JO63TAx/6XZf/CWhgMzu5m0QirvPfGvptOusAxG12w2+aua1Jkjr7hzaWDnJ2n6JFeexMHI+Zjg==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/bonjour": "^3.5.13",
                 "@types/connect-history-api-fallback": "^1.5.4",
@@ -52682,6 +52723,7 @@
             "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
             "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
             "license": "MIT",
+            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
@@ -53424,6 +53466,7 @@
             "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
             "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
             "license": "MIT",
+            "peer": true,
             "engines": {
                 "node": ">=10.0.0"
             },
@@ -53657,7 +53700,8 @@
             "version": "0.15.1",
             "resolved": "https://registry.npmjs.org/zone.js/-/zone.js-0.15.1.tgz",
             "integrity": "sha512-XE96n56IQpJM7NAoXswY3XRLcWFW83xe0BiAOeMD7K5k5xecOeul3Qcpx6GqEeeHNkW5DWL5zOyTbEfB4eti8w==",
-            "license": "MIT"
+            "license": "MIT",
+            "peer": true
         },
         "node_modules/zustand": {
             "version": "5.0.9",
@@ -53691,7 +53735,7 @@
         },
         "packages/admin-ui": {
             "name": "@vendure/admin-ui",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@angular/animations": "^19.2.4",
@@ -53714,7 +53758,7 @@
                 "@ng-select/ng-select": "^14.2.6",
                 "@ngx-translate/core": "^16.0.4",
                 "@ngx-translate/http-loader": "^16.0.1",
-                "@vendure/common": "^3.5.3",
+                "@vendure/common": "3.5.2",
                 "@webcomponents/custom-elements": "^1.6.0",
                 "apollo-angular": "^10.0.3",
                 "apollo-upload-client": "^18.0.1",
@@ -53785,7 +53829,7 @@
         },
         "packages/admin-ui-plugin": {
             "name": "@vendure/admin-ui-plugin",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "date-fns": "^4.0.0",
@@ -53795,9 +53839,9 @@
             "devDependencies": {
                 "@types/express": "^5.0.1",
                 "@types/fs-extra": "^11.0.4",
-                "@vendure/admin-ui": "^3.5.3",
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3",
+                "@vendure/admin-ui": "3.5.2",
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2",
                 "express": "^5.1.0",
                 "rimraf": "^5.0.5",
                 "typescript": "5.8.2"
@@ -53886,7 +53930,6 @@
             "integrity": "sha512-ixxqmmCcc1Nf8S0mS0TkJ/3LKcC8mruYJPOU6Ia2F/zUUR4pApW7LzrpU3JmtePbRUTes9bEqRc1Gg4iyRnDzA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "8.52.0",
                 "@typescript-eslint/visitor-keys": "8.52.0"
@@ -53945,7 +53988,6 @@
             "integrity": "sha512-XP3LClsCc0FsTK5/frGjolyADTh3QmsLp6nKd476xNI9CsSsLnmn4f0jrzNoAulmxlmNIpeXuHYeEQv61Q6qeQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/project-service": "8.52.0",
                 "@typescript-eslint/tsconfig-utils": "8.52.0",
@@ -53974,7 +54016,6 @@
             "integrity": "sha512-ink3/Zofus34nmBsPjow63FP5M7IGff0RKAgqR6+CFpdk22M7aLwC9gOcLGYqr7MczLPzZVERW9hRog3O4n1sQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@typescript-eslint/types": "8.52.0",
                 "eslint-visitor-keys": "^4.2.1"
@@ -54003,7 +54044,6 @@
             "integrity": "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "balanced-match": "^1.0.0"
             }
@@ -54014,7 +54054,6 @@
             "integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
             },
@@ -54028,7 +54067,6 @@
             "integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
             },
@@ -54045,7 +54083,6 @@
             "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
             "dev": true,
             "license": "ISC",
-            "peer": true,
             "bin": {
                 "semver": "bin/semver.js"
             },
@@ -54060,7 +54097,7 @@
         },
         "packages/asset-server-plugin": {
             "name": "@vendure/asset-server-plugin",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "file-type": "^19.0.0",
@@ -54073,8 +54110,8 @@
                 "@types/express": "^5.0.1",
                 "@types/fs-extra": "^11.0.4",
                 "@types/node-fetch": "^2.6.11",
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3",
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2",
                 "express": "^5.1.0",
                 "node-fetch": "^2.7.0",
                 "rimraf": "^5.0.5",
@@ -54141,11 +54178,11 @@
         },
         "packages/cli": {
             "name": "@vendure/cli",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@clack/prompts": "^0.7.0",
-                "@vendure/common": "^3.5.3",
+                "@vendure/common": "3.5.2",
                 "change-case": "^4.1.2",
                 "commander": "^11.0.0",
                 "dotenv": "^16.4.5",
@@ -54160,8 +54197,8 @@
                 "vendure": "dist/cli.js"
             },
             "devDependencies": {
-                "@vendure/core": "^3.5.3",
-                "@vendure/testing": "^3.5.3",
+                "@vendure/core": "3.5.2",
+                "@vendure/testing": "3.5.2",
                 "cross-env": "^7.0.3",
                 "typescript": "5.8.2"
             },
@@ -54190,7 +54227,7 @@
         },
         "packages/common": {
             "name": "@vendure/common",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "devDependencies": {
                 "rimraf": "^5.0.5",
@@ -54202,7 +54239,7 @@
         },
         "packages/core": {
             "name": "@vendure/core",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@apollo/server": "^4.12.2",
@@ -54214,7 +54251,7 @@
                 "@nestjs/platform-express": "^11.0.12",
                 "@nestjs/terminus": "^11.0.0",
                 "@nestjs/typeorm": "^11.0.0",
-                "@vendure/common": "^3.5.3",
+                "@vendure/common": "3.5.2",
                 "bcrypt": "^5.1.1",
                 "body-parser": "^1.20.2",
                 "cookie-session": "^2.1.0",
@@ -54386,11 +54423,11 @@
         },
         "packages/create": {
             "name": "@vendure/create",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@clack/prompts": "^0.11.0",
-                "@vendure/common": "^3.5.3",
+                "@vendure/common": "3.5.2",
                 "commander": "^14.0.1",
                 "cross-spawn": "^7.0.6",
                 "fs-extra": "^11.2.0",
@@ -54409,7 +54446,7 @@
                 "@types/fs-extra": "^11.0.4",
                 "@types/handlebars": "^4.1.0",
                 "@types/semver": "^7.5.8",
-                "@vendure/core": "^3.5.3",
+                "@vendure/core": "3.5.2",
                 "rimraf": "^5.0.5",
                 "ts-node": "^10.9.2",
                 "typescript": "5.8.2"
@@ -54472,7 +54509,7 @@
         },
         "packages/dashboard": {
             "name": "@vendure/dashboard",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "dependencies": {
                 "@babel/core": "^7.26.0",
                 "@babel/preset-react": "^7.26.3",
@@ -54516,10 +54553,10 @@
                 "@tanstack/eslint-plugin-query": "^5.66.1",
                 "@tanstack/react-query": "^5.66.7",
                 "@tanstack/react-query-devtools": "^5.68.0",
-                "@tanstack/react-router": "^1.105.0",
+                "@tanstack/react-router": "^1.154.0",
                 "@tanstack/react-table": "^8.21.2",
-                "@tanstack/router-devtools": "^1.105.0",
-                "@tanstack/router-plugin": "^1.105.0",
+                "@tanstack/router-devtools": "^1.154.0",
+                "@tanstack/router-plugin": "^1.154.0",
                 "@tiptap/extension-floating-menu": "^3.4.4",
                 "@tiptap/extension-image": "^3.4.4",
                 "@tiptap/extension-table": "^3.4.4",
@@ -54574,8 +54611,8 @@
                 "@storybook/addon-vitest": "^10.0.0-beta.9",
                 "@storybook/react-vite": "^10.0.0-beta.9",
                 "@types/node": "^22.13.4",
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3",
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2",
                 "@vitest/browser": "^3.2.4",
                 "@vitest/coverage-v8": "^3.2.4",
                 "eslint": "^9.19.0",
@@ -54952,21 +54989,21 @@
             }
         },
         "packages/dev-server": {
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@nestjs/axios": "^4.0.0",
-                "@vendure/admin-ui-plugin": "^3.5.3",
-                "@vendure/asset-server-plugin": "^3.5.3",
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3",
-                "@vendure/elasticsearch-plugin": "^3.5.3",
-                "@vendure/email-plugin": "^3.5.3",
+                "@vendure/admin-ui-plugin": "3.5.2",
+                "@vendure/asset-server-plugin": "3.5.2",
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2",
+                "@vendure/elasticsearch-plugin": "3.5.2",
+                "@vendure/email-plugin": "3.5.2",
                 "typescript": "5.8.2"
             },
             "devDependencies": {
-                "@vendure/testing": "^3.5.3",
-                "@vendure/ui-devkit": "^3.5.3",
+                "@vendure/testing": "3.5.2",
+                "@vendure/ui-devkit": "3.5.2",
                 "commander": "^12.0.0",
                 "concurrently": "^9.2.0",
                 "csv-stringify": "^6.4.6",
@@ -54999,7 +55036,7 @@
         },
         "packages/elasticsearch-plugin": {
             "name": "@vendure/elasticsearch-plugin",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@elastic/elasticsearch": "~7.9.1",
@@ -55007,8 +55044,8 @@
                 "fast-deep-equal": "^3.1.3"
             },
             "devDependencies": {
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3",
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2",
                 "rimraf": "^5.0.5",
                 "typescript": "5.8.2"
             },
@@ -55018,7 +55055,7 @@
         },
         "packages/email-plugin": {
             "name": "@vendure/email-plugin",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@types/nodemailer": "^6.4.9",
@@ -55034,8 +55071,8 @@
                 "@types/express": "^5.0.1",
                 "@types/fs-extra": "^11.0.4",
                 "@types/mjml": "^4.7.4",
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3",
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2",
                 "rimraf": "^5.0.5",
                 "typescript": "5.8.2"
             },
@@ -55045,7 +55082,7 @@
         },
         "packages/graphiql-plugin": {
             "name": "@vendure/graphiql-plugin",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "express": "^5.1.0"
@@ -55055,8 +55092,8 @@
                 "@types/express": "^5.0.0",
                 "@types/react": "^19.0.0",
                 "@types/react-dom": "^19.0.0",
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3",
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2",
                 "@vitejs/plugin-react": "^5.0.4",
                 "graphiql": "^4.0.2",
                 "react": "^19.0.0",
@@ -55089,14 +55126,14 @@
         },
         "packages/harden-plugin": {
             "name": "@vendure/harden-plugin",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "graphql-query-complexity": "^0.12.0"
             },
             "devDependencies": {
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3"
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2"
             },
             "funding": {
                 "url": "https://github.com/sponsors/michaelbromley"
@@ -55107,12 +55144,12 @@
         },
         "packages/job-queue-plugin": {
             "name": "@vendure/job-queue-plugin",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "devDependencies": {
                 "@google-cloud/pubsub": "^4.11.0",
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3",
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2",
                 "bullmq": "^5.66.4",
                 "ioredis": "5.8.2",
                 "rimraf": "^5.0.5",
@@ -55172,7 +55209,7 @@
         },
         "packages/payments-plugin": {
             "name": "@vendure/payments-plugin",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "currency.js": "2.0.4"
@@ -55181,9 +55218,9 @@
                 "@mollie/api-client": "^4.3.3",
                 "@types/braintree": "^3.3.11",
                 "@types/localtunnel": "2.0.4",
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3",
-                "@vendure/testing": "^3.5.3",
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2",
+                "@vendure/testing": "3.5.2",
                 "braintree": "^3.22.0",
                 "localtunnel": "2.0.2",
                 "nock": "^13.1.4",
@@ -55213,15 +55250,15 @@
         },
         "packages/sentry-plugin": {
             "name": "@vendure/sentry-plugin",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@sentry/nestjs": "^10.2.0",
                 "@sentry/profiling-node": "^10.2.0"
             },
             "devDependencies": {
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3"
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2"
             },
             "funding": {
                 "url": "https://github.com/sponsors/michaelbromley"
@@ -55229,14 +55266,14 @@
         },
         "packages/stellate-plugin": {
             "name": "@vendure/stellate-plugin",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "node-fetch": "^2.7.0"
             },
             "devDependencies": {
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3"
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2"
             },
             "funding": {
                 "url": "https://github.com/sponsors/michaelbromley"
@@ -55244,7 +55281,7 @@
         },
         "packages/telemetry-plugin": {
             "name": "@vendure/telemetry-plugin",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@opentelemetry/api": "^1.9.0",
@@ -55258,8 +55295,8 @@
                 "javascript-stringify": "^2.1.0"
             },
             "devDependencies": {
-                "@vendure/common": "^3.5.3",
-                "@vendure/core": "^3.5.3",
+                "@vendure/common": "3.5.2",
+                "@vendure/core": "3.5.2",
                 "typescript": "5.8.2"
             },
             "funding": {
@@ -55268,11 +55305,11 @@
         },
         "packages/testing": {
             "name": "@vendure/testing",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@graphql-typed-document-node/core": "^3.2.0",
-                "@vendure/common": "^3.5.3",
+                "@vendure/common": "3.5.2",
                 "faker": "^4.1.0",
                 "form-data": "^4.0.0",
                 "graphql": "^16.11.0",
@@ -55285,7 +55322,7 @@
                 "@types/mysql": "^2.15.26",
                 "@types/node-fetch": "^2.6.4",
                 "@types/pg": "^8.11.2",
-                "@vendure/core": "^3.5.3",
+                "@vendure/core": "3.5.2",
                 "mysql2": "^3.15.0",
                 "pg": "^8.11.3",
                 "rimraf": "^5.0.5",
@@ -55297,15 +55334,15 @@
         },
         "packages/ui-devkit": {
             "name": "@vendure/ui-devkit",
-            "version": "3.5.3",
+            "version": "3.5.2",
             "license": "GPL-3.0-or-later",
             "dependencies": {
                 "@angular-devkit/build-angular": "^19.2.5",
                 "@angular/cli": "^19.2.5",
                 "@angular/compiler": "^19.2.4",
                 "@angular/compiler-cli": "^19.2.4",
-                "@vendure/admin-ui": "^3.5.3",
-                "@vendure/common": "^3.5.3",
+                "@vendure/admin-ui": "3.5.2",
+                "@vendure/common": "3.5.2",
                 "chalk": "^4.1.0",
                 "chokidar": "^3.6.0",
                 "fs-extra": "^11.2.0",
@@ -55316,7 +55353,7 @@
                 "@rollup/plugin-node-resolve": "^15.2.3",
                 "@rollup/plugin-terser": "^0.4.4",
                 "@types/fs-extra": "^11.0.4",
-                "@vendure/core": "^3.5.3",
+                "@vendure/core": "3.5.2",
                 "react": "^19.0.0",
                 "react-dom": "^19.0.0",
                 "rimraf": "^5.0.5",


### PR DESCRIPTION
## Summary

- Regenerates package-lock.json to sync with package.json

## Context

PR #4124 (docs migration) reverted `@tanstack/react-router` from `1.154.x` back to `1.146.x`. This broke `npm ci`.

probably a bad merge conflict resolution.

## Changes

- `@tanstack/*` packages: 1.146.x → 1.157.x (restores PR #4153 fix)
- `@babel/*` packages: 7.27.x → 7.28.6 (patch updates)
- `seroval`: 1.4.2 → 1.5.0 (minor update)

## Test plan

- [x] `npm ci` completes successfully
- [x] Builds pass
