### PR TITLE
fix: Silent error when creating product variant when no active tax zo…

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/components/create-product-variants-dialog.tsx
@@ -10,11 +10,12 @@ import {
 } from '@/vdb/components/ui/dialog.js';
 import { api } from '@/vdb/graphql/api.js';
 import { useChannel } from '@/vdb/hooks/use-channel.js';
-import { Trans } from '@lingui/react/macro';
 import { normalizeString } from '@/vdb/lib/utils.js';
+import { Trans, useLingui } from '@lingui/react/macro';
 import { useMutation } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
 import {
     addOptionGroupToProductDocument,
     createProductOptionGroupDocument,
@@ -31,6 +32,7 @@ export function CreateProductVariantsDialog({
     productName: string;
     onSuccess?: () => void;
 }) {
+    const { t } = useLingui();
     const { activeChannel } = useChannel();
     const [variantData, setVariantData] = useState<VariantConfiguration | null>(null);
     const [open, setOpen] = useState(false);
@@ -127,8 +129,9 @@ export function CreateProductVariantsDialog({
             setOpen(false);
             onSuccess?.();
         } catch (error) {
-            console.error('Error creating variants:', error);
-            // Handle error (show toast notification, etc.)
+            toast.error(t`Failed to create product variants`, {
+                description: error instanceof Error ? error.message : t`Unknown error`,
+            });
         }
     }
 


### PR DESCRIPTION
## Description

The **"Create Variants"** dialog silently swallowed errors during variant creation.  
If the backend returned an error (e.g., *"The active tax zone could not be determined"*), the admin saw no feedback , the `catch` block only had `console.error` with an unimplemented TODO comment.

Added a `toast.error()` notification so the admin now sees the error message when variant creation fails.

---

**Note:** There is a second related issue where retrying after a failure only shows **1 variant input field** instead of all expected fields. This happens because `handleCreateVariants` runs three sequential steps via `Promise.all` / `mutateAsync`:

1. Create option groups (persisted to server)  
2. Assign option groups to product (persisted to server)  
3. Create variants (fails)

Steps 1–2 succeed and persist before step 3 fails, leaving the product with option groups but no variants. When the dialog reopens, it mounts fresh with empty local state, so `generateVariants([])` returns a single default variant.

Fixing this properly requires either:
- Splitting the flow into separate phases
- Detecting already-assigned option groups on dialog open
- Adding rollback logic  

This needs further discussion on the preferred approach.

---

## Breaking changes

None.

---

## Checklist

📌 **Always:**
- [x] I have set a clear title  
- [x] My PR is small and contains a single feature  
- [x] I have checked my own PR  



Partially fixes #4358 