### PR TITLE
fix(docs): Correct typo in EventBus JSDoc

### DIFF
--- a/packages/core/src/event-bus/event-bus.ts
+++ b/packages/core/src/event-bus/event-bus.ts
@@ -62,7 +62,7 @@ export type BlockingEventHandlerOptions<T extends VendureEvent> = {
  * * when an Order transitions state ({@link OrderStateTransitionEvent})
  * * when a Customer registers a new account ({@link AccountRegistrationEvent})
  *
- * Using the EventBus it is possible to subscribe to an take action when these events occur.
+ * Using the EventBus it is possible to subscribe to and take action when these events occur.
  * This is done with the `.ofType()` method, which takes an event type and returns an rxjs observable
  * stream of events:
  *


### PR DESCRIPTION
# Description

While using the EventBus, I noticed a small typo in the JSDoc in the file:

`packages/core/src/event-bus/event-bus.ts`

I corrected the line:

* Using the EventBus it is possible to subscribe to an take action when these events occur.

to:

* Using the EventBus it is possible to subscribe to and take action when these events occur.


I’m not sure it creates much impact, but it confused me for a second, so I thought I’d make a tiny PR.

# Breaking changes

No breaking changes
