### PR TITLE
fix(core): Remove stale shipping lines when shipping method no longer exists

### DIFF
--- a/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.spec.ts
@@ -188,6 +188,74 @@ describe('OrderCalculator', () => {
             expect(order.totalWithTax).toBe(order.subTotalWithTax + 1200);
             assertOrderTotalsAddUp(order);
         });
+
+        it('removes shipping line when shipping method no longer exists', async () => {
+            const deletedShippingMethodId = 'T_deleted';
+            const module = await Test.createTestingModule({
+                providers: [
+                    OrderCalculator,
+                    RequestContextCacheService,
+                    { provide: TaxRateService, useClass: MockTaxRateService },
+                    { provide: ShippingCalculator, useValue: { getEligibleShippingMethods: () => [] } },
+                    {
+                        provide: ShippingMethodService,
+                        useValue: {
+                            findOne: (requestCtx: RequestContext, id: string) => {
+                                if (id === deletedShippingMethodId) {
+                                    return undefined;
+                                }
+                                return {
+                                    id: mockShippingMethodId,
+                                    test: () => true,
+                                    apply() {
+                                        return {
+                                            price: 500,
+                                            priceIncludesTax: requestCtx.channel.pricesIncludeTax,
+                                            taxRate: 20,
+                                        };
+                                    },
+                                };
+                            },
+                        },
+                    },
+                    { provide: ListQueryBuilder, useValue: {} },
+                    { provide: ConfigService, useClass: MockConfigService },
+                    { provide: EventBus, useValue: { publish: () => ({}) } },
+                    { provide: ZoneService, useValue: { getAllWithMembers: () => [] } },
+                ],
+            }).compile();
+
+            const calc = module.get(OrderCalculator);
+            const mockConfigService = module.get<ConfigService, MockConfigService>(ConfigService);
+            mockConfigService.taxOptions = {
+                taxZoneStrategy: new DefaultTaxZoneStrategy(),
+                taxLineCalculationStrategy: new DefaultTaxLineCalculationStrategy(),
+            };
+
+            const ctx = createRequestContext({ pricesIncludeTax: false });
+            const order = createOrder({
+                ctx,
+                lines: [
+                    {
+                        listPrice: 100,
+                        taxCategory: taxCategoryStandard,
+                        quantity: 1,
+                    },
+                ],
+            });
+            order.shippingLines = [
+                new ShippingLine({
+                    shippingMethodId: deletedShippingMethodId as any,
+                }),
+            ];
+
+            await calc.applyPriceAdjustments(ctx, order, []);
+
+            expect(order.shippingLines.length).toBe(0);
+            expect(order.shipping).toBe(0);
+            expect(order.shippingWithTax).toBe(0);
+            assertOrderTotalsAddUp(order);
+        });
     });
 
     describe('promotions', () => {

--- a/packages/core/src/service/helpers/order-calculator/order-calculator.ts
+++ b/packages/core/src/service/helpers/order-calculator/order-calculator.ts
@@ -314,7 +314,8 @@ export class OrderCalculator {
                 shippingLine?.shippingMethodId &&
                 (await this.shippingMethodService.findOne(ctx, shippingLine.shippingMethodId));
             if (!currentShippingMethod) {
-                return;
+                order.shippingLines = order.shippingLines.filter(sl => sl !== shippingLine);
+                continue;
             }
             const currentMethodStillEligible = await currentShippingMethod.test(ctx, order);
             if (currentMethodStillEligible) {


### PR DESCRIPTION
# Description

In OrderCalculator.applyShipping(), when a ShippingLine references a ShippingMethod that has been soft-deleted or removed from the channel, the code was returning early from the entire method instead of removing the stale shipping line. This left an orphaned ShippingLine on the order, causing "Cannot return null for non-nullable field ShippingLine.shippingMethod" errors on subsequent GraphQL queries.

Fixes #4486

# Breaking changes

No

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed
