### PR TITLE
fix(dashboard): Invalidate child collection query cache on remount

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
@@ -67,7 +67,32 @@ function CollectionListPage() {
     const [nextPageToFetch, setNextPageToFetch] = useState<Record<string, number>>({});
 
     useEffect(() => {
-        queryClient.invalidateQueries({ queryKey: ['childCollections'] });
+        // Hydrate accumulatedChildren from the query cache so that previously
+        // expanded folders show cached data immediately while refetching.
+        const cachedQueries = queryClient.getQueriesData<
+            ResultOf<typeof collectionListDocument>
+        >({ queryKey: ['childCollections'] });
+        const hydrated: Record<string, { items: Collection[]; totalItems: number }> = {};
+        for (const [queryKey, data] of cachedQueries) {
+            if (!data) continue;
+            const collectionId = queryKey[1] as string;
+            if (!collectionId) continue;
+            const page = queryKey[3] as number;
+            if (page === 0) {
+                hydrated[collectionId] = {
+                    items: data.collections.items,
+                    totalItems: data.collections.totalItems,
+                };
+            } else if (hydrated[collectionId]) {
+                hydrated[collectionId] = {
+                    items: [...hydrated[collectionId].items, ...data.collections.items],
+                    totalItems: data.collections.totalItems,
+                };
+            }
+        }
+        if (Object.keys(hydrated).length > 0) {
+            setAccumulatedChildren(hydrated);
+        }
     }, []);
 
     useQueries({

--- a/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
@@ -69,9 +69,14 @@ function CollectionListPage() {
     useEffect(() => {
         // Hydrate accumulatedChildren from the query cache so that previously
         // expanded folders show cached data immediately while refetching.
-        const cachedQueries = queryClient.getQueriesData<
-            ResultOf<typeof collectionListDocument>
-        >({ queryKey: ['childCollections'] });
+        const cachedQueries = queryClient
+            .getQueriesData<ResultOf<typeof collectionListDocument>>({ queryKey: ['childCollections'] })
+            .sort((a, b) => {
+                // Sort by page number to ensure page 0 is processed first
+                const pageA = (a[0][3] as number) ?? 0;
+                const pageB = (b[0][3] as number) ?? 0;
+                return pageA - pageB;
+            });
         const hydrated: Record<string, { items: Collection[]; totalItems: number }> = {};
         for (const [queryKey, data] of cachedQueries) {
             if (!data) continue;

--- a/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
@@ -11,17 +11,17 @@ import { ExpandedState, getExpandedRowModel } from '@tanstack/react-table';
 import { TableOptions } from '@tanstack/table-core';
 import { ResultOf } from 'gql.tada';
 import { Folder, FolderOpen, PlusIcon } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { toast } from 'sonner';
 
-import { RichTextDescriptionCell } from '@/vdb/components/shared/table-cell/order-table-cell-components.js';
-import { Badge } from '@/vdb/components/ui/badge.js';
 import {
     calculateDragTargetPosition,
     calculateSiblingIndex,
     getItemParentId,
     isCircularReference,
 } from '@/vdb/components/data-table/data-table-utils.js';
+import { RichTextDescriptionCell } from '@/vdb/components/shared/table-cell/order-table-cell-components.js';
+import { Badge } from '@/vdb/components/ui/badge.js';
 import { collectionListDocument, moveCollectionDocument } from './collections.graphql.js';
 import {
     AssignCollectionsToChannelBulkAction,
@@ -32,12 +32,10 @@ import {
 } from './components/collection-bulk-actions.js';
 import { CollectionContentsSheet } from './components/collection-contents-sheet.js';
 
-
 export const Route = createFileRoute('/_authenticated/_collections/collections')({
     component: CollectionListPage,
     loader: () => ({ breadcrumb: () => <Trans>Collections</Trans> }),
 });
-
 
 type Collection = ResultOf<typeof collectionListDocument>['collections']['items'][number];
 
@@ -68,34 +66,41 @@ function CollectionListPage() {
     >({});
     const [nextPageToFetch, setNextPageToFetch] = useState<Record<string, number>>({});
 
+    useEffect(() => {
+        queryClient.invalidateQueries({ queryKey: ['childCollections'] });
+    }, []);
+
     useQueries({
-        queries: expanded === true ? [] : Object.entries(expanded)
-            .filter(([collectionId]) => !accumulatedChildren[collectionId])
-            .map(([collectionId]) => {
-                return {
-                    queryKey: ['childCollections', collectionId, 'page', 0],
-                    queryFn: async () => {
-                        const result = await api.query(collectionListDocument, {
-                            options: {
-                                filter: {
-                                    parentId: { eq: collectionId },
-                                },
-                                take: CHILDREN_PAGE_SIZE,
-                                skip: 0,
-                            },
-                        });
-                        setAccumulatedChildren(prev => ({
-                            ...prev,
-                            [collectionId]: {
-                                items: result.collections.items,
-                                totalItems: result.collections.totalItems,
-                            },
-                        }));
-                        return result;
-                    },
-                    staleTime: 1000 * 60 * 5,
-                } satisfies FetchQueryOptions;
-            }),
+        queries:
+            expanded === true
+                ? []
+                : Object.entries(expanded)
+                      .filter(([collectionId]) => !accumulatedChildren[collectionId])
+                      .map(([collectionId]) => {
+                          return {
+                              queryKey: ['childCollections', collectionId, 'page', 0],
+                              queryFn: async () => {
+                                  const result = await api.query(collectionListDocument, {
+                                      options: {
+                                          filter: {
+                                              parentId: { eq: collectionId },
+                                          },
+                                          take: CHILDREN_PAGE_SIZE,
+                                          skip: 0,
+                                      },
+                                  });
+                                  setAccumulatedChildren(prev => ({
+                                      ...prev,
+                                      [collectionId]: {
+                                          items: result.collections.items,
+                                          totalItems: result.collections.totalItems,
+                                      },
+                                  }));
+                                  return result;
+                              },
+                              staleTime: 1000 * 60 * 5,
+                          } satisfies FetchQueryOptions;
+                      }),
     });
 
     useQueries({
@@ -156,7 +161,10 @@ function CollectionListPage() {
                         _totalItems: childData.totalItems,
                         _loadedItems: childData.items.length,
                         id: `load-more-${row.id}`,
-                        breadcrumbs: [...(row.breadcrumbs || []), { id: row.id, name: row.name, slug: row.slug }],
+                        breadcrumbs: [
+                            ...(row.breadcrumbs || []),
+                            { id: row.id, name: row.name, slug: row.slug },
+                        ],
                     });
                 }
             }
@@ -177,7 +185,12 @@ function CollectionListPage() {
         }));
     };
 
-    const handleReorder = async (oldIndex: number, newIndex: number, item: Collection, allItems?: Collection[]) => {
+    const handleReorder = async (
+        oldIndex: number,
+        newIndex: number,
+        item: Collection,
+        allItems?: Collection[],
+    ) => {
         if (isLoadMoreRow(item as CollectionOrLoadMore)) {
             return;
         }
@@ -214,9 +227,16 @@ function CollectionListPage() {
                 throw new Error('Circular reference detected');
             }
 
-            const adjustedIndex = targetParentId === sourceParentId
-                ? calculateSiblingIndex({ item, oldIndex: adjustedOldIndex, newIndex: adjustedNewIndex, items, parentId: sourceParentId })
-                : initialIndex;
+            const adjustedIndex =
+                targetParentId === sourceParentId
+                    ? calculateSiblingIndex({
+                          item,
+                          oldIndex: adjustedOldIndex,
+                          newIndex: adjustedNewIndex,
+                          items,
+                          parentId: sourceParentId,
+                      })
+                    : initialIndex;
 
             await api.mutate(moveCollectionDocument, {
                 input: {
@@ -245,7 +265,7 @@ function CollectionListPage() {
                 toast.success(t`Collection position updated`);
             } else {
                 queriesToInvalidate.push(
-                    queryClient.invalidateQueries({ queryKey: ['childCollections', targetParentId] })
+                    queryClient.invalidateQueries({ queryKey: ['childCollections', targetParentId] }),
                 );
                 await Promise.all(queriesToInvalidate);
                 toast.success(t`Collection moved to new parent`);
@@ -343,7 +363,9 @@ function CollectionListPage() {
                         return (
                             <div className="flex flex-wrap gap-2">
                                 {children.slice(0, maxDisplay).map(child => (
-                                    <Badge key={child.id} variant="outline">{child.name}</Badge>
+                                    <Badge key={child.id} variant="outline">
+                                        {child.name}
+                                    </Badge>
                                 ))}
                                 {leftOver > 0 ? (
                                     <Badge variant="outline">
@@ -355,13 +377,7 @@ function CollectionListPage() {
                     },
                 },
             }}
-            defaultColumnOrder={[
-                'featuredAsset',
-                'name',
-                'slug',
-                'breadcrumbs',
-                'productVariantCount',
-            ]}
+            defaultColumnOrder={['featuredAsset', 'name', 'slug', 'breadcrumbs', 'productVariantCount']}
             transformData={data => {
                 return addSubCollections(data);
             }}
@@ -392,7 +408,10 @@ function CollectionListPage() {
                                     variant="outline"
                                     onClick={() => handleLoadMoreChildren(original._parentId)}
                                 >
-                                    <Trans>Load {Math.min(remaining, CHILDREN_PAGE_SIZE)} more ({remaining} remaining)</Trans>
+                                    <Trans>
+                                        Load {Math.min(remaining, CHILDREN_PAGE_SIZE)} more ({remaining}{' '}
+                                        remaining)
+                                    </Trans>
                                 </Button>
                             </div>
                         );
@@ -455,4 +474,3 @@ function CollectionListPage() {
         </ListPage>
     );
 }
-

--- a/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
@@ -99,33 +99,31 @@ function CollectionListPage() {
         queries:
             expanded === true
                 ? []
-                : Object.entries(expanded)
-                      .filter(([collectionId]) => !accumulatedChildren[collectionId])
-                      .map(([collectionId]) => {
-                          return {
-                              queryKey: ['childCollections', collectionId, 'page', 0],
-                              queryFn: async () => {
-                                  const result = await api.query(collectionListDocument, {
-                                      options: {
-                                          filter: {
-                                              parentId: { eq: collectionId },
-                                          },
-                                          take: CHILDREN_PAGE_SIZE,
-                                          skip: 0,
+                : Object.entries(expanded).map(([collectionId]) => {
+                      return {
+                          queryKey: ['childCollections', collectionId, 'page', 0],
+                          queryFn: async () => {
+                              const result = await api.query(collectionListDocument, {
+                                  options: {
+                                      filter: {
+                                          parentId: { eq: collectionId },
                                       },
-                                  });
-                                  setAccumulatedChildren(prev => ({
-                                      ...prev,
-                                      [collectionId]: {
-                                          items: result.collections.items,
-                                          totalItems: result.collections.totalItems,
-                                      },
-                                  }));
-                                  return result;
-                              },
-                              staleTime: 1000 * 60 * 5,
-                          } satisfies FetchQueryOptions;
-                      }),
+                                      take: CHILDREN_PAGE_SIZE,
+                                      skip: 0,
+                                  },
+                              });
+                              setAccumulatedChildren(prev => ({
+                                  ...prev,
+                                  [collectionId]: {
+                                      items: result.collections.items,
+                                      totalItems: result.collections.totalItems,
+                                  },
+                              }));
+                              return result;
+                          },
+                          staleTime: 1000 * 60 * 5,
+                      } satisfies FetchQueryOptions;
+                  }),
     });
 
     useQueries({


### PR DESCRIPTION
# Description

When navigating away from the Collections list page and returning via client-side (SPA) navigation, the expand/collapse toggle buttons on collection rows stop working. Clicking the folder icon to expand a collection's children has no effect. A full page reload is required to restore the functionality.

# To Reproduce

Steps to reproduce the behavior:

  1. Go to the Collections list page
  2. Expand one or more collections by clicking the folder icon (verify it works)
  3. Navigate to any other page via the sidebar (e.g., Products)
  4. Navigate back to the Collections list page
  5. Click the folder icon on any collection to expand it

# Fix

Invalidate childCollections queries on component mount so that cached data is refetched and the queryFn correctly populates the local state.
  
# Breaking changes

Maybe check the pagination system ? the useQuery seems to be there for this feature


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
