### PR TITLE
fix(dashboard): Persist collection tree expanded state across navigation

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_collections/collections.tsx
@@ -6,12 +6,12 @@ import { ListPage } from '@/vdb/framework/page/list-page.js';
 import { api } from '@/vdb/graphql/api.js';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { FetchQueryOptions, useQueries, useQueryClient } from '@tanstack/react-query';
-import { createFileRoute, Link } from '@tanstack/react-router';
+import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { ExpandedState, getExpandedRowModel } from '@tanstack/react-table';
 import { TableOptions } from '@tanstack/table-core';
 import { ResultOf } from 'gql.tada';
 import { Folder, FolderOpen, PlusIcon } from 'lucide-react';
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 import { toast } from 'sonner';
 
 import { RichTextDescriptionCell } from '@/vdb/components/shared/table-cell/order-table-cell-components.js';
@@ -33,9 +33,29 @@ import {
 import { CollectionContentsSheet } from './components/collection-contents-sheet.js';
 
 
+function parseExpandedParam(expanded?: string): ExpandedState {
+    if (!expanded) return {};
+    const ids = expanded.split(',').filter(Boolean);
+    return Object.fromEntries(ids.map(id => [id, true]));
+}
+
+function serializeExpandedState(expanded: ExpandedState): string | undefined {
+    if (expanded === true) return undefined;
+    const ids = Object.entries(expanded)
+        .filter(([_, v]) => v)
+        .map(([id]) => id);
+    return ids.length > 0 ? ids.join(',') : undefined;
+}
+
 export const Route = createFileRoute('/_authenticated/_collections/collections')({
     component: CollectionListPage,
     loader: () => ({ breadcrumb: () => <Trans>Collections</Trans> }),
+    validateSearch: (search: Record<string, unknown>) => {
+        return {
+            ...search,
+            expanded: (search.expanded as string) || undefined,
+        };
+    },
 });
 
 
@@ -61,12 +81,28 @@ function isLoadMoreRow(row: CollectionOrLoadMore): row is LoadMoreRow {
 function CollectionListPage() {
     const { t } = useLingui();
     const queryClient = useQueryClient();
-    const [expanded, setExpanded] = useState<ExpandedState>({});
+    const routeSearch = Route.useSearch();
+    const navigate = useNavigate({ from: Route.fullPath });
+    const [expanded, setExpandedState] = useState<ExpandedState>(() => parseExpandedParam(routeSearch.expanded));
     const [searchTerm, setSearchTerm] = useState<string>('');
     const [accumulatedChildren, setAccumulatedChildren] = useState<
         Record<string, { items: Collection[]; totalItems: number }>
     >({});
     const [nextPageToFetch, setNextPageToFetch] = useState<Record<string, number>>({});
+
+    const setExpanded = useCallback((updater: ExpandedState | ((prev: ExpandedState) => ExpandedState)) => {
+        setExpandedState(prev => {
+            const next = typeof updater === 'function' ? updater(prev) : updater;
+            navigate({
+                search: (old: Record<string, unknown>) => ({
+                    ...old,
+                    expanded: serializeExpandedState(next),
+                }),
+                replace: true,
+            });
+            return next;
+        });
+    }, [navigate]);
 
     useQueries({
         queries: expanded === true ? [] : Object.entries(expanded)


### PR DESCRIPTION
# Description

Fixes #4388

When navigating to a collection detail page and back to the collection list, the expanded state of the collection tree was lost — making it impossible to re-expand previously expanded collections without a full page reload.

**Root cause:** The `expanded` state was stored as local React state (`useState`) which gets destroyed when the component unmounts during route navigation.

**Fix:** Persist expanded collection IDs in URL search params (consistent with how the ListPage already persists sort, pagination, and filters). On mount, the expanded state is restored from the URL.

# Breaking changes

None.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)