### PR TITLE
fix: Allow scrool in promotion actions and conditions

### DIFF
--- a/packages/dashboard/src/lib/components/ui/dropdown-menu.tsx
+++ b/packages/dashboard/src/lib/components/ui/dropdown-menu.tsx
@@ -27,7 +27,7 @@ function DropdownMenuContent({
                 data-slot="dropdown-menu-content"
                 sideOffset={sideOffset}
                 className={cn(
-                    'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-[calc(var(--radix-dropdown-menu-content-available-height)-16px)] min-w-[8rem] overflow-y-auto rounded-md border p-1 shadow-md',
+                    'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-[calc(var(--radix-dropdown-menu-content-available-height)-16px)] min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-md',
                     className,
                 )}
                 {...props}
@@ -196,7 +196,7 @@ function DropdownMenuSubContent({
         <DropdownMenuPrimitive.SubContent
             data-slot="dropdown-menu-sub-content"
             className={cn(
-                'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-[calc(var(--radix-dropdown-menu-content-available-height)-16px)] min-w-[8rem] overflow-y-auto rounded-md border p-1 shadow-lg',
+                'bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 max-h-[calc(var(--radix-dropdown-menu-content-available-height)-16px)] min-w-[8rem] overflow-x-hidden overflow-y-auto rounded-md border p-1 shadow-lg',
                 className,
             )}
             {...props}


### PR DESCRIPTION
# Description

Fixes the Ui for promotion action and condition when many custom promotion actions are registered, adds overflow to  DropDownMenuContent and SubContent 

# Breaking changes

N/A
# Screenshots
<img width="977" height="772" alt="image" src="https://github.com/user-attachments/assets/89f41a47-2c93-4991-bf95-bf56ba7aae81" />



# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR (Fix typos and remove unused or commented out code)

Fixes #4400 


