### PR TITLE
fix(create): Add ts-node to scaffolded project devDependencies

### DIFF
--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -234,6 +234,7 @@ export function getDependencies(
     const devDependencies = [
         `@vendure/cli${vendurePkgVersion}`,
         'concurrently',
+        'ts-node',
         `typescript@${TYPESCRIPT_VERSION}`,
     ];
     return { dependencies, devDependencies };


### PR DESCRIPTION
# Description

Fixes #4193

This was tested locally by running the built package.

Adds `ts-node` as an explicit `devDependency` in projects scaffolded by `@vendure/create`.

In monorepo mode (`--with-storefront`), npm workspaces nest transitive dependencies under their parent package's `node_modules/`. Since `ts-node` was only available transitively (via `@vendure/cli` and `typeorm`), it was invisible to the server workspace and caused failures when trying to run `dev:server` or `populate` (which need `ts-node` to transpile `vendure-config.ts`).

Single-project mode was unaffected because npm's flat resolution hoisted `ts-node` to the top-level `node_modules/`.

# Breaking changes

None.

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
