### PR TITLE
fix(dashboard): Wrap faceted filters to prevent horizontal overflow

### DIFF
--- a/packages/dashboard/src/lib/components/data-table/data-table.tsx
+++ b/packages/dashboard/src/lib/components/data-table/data-table.tsx
@@ -349,7 +349,7 @@ export function DataTable<TData>({
             table={table}
         >
             <div className="space-y-2 @container/table">
-                <div className="flex items-center justify-between gap-2">
+                <div className="flex items-start justify-between gap-2">
                     <div className="flex flex-wrap items-center gap-2">
                         {onSearchTermChange && (
                             <Input


### PR DESCRIPTION
## Summary
- Add `flex-wrap` to the faceted filter container in the DataTable toolbar
- When many custom faceted filters are added, they now wrap to the next line instead of causing horizontal page overflow

Fixes #4359