### PR TITLE
fix(asset-server-plugin): Set correct Content-Type for PDF assets

### DIFF
--- a/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
+++ b/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
@@ -279,7 +279,7 @@ describe('AssetServerPlugin', () => {
         }
 
         beforeAll(async () => {
-            const formats = ['gif', 'jpg', 'png', 'svg', 'tiff', 'webp'];
+            const formats = ['gif', 'jpg', 'png', 'svg', 'tiff', 'webp', 'pdf'];
 
             const filesToUpload = formats.map(ext => path.join(__dirname, `fixtures/assets/test.${ext}`));
             const { createAssets }: CreateAssetsMutation = await adminClient.fileUploadMutation({
@@ -315,6 +315,10 @@ describe('AssetServerPlugin', () => {
 
         it('webp', async () => {
             await testMimeTypeOfAssetWithExt('webp', 'image/webp');
+        });
+
+        it('pdf', async () => {
+            await testMimeTypeOfAssetWithExt('pdf', 'application/pdf');
         });
     });
 

--- a/packages/asset-server-plugin/e2e/fixtures/assets/test.pdf
+++ b/packages/asset-server-plugin/e2e/fixtures/assets/test.pdf
@@ -1,0 +1,12 @@
+%PDF-1.0
+1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj 2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj 3 0 obj<</Type/Page/MediaBox[0 0 3 3]/Parent 2 0 R>>endobj
+xref
+0 4
+0000000000 65535 f 
+0000000009 00000 n 
+0000000058 00000 n 
+0000000115 00000 n 
+trailer<</Size 4/Root 1 0 R>>
+startxref
+190
+%%EOF

--- a/packages/asset-server-plugin/src/asset-server.ts
+++ b/packages/asset-server-plugin/src/asset-server.ts
@@ -307,6 +307,8 @@ export class AssetServer {
                 return 'image/tiff';
             case '.webp':
                 return 'image/webp';
+            case '.pdf':
+                return 'application/pdf';
         }
     }
 }


### PR DESCRIPTION
# Description

PDF files served by the asset server were returning `application/octet-stream` instead of `application/pdf`, causing Chromium-based browsers to download them instead of displaying inline.

Added `.pdf` to the `getMimeType()` extension-based lookup in `AssetServer` so PDFs resolve correctly without relying on async `file-type` detection.

Fixes #4403

# Breaking changes

None.

# Screenshots
https://github.com/user-attachments/assets/d0e43311-14f0-4afb-8e2f-32f9a9c4e2b0

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed