### PR TITLE
fix(dashboard): Treat args with defaultValue as valid in ConfigurableOperationInput

### DIFF
--- a/packages/dashboard/e2e/tests/catalog/collections.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/collections.spec.ts
@@ -1,6 +1,8 @@
-import { expect } from '@playwright/test';
+import { type Page, expect, test } from '@playwright/test';
 
+import { BaseDetailPage } from '../../page-objects/detail-page.base.js';
 import { createCrudTestSuite } from '../../utils/crud-test-factory.js';
+import { VendureAdminClient } from '../../utils/vendure-admin-client.js';
 
 createCrudTestSuite({
     entityName: 'collection',
@@ -13,4 +15,142 @@ createCrudTestSuite({
     afterFillCreate: async (_page, detail) => {
         await expect(detail.formItem('Slug').getByRole('textbox')).not.toHaveValue('', { timeout: 5_000 });
     },
+});
+
+// #4389 — After 3.5.4, collections with filters are not noticed as changed when
+// editing name or description, because the combineWithAnd arg (added in 3.5.4) is
+// required with a defaultValue, but legacy collections don't have it stored. The
+// validity check in ConfigurableOperationInput treated it as permanently invalid,
+// keeping the Update button disabled via the filtersArgsValid gate.
+test.describe('Issue #4389: Collection form dirty state with filters', () => {
+    test.describe.configure({ mode: 'serial' });
+
+    let collectionId: string;
+
+    const detailPage = (page: Page) =>
+        new BaseDetailPage(page, {
+            newPath: '/collections/new',
+            pathPrefix: '/collections/',
+            newTitle: 'New collection',
+        });
+
+    // Create a collection with a facet-value-filter that deliberately omits the
+    // combineWithAnd arg — this simulates legacy collections created before 3.5.4
+    // added that argument, which is the root cause of #4389.
+    test.beforeAll(async ({ browser }) => {
+        const page = await browser.newPage();
+        const client = new VendureAdminClient(page);
+        await client.login();
+
+        // Get a facet value ID to use in the filter
+        const { facetValues } = await client.gql(`
+            query { facetValues(options: { take: 1 }) { items { id name } } }
+        `);
+        const facetValueId = facetValues.items[0].id as string;
+
+        // Create collection with filter — note: combineWithAnd is intentionally
+        // omitted to reproduce the legacy-data bug
+        const { createCollection } = await client.gql(
+            `
+            mutation ($input: CreateCollectionInput!) {
+                createCollection(input: $input) { id }
+            }
+        `,
+            {
+                input: {
+                    translations: [
+                        {
+                            languageCode: 'en',
+                            name: 'E2E Filter Test',
+                            slug: 'e2e-filter-test',
+                            description: '',
+                        },
+                    ],
+                    filters: [
+                        {
+                            code: 'facet-value-filter',
+                            arguments: [
+                                { name: 'facetValueIds', value: `["${facetValueId}"]` },
+                                { name: 'containsAny', value: 'false' },
+                            ],
+                        },
+                    ],
+                },
+            },
+        );
+        collectionId = createCollection.id;
+        await page.close();
+    });
+
+    test.afterAll(async ({ browser }) => {
+        if (!collectionId) return;
+        const page = await browser.newPage();
+        const client = new VendureAdminClient(page);
+        await client.login();
+        await client.gql(
+            `
+            mutation ($id: ID!) { deleteCollection(id: $id) { result } }
+        `,
+            { id: collectionId },
+        );
+        await page.close();
+    });
+
+    async function goToCollection(page: Page) {
+        await page.goto(`/collections/${collectionId}`);
+        // Wait for the filter card to render — confirms the detail page loaded
+        await expect(page.getByText('facet-value-filter')).toBeVisible({ timeout: 10_000 });
+    }
+
+    test('should enable Update button when editing the Name field', async ({ page }) => {
+        await goToCollection(page);
+        const dp = detailPage(page);
+
+        // Update button should be disabled initially
+        await expect(dp.updateButton).toBeDisabled();
+
+        // Edit the name
+        await dp.fillInput('Name', 'E2E Filter Test Updated');
+
+        // Update button should now be enabled
+        await expect(dp.updateButton).toBeEnabled({ timeout: 5_000 });
+    });
+
+    test('should enable Update button when editing the Description field', async ({ page }) => {
+        await goToCollection(page);
+        const dp = detailPage(page);
+
+        await expect(dp.updateButton).toBeDisabled();
+
+        // The description is a TipTap rich text editor (contenteditable),
+        // not a regular input. Click the editor area and type.
+        const editor = page.locator('.rich-text-editor');
+        await editor.click();
+        await page.keyboard.type('A test description');
+
+        // Click elsewhere to blur and trigger change detection
+        await page.getByText('Filters').first().click();
+
+        await expect(dp.updateButton).toBeEnabled({ timeout: 5_000 });
+    });
+
+    test('should persist changes after saving', async ({ page }) => {
+        await goToCollection(page);
+        const dp = detailPage(page);
+
+        await expect(dp.updateButton).toBeDisabled();
+
+        // Edit the name
+        await dp.fillInput('Name', 'E2E Filter Test Saved');
+        await expect(dp.updateButton).toBeEnabled({ timeout: 5_000 });
+
+        // Save
+        await dp.clickUpdate();
+        await dp.expectSuccessToast(/updated/i);
+
+        // Reload and verify the change persisted
+        await page.reload();
+        await expect(page.getByText('facet-value-filter')).toBeVisible({ timeout: 10_000 });
+        await expect(dp.formItem('Name').getByRole('textbox')).toHaveValue('E2E Filter Test Saved');
+    });
 });

--- a/packages/dashboard/e2e/tests/sales/orders.spec.ts
+++ b/packages/dashboard/e2e/tests/sales/orders.spec.ts
@@ -1,7 +1,7 @@
 import { type Page, expect, test } from '@playwright/test';
 
-import { VENDURE_PORT } from '../../constants.js';
 import { BaseListPage } from '../../page-objects/list-page.base.js';
+import { VendureAdminClient } from '../../utils/vendure-admin-client.js';
 
 // Orders use a multi-step draft flow rather than a single CRUD form.
 // Each action (set customer, add line, set address, set shipping) is an
@@ -205,48 +205,6 @@ test.describe('Orders', () => {
 });
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
-
-const ADMIN_API = `http://localhost:${VENDURE_PORT}/admin-api`;
-
-/** Thin wrapper around Playwright's request API with Vendure bearer-token auth. */
-class VendureAdminClient {
-    private authToken: string | null = null;
-    constructor(private page: Page) {}
-
-    async login(username = 'superadmin', password = 'superadmin') {
-        const response = await this.page.request.post(ADMIN_API, {
-            data: {
-                query: `mutation ($u: String!, $p: String!) {
-                    login(username: $u, password: $p) {
-                        ... on CurrentUser { id }
-                        ... on ErrorResult { errorCode message }
-                    }
-                }`,
-                variables: { u: username, p: password },
-            },
-        });
-        this.authToken = response.headers()['vendure-auth-token'] ?? null;
-        const json = await response.json();
-        if (json.errors?.length) {
-            throw new Error(`Login failed: ${String(json.errors[0].message)}`);
-        }
-    }
-
-    async gql(query: string, variables?: Record<string, unknown>) {
-        if (!this.authToken) throw new Error('Call login() first');
-        const response = await this.page.request.post(ADMIN_API, {
-            headers: { Authorization: `Bearer ${this.authToken}` },
-            data: { query, variables },
-        });
-        const newToken = response.headers()['vendure-auth-token'];
-        if (newToken) this.authToken = newToken;
-        const json = await response.json();
-        if (json.errors?.length) {
-            throw new Error(`GraphQL error: ${String(json.errors[0].message)}`);
-        }
-        return json.data;
-    }
-}
 
 /**
  * Creates a payment method (idempotent), builds a fully-paid order via the

--- a/packages/dashboard/e2e/utils/vendure-admin-client.ts
+++ b/packages/dashboard/e2e/utils/vendure-admin-client.ts
@@ -1,0 +1,45 @@
+import { type Page } from '@playwright/test';
+
+import { VENDURE_PORT } from '../constants.js';
+
+const ADMIN_API = `http://localhost:${VENDURE_PORT}/admin-api`;
+
+/** Thin wrapper around Playwright's request API with Vendure bearer-token auth. */
+export class VendureAdminClient {
+    private authToken: string | null = null;
+    constructor(private page: Page) {}
+
+    async login(username = 'superadmin', password = 'superadmin') {
+        const response = await this.page.request.post(ADMIN_API, {
+            data: {
+                query: `mutation ($u: String!, $p: String!) {
+                    login(username: $u, password: $p) {
+                        ... on CurrentUser { id }
+                        ... on ErrorResult { errorCode message }
+                    }
+                }`,
+                variables: { u: username, p: password },
+            },
+        });
+        this.authToken = response.headers()['vendure-auth-token'] ?? null;
+        const json = await response.json();
+        if (json.errors?.length) {
+            throw new Error(`Login failed: ${String(json.errors[0].message)}`);
+        }
+    }
+
+    async gql(query: string, variables?: Record<string, unknown>) {
+        if (!this.authToken) throw new Error('Call login() first');
+        const response = await this.page.request.post(ADMIN_API, {
+            headers: { Authorization: `Bearer ${this.authToken}` },
+            data: { query, variables },
+        });
+        const newToken = response.headers()['vendure-auth-token'];
+        if (newToken) this.authToken = newToken;
+        const json = await response.json();
+        if (json.errors?.length) {
+            throw new Error(`GraphQL error: ${String(json.errors[0].message)}`);
+        }
+        return json.data;
+    }
+}

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-input.tsx
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-input.tsx
@@ -45,6 +45,10 @@ export function ConfigurableOperationInput({
         const isValid = operationDefinition.args.every(arg => {
             if (!arg.required || arg.list) return true;
             const argValue = value.arguments.find(a => a.name === arg.name)?.value;
+            // Args with a defaultValue are considered valid even when absent from
+            // stored data. This handles legacy collections created before an arg
+            // (e.g. combineWithAnd) was added to the filter definition.
+            if (argValue === undefined && arg.defaultValue != null) return true;
             return argValue !== undefined && argValue !== '';
         });
 


### PR DESCRIPTION
## Summary

Fixes #4389 — collections with filters created before v3.5.4 could not be edited (Update button stayed permanently disabled) because the `combineWithAnd` argument added in 3.5.4 was absent from legacy stored data.

**Root cause:** `ConfigurableOperationInput`'s validity check treated any missing required arg as invalid, even when the arg definition provides a `defaultValue`. Since the Update button on the collection detail page is gated by `filtersArgsValid`, it was permanently disabled.

**Fix:** Args absent from stored data but with a `defaultValue` in the operation definition are now treated as valid. This is a 4-line change in `configurable-operation-input.tsx`.

This supersedes #4453, which proposed adding `keepDirtyValues: true` to `useGeneratedForm`. Investigation showed that `keepDirtyValues` is unnecessary — react-hook-form v7.70.0 already deep-compares the `values` prop internally and does not reset dirty state when no structural change occurs. The sole issue was the validity gate, not dirty-state management.

### Changes
- **`configurable-operation-input.tsx`** — treat args with `defaultValue` as valid when absent from stored data
- **`vendure-admin-client.ts`** (new) — extract shared Admin API helper for e2e tests
- **`collections.spec.ts`** — add regression tests for #4389
- **`orders.spec.ts`** — use shared `VendureAdminClient`

## Test plan
- [x] Added 3 e2e regression tests: name edit, description edit, save persistence
- [x] Tests correctly fail when the fix is reverted (verified via sanity check)
- [x] Full dashboard e2e suite passes (216 tests, 0 failures)