### PR TITLE
fix(dashboard): Ensure nullable numeric fields default to null

### DIFF
--- a/packages/dashboard/src/lib/framework/form-engine/form-schema-tools.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/form-schema-tools.ts
@@ -366,6 +366,14 @@ export function getDefaultValueFromField(field: FieldInfo, defaultLanguageCode?:
                 return defaultLanguageCode || 'en';
             case 'Boolean':
                 return false;
+            case 'Int':
+            case 'Float':
+            case 'Money':
+            case 'DateTime':
+                // Nullable numeric/date fields should default to null, not 0.
+                // This allows forms to distinguish between "no value" (unlimited)
+                // and "zero value" (explicit zero).
+                return null;
             default:
                 // Object-typed fields (e.g. customFields without typeInfo) should default
                 // to {} to match the Zod schema which expects an object.


### PR DESCRIPTION
## Summary
- Nullable Int, Float, Money, and DateTime fields now correctly default to null instead of 0
- Fixes promotion usageLimit and perCustomerUsageLimit fields defaulting to 0 when creating new promotions

## Test plan
- [x] Unit tests pass
- [x] Manual test: Create new promotion, verify usageLimit fields are empty (null) not 0

Fixes #4328