### PR TITLE
fix(core): Persist scalar custom fields in updateGlobalSettings with relations

### DIFF
--- a/packages/core/src/service/services/global-settings.service.ts
+++ b/packages/core/src/service/services/global-settings.service.ts
@@ -78,7 +78,8 @@ export class GlobalSettingsService {
         const settings = await this.getSettings(ctx);
         await this.eventBus.publish(new GlobalSettingsEvent(ctx, settings, input));
         patchEntity(settings, input);
-        await this.customFieldRelationService.updateRelations(ctx, GlobalSettings, input, settings);
-        return this.connection.getRepository(ctx, GlobalSettings).save(settings);
+        const savedSettings = await this.connection.getRepository(ctx, GlobalSettings).save(settings);
+        await this.customFieldRelationService.updateRelations(ctx, GlobalSettings, input, savedSettings);
+        return savedSettings;
     }
 }


### PR DESCRIPTION
## Summary

- Fixes `updateGlobalSettings` mutation not persisting scalar custom field values when a relational custom field is also defined on `GlobalSettings`
- Saves the entity to DB **before** calling `updateRelations()`, matching the pattern used by other services (e.g. `CollectionService`, `FacetService`)
- Adds e2e test verifying scalar + relational custom fields persist together

Fixes #4342

## Test plan

- [x] Existing `custom-field-relations` e2e tests pass (59/59)
- [x] Existing `global-settings` e2e tests pass (7/7)  
- [x] New test verifies scalar values persist when updated alongside relations
- [x] New test re-queries after mutation to confirm DB persistence

🤖 Generated with [Claude Code](https://claude.com/claude-code)