### PR TITLE
fix(core): Persist custom fields when creating new ProductVariantPrice

### DIFF
--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -603,8 +603,17 @@ export class ProductVariantService {
                     price,
                     variant: new ProductVariant({ id: productVariantId }),
                     currencyCode: currencyCode ?? ctx.channel.defaultCurrencyCode,
+                    customFields,
                 }),
             );
+            if (customFields) {
+                await this.customFieldRelationService.updateRelations(
+                    ctx,
+                    ProductVariantPrice,
+                    customFields,
+                    createdPrice,
+                );
+            }
             await this.eventBus.publish(new ProductVariantPriceEvent(ctx, [createdPrice], 'created'));
             additionalPricesToUpdate = await productVariantPriceUpdateStrategy.onPriceCreated(
                 ctx,


### PR DESCRIPTION
## Summary

When creating a new `ProductVariantPrice` (e.g. adding a new currency to a product variant via the dashboard), custom fields were not being persisted. The `customFields` parameter was only being used when updating existing prices, not when creating new ones.

This fix:
- Includes `customFields` in the `ProductVariantPrice` entity constructor when creating new prices
- Calls `customFieldRelationService.updateRelations` to handle any relation-type custom fields

## Test plan

- [x] Added e2e test that verifies custom fields persist when creating a new `ProductVariantPrice`
- [x] Verified test fails without the fix (costPrice is `null` instead of expected value)
- [x] Verified test passes with the fix

Fixes #3909
Fixes #3484

---

**Note:** The dashboard-side fix for this issue is in PR #4180