### PR TITLE
feat(core): add previous to collection update-events

### DIFF
--- a/packages/core/src/event-bus/events/collection-event.ts
+++ b/packages/core/src/event-bus/events/collection-event.ts
@@ -21,6 +21,7 @@ export class CollectionEvent extends VendureEntityEvent<Collection, CollectionIn
         entity: Collection,
         type: 'created' | 'updated' | 'deleted',
         input?: CollectionInputTypes,
+        public readonly previousEntity?: Collection,
     ) {
         super(entity, type, ctx, input);
     }


### PR DESCRIPTION
# Description

In addition to the updated CollectionEntity, there are scenarios where it comes in handy to have the state of the collection before the event happened.

# Breaking changes

Nope. Only an additional optional property on the CollectionEvent


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

