### PR TITLE
fix: Refresh language selector after saving language

### DIFF
--- a/packages/dashboard/src/lib/components/layout/manage-languages-dialog.tsx
+++ b/packages/dashboard/src/lib/components/layout/manage-languages-dialog.tsx
@@ -14,11 +14,10 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Separator } from '@/vdb/components/ui/separator.js';
 import { api } from '@/vdb/graphql/api.js';
 import { graphql } from '@/vdb/graphql/graphql.js';
+import { schemaLanguageCodes as globalLanguageCodes } from '@/vdb/graphql/schema-enums.js';
 import { useChannel } from '@/vdb/hooks/use-channel.js';
-import { useLocalFormat } from '@/vdb/hooks/use-local-format.js';
 import { usePermissions } from '@/vdb/hooks/use-permissions.js';
 import { useSortedLanguages } from '@/vdb/hooks/use-sorted-languages.js';
-import { schemaLanguageCodes as globalLanguageCodes } from '@/vdb/graphql/schema-enums.js';
 import { Trans } from '@lingui/react/macro';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { AlertCircle, Lock } from 'lucide-react';
@@ -113,6 +112,7 @@ export function ManageLanguagesDialog({ open, onClose }: ManageLanguagesDialogPr
             api.mutate(updateGlobalSettingsLanguagesDocument, { input }),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['globalSettings'] });
+            queryClient.invalidateQueries({ queryKey: ['getServerConfig'] });
             toast.success('Global language settings updated successfully');
         },
         onError: (error: any) => {
@@ -128,6 +128,7 @@ export function ManageLanguagesDialog({ open, onClose }: ManageLanguagesDialogPr
         }) => api.mutate(updateChannelDocument, { input }),
         onSuccess: () => {
             queryClient.invalidateQueries({ queryKey: ['channels'] });
+            queryClient.invalidateQueries({ queryKey: ['activeChannel'] });
             toast.success('Channel language settings updated successfully');
         },
         onError: (error: any) => {


### PR DESCRIPTION
## Description

When adding a new content language via the Manage Languages dialog, the language does not appear in the channel switcher language selector until a manual page reload.

The root cause is that the mutation `onSuccess` callbacks invalidated the wrong query keys:
- `updateChannel` invalidated `['channels']` but `ChannelProvider` fetches active channel with `['activeChannel']`

The channel switcher dropdown is driven by `displayChannel?.availableLanguageCodes` from the `activeChannel` query, so invalidating `['activeChannel']` is the essential fix. `serverConfig.availableLanguages` and `hasMultipleLanguages` are declared in the channel switcher but not actually referenced, so the `['getServerConfig']` invalidation was added for consistency since other components consume it.

## Breaking changes

None.

## Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

Fixes : #4379 