### PR TITLE
feat(dashboard): Improve product variant handling by providing enhanced "creation assistant" dialog

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx
@@ -110,22 +110,43 @@ export function GenerateVariantsPanel({
     productId,
     productName,
     optionGroups,
+    existingVariants,
     onSuccess,
     onBack,
+    additionalActions,
 }: Readonly<{
     productId: string;
     productName: string;
     optionGroups: OptionGroup[];
+    existingVariants?: Array<{ options: Array<{ id: string }> }>;
     onSuccess?: () => void;
     onBack?: {
         handler: () => void;
         confirmation?: { title: string; description: string };
     };
+    additionalActions?: React.ReactNode;
 }>) {
     const { t } = useLingui();
     const { activeChannel } = useChannel();
 
-    const variants = useMemo(() => generateVariantCombinations(optionGroups), [optionGroups]);
+    const variants = useMemo(() => {
+        const all = generateVariantCombinations(optionGroups);
+        if (!existingVariants?.length) return all;
+        const existingCombos = new Set(
+            existingVariants.map(v =>
+                v.options
+                    .map(o => o.id)
+                    .sort((a, b) => a.localeCompare(b))
+                    .join(','),
+            ),
+        );
+        return all.filter(
+            v =>
+                !existingCombos.has(
+                    v.optionIds.slice().sort((a, b) => a.localeCompare(b)).join(','),
+                ),
+        );
+    }, [optionGroups, existingVariants]);
 
     // For small products (few option-group combinations) the historical
     // "all variants enabled by default" workflow is convenient. For products
@@ -278,7 +299,7 @@ export function GenerateVariantsPanel({
                                     />
                                 </TableHead>
                             )}
-                            {showVariantTools && (
+                            {variants.some(v => v.optionNames.length > 0) && (
                                 <TableHead>
                                     <Trans>Variant</Trans>
                                 </TableHead>
@@ -322,7 +343,7 @@ export function GenerateVariantsPanel({
                                     </TableCell>
                                 )}
 
-                                {showVariantTools && (
+                                {variant.optionNames.length > 0 && (
                                     <TableCell className="font-medium">
                                         {variant.optionNames.join(' / ')}
                                     </TableCell>
@@ -418,20 +439,23 @@ export function GenerateVariantsPanel({
                                 </button>
                             ))}
                     </div>
-                    <Button
-                        type="button"
-                        onClick={handleCreateVariants}
-                        disabled={createVariantsMutation.isPending || enabledCount === 0}
-                    >
-                        <Save className="mr-2 h-4 w-4" />
-                        {createVariantsMutation.isPending && <Trans>Creating...</Trans>}
-                        {!createVariantsMutation.isPending && enabledCount === 1 && (
-                            <Trans>Create variant</Trans>
-                        )}
-                        {!createVariantsMutation.isPending && enabledCount !== 1 && (
-                            <Trans>Create {enabledCount} variants</Trans>
-                        )}
-                    </Button>
+                    <div className="flex gap-2 items-center">
+                        {additionalActions}
+                        <Button
+                            type="button"
+                            onClick={handleCreateVariants}
+                            disabled={createVariantsMutation.isPending || enabledCount === 0}
+                        >
+                            <Save className="mr-2 h-4 w-4" />
+                            {createVariantsMutation.isPending && <Trans>Creating...</Trans>}
+                            {!createVariantsMutation.isPending && enabledCount === 1 && (
+                                <Trans>Create variant</Trans>
+                            )}
+                            {!createVariantsMutation.isPending && enabledCount !== 1 && (
+                                <Trans>Create {enabledCount} variants</Trans>
+                            )}
+                        </Button>
+                    </div>
                 </div>
             </div>
         </Form>

--- a/packages/dashboard/src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/components/product-option-group-badge.tsx
@@ -1,14 +1,15 @@
 import { Badge } from '@/vdb/components/ui/badge.js';
 import { Link } from '@tanstack/react-router';
-import { Edit2 } from 'lucide-react';
+import { Edit2, X } from 'lucide-react';
 
 interface ProductOptionGroupBadgeProps {
     id: string;
     name: string;
     productId: string;
+    onRemove?: () => void;
 }
 
-export function ProductOptionGroupBadge({ id, name, productId }: ProductOptionGroupBadgeProps) {
+export function ProductOptionGroupBadge({ id, name, productId, onRemove }: ProductOptionGroupBadgeProps) {
     return (
         <Badge variant="secondary" className="text-xs">
             <span>{name}</span>
@@ -19,6 +20,16 @@ export function ProductOptionGroupBadge({ id, name, productId }: ProductOptionGr
             >
                 <Edit2 className="h-3 w-3" />
             </Link>
+            {onRemove && (
+                <button
+                    type="button"
+                    onClick={onRemove}
+                    className="ml-1 inline-flex"
+                    aria-label="Remove option group"
+                >
+                    <X className="h-3 w-3" />
+                </button>
+            )}
         </Badge>
     );
 }

--- a/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id.tsx
@@ -307,6 +307,19 @@ function ProductDetailPage() {
                                         description: t`This will remove all option groups from this product and return to the variant setup choice.`,
                                     },
                                 }}
+                                additionalActions={
+                                    <AddOptionGroupDialog
+                                        productId={entity.id}
+                                        existingGroupIds={entity.optionGroups.map(g => g.id)}
+                                        onSuccess={() => refreshEntity()}
+                                        trigger={
+                                            <Button variant="outline" type="button">
+                                                <PlusIcon className="mr-2 h-4 w-4" />
+                                                <Trans>Add option group</Trans>
+                                            </Button>
+                                        }
+                                    />
+                                }
                             />
                         )}
                     </PageBlock>
@@ -320,6 +333,7 @@ function ProductDetailPage() {
                                     id={g.id}
                                     name={g.name}
                                     productId={entity.id}
+                                    onRemove={() => removeAllOptionGroups(entity.id, [g])}
                                 />
                             ))}
                         </div>

--- a/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
@@ -40,6 +40,7 @@ import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
 import { AddOptionGroupDialog } from './components/add-option-group-dialog.js';
 import { AddProductVariantDialog } from './components/add-product-variant-dialog.js';
+import { GenerateVariantsPanel } from './components/generate-variants-panel.js';
 import {
     createProductOptionDocument,
     deleteProductVariantDocument,
@@ -194,6 +195,7 @@ function ManageProductVariants() {
     });
 
     const [forceRemoveGroupId, setForceRemoveGroupId] = useState<string | null>(null);
+    const [showGenerator, setShowGenerator] = useState(false);
 
     const removeOptionGroupMutation = useMutation({
         mutationFn: api.mutate(removeOptionGroupFromProductDocument),
@@ -269,6 +271,24 @@ function ManageProductVariants() {
         return null;
     }
 
+    const optionGroupsCount = productData.product.optionGroups.length;
+    const totalCombos = productData.product.optionGroups.reduce(
+        (acc, g) => acc * g.options.length,
+        1,
+    );
+    const existingFullCombos = new Set(
+        productData.product.variants
+            .filter(v => v.options.length === optionGroupsCount)
+            .map(v =>
+                v.options
+                    .map(o => o.id)
+                    .sort((a, b) => a.localeCompare(b))
+                    .join(','),
+            ),
+    );
+    const optionsExhausted =
+        optionGroupsCount > 0 && totalCombos > 0 && existingFullCombos.size >= totalCombos;
+
     return (
         <Page pageId={pageId}>
             <PageTitle>
@@ -339,6 +359,25 @@ function ManageProductVariants() {
                     />
                 </PageBlock>
 
+                {showGenerator ? (
+                    <PageBlock
+                        column="main"
+                        blockId="generate-variants"
+                        title={<Trans>Generate variants</Trans>}
+                    >
+                        <GenerateVariantsPanel
+                            productId={id}
+                            productName={productData.product.name}
+                            optionGroups={productData.product.optionGroups}
+                            existingVariants={productData.product.variants}
+                            onSuccess={() => {
+                                setShowGenerator(false);
+                                refetch();
+                            }}
+                            onBack={{ handler: () => setShowGenerator(false) }}
+                        />
+                    </PageBlock>
+                ) : (
                 <PageBlock column="main" blockId="product-variants" title={<Trans>Variants</Trans>}>
                     <div className="mb-4">
                         <Table>
@@ -470,15 +509,26 @@ function ManageProductVariants() {
                         </Table>
                     </div>
 
-                    {productData.product.optionGroups.length > 0 && (
-                        <AddProductVariantDialog
-                            productId={id}
-                            onSuccess={() => {
-                                refetch();
-                            }}
-                        />
+                    {productData.product.optionGroups.length > 0 && !optionsExhausted && (
+                        <div className="flex gap-2">
+                            <Button
+                                variant="outline"
+                                type="button"
+                                onClick={() => setShowGenerator(true)}
+                            >
+                                <Plus className="mr-2 h-4 w-4" />
+                                <Trans>Generate variants</Trans>
+                            </Button>
+                            <AddProductVariantDialog
+                                productId={id}
+                                onSuccess={() => {
+                                    refetch();
+                                }}
+                            />
+                        </div>
                     )}
                 </PageBlock>
+                )}
             </PageLayout>
             <AlertDialog open={!!forceRemoveGroupId} onOpenChange={(open) => { if (!open) setForceRemoveGroupId(null); }}>
                 <AlertDialogContent>


### PR DESCRIPTION
# Description

Right now, product option (groups) and variant creation and management is a little confusing and error-prone UX-wise.
It's easy to create duplicate option groups and difficult to delete these, while it's difficult to efficiently create product variants for new options added at a later time, when some variants exist already.

The functionality of the buttons "Create Variant" and "Manage Variants" is confusing - the former only appearing if no variants exist, the latter only appearing if there are variants.
A video is attached displaying some of the issues with the dialog and what happens if option groups existed and then all variants are deleted and readded.
The Manage Variants page on the other hand doesn't provide any added value regarding variants, it rather enables managing the option groups and options.
The Manage Variants page also provides another dialog for adding a variant, adding to the confusion.

Therefore, I want to propose:
- enhancing the "Create Variant" dialog into an "assistant" displaying already existing option groups, enabling creation of new options (groups), and intelligently creating variants for new option combinations
- replacing /variants page with /options page, only keeping the option group management and moving the "manage" button to the product options block
- adding the missing delete action for option groups in /options
- moving the other "manually add variant" dialog to the product detail page (if even desired to keep)

# Screenshots

Current state:
[Untitled.webm](https://github.com/user-attachments/assets/4852c66c-da21-42d3-96c9-d784cd00685c)


Updated:
<img width="1273" height="753" alt="image" src="https://github.com/user-attachments/assets/f5e65686-e180-4587-8897-76cc0b8ade85" />
<img width="308" height="195" alt="image" src="https://github.com/user-attachments/assets/3b83b426-61c3-4fff-a452-5790bb8641f7" />
<img width="1505" height="617" alt="image" src="https://github.com/user-attachments/assets/a76aaef5-0f13-4f7f-ab14-32e2bb7cd608" />


# Checklist

📌 Always:
- [x] I have set a clear title
- [ ] [Tbh, not sure here]  My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
