### PR TITLE
fix(core,dashboard): make coupon code validation case-insensitive

### DIFF
--- a/packages/core/e2e/order-promotion.e2e-spec.ts
+++ b/packages/core/e2e/order-promotion.e2e-spec.ts
@@ -185,15 +185,12 @@ describe('Promotions applied to Orders', () => {
             expect(applyCouponCode.errorCode).toBe(ErrorCode.COUPON_CODE_EXPIRED_ERROR);
         });
 
-        it('coupon code application is case-sensitive', async () => {
+        it('coupon code application is case-insensitive', async () => {
             const { applyCouponCode } = await shopClient.query(applyCouponCodeDocument, {
                 couponCode: TEST_COUPON_CODE.toLowerCase(),
             });
-            orderResultGuard.assertErrorResult(applyCouponCode);
-            expect(applyCouponCode.message).toBe(
-                `Coupon code "${TEST_COUPON_CODE.toLowerCase()}" is not valid`,
-            );
-            expect(applyCouponCode.errorCode).toBe(ErrorCode.COUPON_CODE_INVALID_ERROR);
+            orderResultGuard.assertSuccess(applyCouponCode);
+            expect(applyCouponCode.couponCodes).toContain(TEST_COUPON_CODE.toLowerCase());
         });
 
         it('applies a valid coupon code', async () => {

--- a/packages/core/src/entity/promotion/promotion.entity.ts
+++ b/packages/core/src/entity/promotion/promotion.entity.ts
@@ -203,7 +203,7 @@ export class Promotion
         if (this.startsAt && this.startsAt > new Date()) {
             return false;
         }
-        if (this.couponCode && !order.couponCodes.includes(this.couponCode)) {
+        if (this.couponCode && !order.couponCodes.some(code => code.toLowerCase() === this.couponCode.toLowerCase())) {
             return false;
         }
         const promotionState: PromotionState = {};

--- a/packages/core/src/service/helpers/order-modifier/order-modifier.ts
+++ b/packages/core/src/service/helpers/order-modifier/order-modifier.ts
@@ -583,7 +583,7 @@ export class OrderModifier {
                         | CouponCodeInvalidError
                         | CouponCodeLimitError;
                 }
-                if (!order.couponCodes.includes(couponCode)) {
+                if (!order.couponCodes.some(cc => cc.toLowerCase() === couponCode.toLowerCase())) {
                     // This is a new coupon code that hadn't been applied before
                     await this.historyService.createHistoryEntryForOrder({
                         ctx,
@@ -594,7 +594,7 @@ export class OrderModifier {
                 }
             }
             for (const existingCouponCode of order.couponCodes) {
-                if (!input.couponCodes.includes(existingCouponCode)) {
+                if (!input.couponCodes.some(cc => cc.toLowerCase() === existingCouponCode.toLowerCase())) {
                     // An existing coupon code has been removed
                     await this.historyService.createHistoryEntryForOrder({
                         ctx,

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -998,7 +998,7 @@ export class OrderService {
         couponCode: string,
     ): Promise<ErrorResultUnion<ApplyCouponCodeResult, Order>> {
         const order = await this.getOrderOrThrow(ctx, orderId);
-        if (order.couponCodes.includes(couponCode)) {
+        if (order.couponCodes.some(cc => cc.toLowerCase() === couponCode.toLowerCase())) {
             return order;
         }
         const validationResult = await this.promotionService.validateCouponCode(
@@ -1026,8 +1026,8 @@ export class OrderService {
      */
     async removeCouponCode(ctx: RequestContext, orderId: ID, couponCode: string) {
         const order = await this.getOrderOrThrow(ctx, orderId);
-        if (order.couponCodes.includes(couponCode)) {
-            order.couponCodes = order.couponCodes.filter(cc => cc !== couponCode);
+        if (order.couponCodes.some(cc => cc.toLowerCase() === couponCode.toLowerCase())) {
+            order.couponCodes = order.couponCodes.filter(cc => cc.toLowerCase() !== couponCode.toLowerCase());
             await this.historyService.createHistoryEntryForOrder({
                 ctx,
                 orderId: order.id,

--- a/packages/core/src/service/services/promotion.service.ts
+++ b/packages/core/src/service/services/promotion.service.ts
@@ -15,7 +15,7 @@ import {
 } from '@vendure/common/lib/generated-types';
 import { ID, PaginatedList } from '@vendure/common/lib/shared-types';
 import { unique } from '@vendure/common/lib/unique';
-import { In, IsNull } from 'typeorm';
+import { In, IsNull, Raw } from 'typeorm';
 
 import { RequestContext } from '../../api/common/request-context';
 import { RelationPaths } from '../../api/decorators/relations.decorator';
@@ -248,7 +248,7 @@ export class PromotionService {
     ): Promise<JustErrorResults<ApplyCouponCodeResult> | Promotion> {
         const promotion = await this.connection.getRepository(ctx, Promotion).findOne({
             where: {
-                couponCode,
+                couponCode: Raw(alias => `LOWER(${alias}) = LOWER(:couponCode)`, { couponCode }),
                 enabled: true,
                 deletedAt: IsNull(),
                 channels: { id: ctx.channelId },
@@ -257,7 +257,7 @@ export class PromotionService {
         });
         if (
             !promotion ||
-            promotion.couponCode !== couponCode ||
+            promotion.couponCode.toLowerCase() !== couponCode.toLowerCase() ||
             !promotion.channels.find(c => idsAreEqual(c.id, ctx.channelId))
         ) {
             return new CouponCodeInvalidError({ couponCode });

--- a/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions_.$id.tsx
@@ -204,7 +204,12 @@ function PromotionDetailPage() {
                             control={form.control}
                             name="couponCode"
                             label={<Trans>Coupon code</Trans>}
-                            render={({ field }) => <Input {...field} />}
+                            render={({ field }) => (
+                                <Input
+                                    {...field}
+                                    onChange={e => field.onChange(e.target.value.toUpperCase())}
+                                />
+                            )}
                         />
                         <FormFieldWrapper
                             control={form.control}


### PR DESCRIPTION
# Description

Coupon codes are now validated case-insensitively across the entire backend. Previously, a customer entering `abc10` when the coupon code was `ABC10` would get an "invalid coupon" error. This aligns Vendure with the behavior of other major e-commerce platforms (Shopify, WooCommerce).

Additionally, the Dashboard now auto-uppercases coupon code input for consistency.

Closes OSS-371

**Changes:**
- `promotion.service.ts`: Use `LOWER()` in DB query for case-insensitive coupon lookup
- `promotion.entity.ts`: Case-insensitive comparison in `test()` method
- `order.service.ts`: Case-insensitive `applyCouponCode` and `removeCouponCode`
- `order-modifier.ts`: Case-insensitive coupon code checks in order modification
- `promotions_.$id.tsx`: Auto-uppercase coupon code input in Dashboard
- `order-promotion.e2e-spec.ts`: Updated test to verify case-insensitive behavior

# Breaking changes

No breaking changes. Coupon codes that previously required exact case matching will now match case-insensitively.

# Screenshots

<img width="697" height="913" alt="Screenshot 2026-02-27 at 14 44 04" src="https://github.com/user-attachments/assets/0428bd53-075c-45a6-a202-e1b1709c8933" />
<img width="518" height="585" alt="Screenshot 2026-02-27 at 14 44 11" src="https://github.com/user-attachments/assets/e49f8eda-bede-495d-b358-603728f78b12" />


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed