### PR TITLE
fix(ci): Correct CI Bot secret names in CLA workflow

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -20,8 +20,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.CI_APP_ID }}
-          private-key: ${{ secrets.CI_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.CI_BOT_APP_ID }}
+          private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
 
       - name: "CLA Assistant"
         if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'


### PR DESCRIPTION
## Summary
- Fixed incorrect secret names in the CLA Assistant workflow (`CI_APP_ID` → `CI_BOT_APP_ID`, `CI_APP_PRIVATE_KEY` → `CI_BOT_APP_PRIVATE_KEY`)
- This resolves the `appId option is required` error causing the CLA check to fail on PRs

## Test plan
- [ ] Verify org secrets `CI_BOT_APP_ID` and `CI_BOT_APP_PRIVATE_KEY` have the `vendure` repo in their visibility settings
- [ ] Open or recheck a PR to confirm the CLA Assistant workflow passes