### PR TITLE
fix(elastic): add configurable precision_threshold to cardinality aggregations

### DIFF
--- a/packages/elasticsearch-plugin/e2e/elasticsearch-plugin-cardinality.e2e-spec.ts
+++ b/packages/elasticsearch-plugin/e2e/elasticsearch-plugin-cardinality.e2e-spec.ts
@@ -1,0 +1,163 @@
+import { Client } from '@elastic/elasticsearch';
+import { DefaultJobQueuePlugin, mergeConfig } from '@vendure/core';
+import { createTestEnvironment } from '@vendure/testing';
+import gql from 'graphql-tag';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
+import {
+    SearchProductsShopQuery,
+    SearchProductsShopQueryVariables,
+} from '../../core/e2e/graphql/generated-e2e-shop-types';
+import { SEARCH_PRODUCTS_SHOP } from '../../core/e2e/graphql/shop-definitions';
+import { awaitRunningJobs } from '../../core/e2e/utils/await-running-jobs';
+import { deleteIndices } from '../src/indexing/indexing-utils';
+import { ElasticsearchPlugin } from '../src/plugin';
+
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { elasticsearchHost, elasticsearchPort } = require('./constants');
+
+const INDEX_PREFIX = 'e2e-cardinality-tests';
+
+/**
+ * Tests for the `cardinalityPrecisionThreshold` SearchConfig option.
+ *
+ * Verifies that setting `cardinalityPrecisionThreshold` correctly propagates
+ * to Elasticsearch cardinality aggregations used in `totalHits()` and
+ * `getDistinctBucketsOfField()`, producing accurate totalItems and
+ * facetValue counts.
+ */
+describe('Elasticsearch plugin cardinalityPrecisionThreshold', () => {
+    const { server, adminClient, shopClient } = createTestEnvironment(
+        mergeConfig(testConfig(), {
+            plugins: [
+                ElasticsearchPlugin.init({
+                    indexPrefix: INDEX_PREFIX,
+                    port: elasticsearchPort,
+                    host: elasticsearchHost,
+                    searchConfig: {
+                        cardinalityPrecisionThreshold: 40000,
+                    },
+                }),
+                DefaultJobQueuePlugin,
+            ],
+        }),
+    );
+
+    beforeAll(async () => {
+        const esClient = new Client({ node: `${elasticsearchHost}:${elasticsearchPort}` });
+        await deleteIndices(esClient, INDEX_PREFIX);
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-full.csv'),
+            customerCount: 1,
+        });
+        await adminClient.asSuperAdmin();
+        await awaitRunningJobs(adminClient, 10_000, 1000);
+        await adminClient.query(REINDEX);
+        await awaitRunningJobs(adminClient);
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    // --- totalHits() with groupByProduct ---
+
+    it('returns correct totalItems when grouped by product', async () => {
+        const { search } = await shopClient.query<SearchProductsShopQuery, SearchProductsShopQueryVariables>(
+            SEARCH_PRODUCTS_SHOP,
+            { input: { groupByProduct: true } },
+        );
+        expect(search.totalItems).toBe(21);
+    });
+
+    it('returns correct totalItems when grouped by SKU', async () => {
+        const { search } = await shopClient.query<SearchProductsShopQuery, SearchProductsShopQueryVariables>(
+            SEARCH_PRODUCTS_SHOP,
+            { input: { groupBySKU: true } },
+        );
+        expect(search.totalItems).toBe(34);
+    });
+
+    it('returns correct totalItems without grouping', async () => {
+        const { search } = await shopClient.query<SearchProductsShopQuery, SearchProductsShopQueryVariables>(
+            SEARCH_PRODUCTS_SHOP,
+            { input: { groupByProduct: false, groupBySKU: false } },
+        );
+        expect(search.totalItems).toBe(35);
+    });
+
+    // --- getDistinctBucketsOfField() with groupByProduct ---
+
+    it('returns correct facetValue counts when grouped by product', async () => {
+        const result = await shopClient.query(SEARCH_GET_FACET_VALUES, {
+            input: { groupByProduct: true },
+        });
+        expect(result.search.facetValues).toEqual([
+            { count: 10, facetValue: { id: 'T_1', name: 'electronics' } },
+            { count: 6, facetValue: { id: 'T_2', name: 'computers' } },
+            { count: 4, facetValue: { id: 'T_3', name: 'photo' } },
+            { count: 7, facetValue: { id: 'T_4', name: 'sports equipment' } },
+            { count: 4, facetValue: { id: 'T_5', name: 'home & garden' } },
+            { count: 4, facetValue: { id: 'T_6', name: 'plants' } },
+        ]);
+    });
+
+    // --- pagination correctness ---
+
+    it('does not produce empty last page when grouped by product', async () => {
+        const { search: countSearch } = await shopClient.query<
+            SearchProductsShopQuery,
+            SearchProductsShopQueryVariables
+        >(SEARCH_PRODUCTS_SHOP, {
+            input: { groupByProduct: true },
+        });
+        const totalItems = countSearch.totalItems;
+        const pageSize = 10;
+        const lastPageSkip = Math.floor((totalItems - 1) / pageSize) * pageSize;
+
+        const { search } = await shopClient.query<SearchProductsShopQuery, SearchProductsShopQueryVariables>(
+            SEARCH_PRODUCTS_SHOP,
+            {
+                input: {
+                    groupByProduct: true,
+                    take: pageSize,
+                    skip: lastPageSkip,
+                },
+            },
+        );
+        expect(search.items.length).toBeGreaterThan(0);
+        expect(search.totalItems).toBe(totalItems);
+    });
+});
+
+const REINDEX = gql`
+    mutation Reindex {
+        reindex {
+            id
+            queueName
+            state
+            progress
+            duration
+            result
+        }
+    }
+`;
+
+const SEARCH_GET_FACET_VALUES = gql`
+    query SearchFacetValues($input: SearchInput!) {
+        search(input: $input) {
+            totalItems
+            facetValues {
+                count
+                facetValue {
+                    id
+                    name
+                }
+            }
+        }
+    }
+`;

--- a/packages/elasticsearch-plugin/src/elasticsearch.service.ts
+++ b/packages/elasticsearch-plugin/src/elasticsearch.service.ts
@@ -275,6 +275,9 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
                 total: {
                     cardinality: {
                         field: groupBySKU ? 'sku.keyword' : 'productId',
+                        ...(searchConfig.cardinalityPrecisionThreshold > 0 && {
+                            precision_threshold: searchConfig.cardinalityPrecisionThreshold,
+                        }),
                     },
                 },
             };
@@ -397,6 +400,9 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
                 total: {
                     cardinality: {
                         field: 'productId',
+                        ...(this.options.searchConfig.cardinalityPrecisionThreshold > 0 && {
+                            precision_threshold: this.options.searchConfig.cardinalityPrecisionThreshold,
+                        }),
                     },
                 },
             };
@@ -407,6 +413,9 @@ export class ElasticsearchService implements OnModuleInit, OnModuleDestroy {
                 total: {
                     cardinality: {
                         field: 'sku.keyword',
+                        ...(this.options.searchConfig.cardinalityPrecisionThreshold > 0 && {
+                            precision_threshold: this.options.searchConfig.cardinalityPrecisionThreshold,
+                        }),
                     },
                 },
             };

--- a/packages/elasticsearch-plugin/src/options.ts
+++ b/packages/elasticsearch-plugin/src/options.ts
@@ -429,6 +429,28 @@ export interface SearchConfig {
      * 10000
      */
     totalItemsMaxSize?: number | boolean;
+    /**
+     * @description
+     * The precision threshold for the
+     * [cardinality aggregation](https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-metrics-cardinality-aggregation.html)
+     * used to count unique products or SKUs when `groupByProduct` or `groupBySKU` is `true`.
+     *
+     * Elasticsearch's cardinality aggregation uses the HyperLogLog++ algorithm which trades
+     * accuracy for memory. The default Elasticsearch `precision_threshold` is `3000`, meaning
+     * counts become approximate for datasets with more than ~3,000 unique values. This can
+     * cause issues such as inflated `totalItems` and empty last pages in paginated results.
+     *
+     * Setting a higher value improves accuracy at the cost of slightly more memory per
+     * aggregation (~8 bytes per unique value up to the threshold). For example, a value of
+     * `40000` uses ~320KB per aggregation and provides exact counts for up to 40,000 unique
+     * products.
+     *
+     * Set to `0` to use the Elasticsearch default of `3000`.
+     *
+     * @default 0
+     * @since 3.5.6
+     */
+    cardinalityPrecisionThreshold?: number;
 
     // prettier-ignore
     /**
@@ -729,6 +751,7 @@ export const defaultOptions: ElasticsearchRuntimeOptions = {
         facetValueMaxSize: 50,
         collectionMaxSize: 50,
         totalItemsMaxSize: 10000,
+        cardinalityPrecisionThreshold: 0,
         multiMatchType: 'best_fields',
         boostFields: {
             productName: 5,


### PR DESCRIPTION
# Description

Elasticsearch's cardinality aggregation uses the HyperLogLog++ algorithm which becomes approximate when the number of unique values exceeds the `precision_threshold` (default: 3000). This causes inflated `totalItems` counts and empty last pages in paginated results for stores with more than ~3,000 unique products.

This PR adds a new `cardinalityPrecisionThreshold` option to `SearchConfig` and applies it to all three cardinality aggregation sites:

- `totalHits()` — counts unique products/SKUs for pagination
- `getDistinctBucketsOfField()` — counts per facet/collection bucket (both `groupByProduct` and `groupBySKU` paths)

The option is only passed to Elasticsearch when explicitly configured, preserving the default ES behavior (`precision_threshold: 3000`) for existing users.

**Usage:**

```ts
ElasticsearchPlugin.init({
  searchConfig: {
    cardinalityPrecisionThreshold: 40000,
  },
}),
```

# Breaking changes

None. The new option is optional and defaults to the existing Elasticsearch behavior.

# Screenshots

N/A

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases
- [x] I have updated the README if needed

