### PR TITLE
fix(dashboard): Preserve dirty state when form values update

### DIFF
--- a/packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx
+++ b/packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx
@@ -122,6 +122,12 @@ export function useGeneratedForm<
         mode: 'onChange',
         defaultValues: processedDefaultValues,
         values,
+        // Preserve user edits when external values update (e.g., due to re-renders
+        // from filter validity state changes). Without this, the form's dirty state
+        // could be incorrectly reset when the component re-renders.
+        resetOptions: {
+            keepDirtyValues: true,
+        },
     });
     let submitHandler = (event: FormEvent): any => {
         event.preventDefault();


### PR DESCRIPTION
## Summary
- Adds `resetOptions.keepDirtyValues: true` to the generated form hook
- Preserves user edits when the form's external `values` prop updates due to re-renders

## Root Cause
When filter validity state changes (added in 3.5.4), the component re-renders. On each render, the `values` prop passed to react-hook-form is recreated. Without `keepDirtyValues`, this can reset the form's dirty state, causing the Update button to remain disabled even after the user has edited fields like name or description.

## Solution
Use react-hook-form's built-in `resetOptions.keepDirtyValues` to preserve user edits when external values update. This is the intended API for exactly this use case.

## Test plan
- [ ] Open a collection that has filters (e.g., "Filter by product variant name")
- [ ] Edit the collection name or description
- [ ] Verify the Update button becomes enabled
- [ ] Save and verify changes persist

Fixes #4389
Fixes OSS-386