### PR TITLE
fix: Discounts visibility in order details table

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_orders/components/order-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/components/order-table.tsx
@@ -124,6 +124,25 @@ function createCustomizeColumns(currencyCode: string) {
                 <Money currencyCode={currencyCode} value={row.original.discountedLinePriceWithTax} />
             ),
         },
+        discounts: {
+            header: () => <Trans>Discounts</Trans>,
+            cell: ({ row }: { row: any }) => {
+                const discounts = row.original.discounts;
+                if (!discounts?.length) return null;
+                return (
+                    <div className="flex flex-col gap-1">
+                        {discounts.map((d: any, i: number) => (
+                            <div key={i} className="flex flex-col">
+                                <span>{d.description}</span>
+                                <span className="text-xs text-muted-foreground">
+                                    <Money currencyCode={currencyCode} value={d.amountWithTax} />
+                                </span>
+                            </div>
+                        ))}
+                    </div>
+                );
+            },
+        },
     };
 }
 


### PR DESCRIPTION
---

## Description

Fix `[object Object]` being displayed in the "Discounts" column of the order detail table in the Dashboard.

The order line table in `order-table.tsx` had custom cell renderers for most columns (featuredAsset, productVariant, unitPrice, quantity, etc.) but was missing one for `discounts`. This caused the auto-generated column renderer in `DefaultDisplayComponent` to call `.join(', ')` on an array of Discount objects, which produced `[object Object]` via `Object.prototype.toString()`.

Added a custom `discounts` column renderer that displays each discount's description along with the formatted amount in a stacked layout, consistent with how other price columns (like Unit Price and Total) display gross/net values.

**File changed:**  
`packages/dashboard/src/app/routes/_authenticated/_orders/components/order-table.tsx`

---

## Breaking changes

None. This is a display-only fix scoped to the order detail table in the Dashboard.

---

## Screenshots


<img width="950" height="525" alt="image" src="https://github.com/user-attachments/assets/aa97e83e-1697-4ef6-a496-8e14cbd49b95" />


---

## Checklist

- [x] I have set a clear title  
- [x] My PR is small and contains a single feature  
- [x] I have checked my own PR  
- [ ] I have added or updated test cases  
- [ ] I have updated the README if needed  

---
Fixes #4326 

