### PR TITLE
fix(ci): Remove [skip ci] from generate_docs workflow

### DIFF
--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -114,6 +114,6 @@ jobs:
               run: |
                   git config user.name "${{ steps.app-token.outputs.app-slug }}[bot]"
                   git config user.email "${{ steps.get-user.outputs.user-id }}+${{ steps.app-token.outputs.app-slug }}[bot]@users.noreply.github.com"
-                  message="${AI_MESSAGE:-docs: Generate docs for source changes} [skip ci]"
+                  message="${AI_MESSAGE:-docs: Generate docs for source changes}"
                   git commit -m "$message"
                   git push


### PR DESCRIPTION
# Description

The `generate_docs.yml` workflow appends `[skip ci]` to its commit message, which causes all PR checks (including `build_and_test.yml`) to be skipped since the docs commit becomes the HEAD of the PR branch.

This is the same issue fixed for `docs_ci.yml` in #4611 — but that fix missed `generate_docs.yml`.

Safe to remove because the docs commit only changes `docs/**`, which won't re-trigger:
- `generate_docs.yml` (triggers on `packages/**/*.ts`)
- `build_and_test.yml` (triggers on `packages/**`)

Note: for `pull_request` events, GitHub evaluates paths against the full PR diff (head vs merge base), so workflows will re-trigger on the bot's push — but `concurrency` with `cancel-in-progress: true` handles this, and re-runs exit early with no changes to commit.

Relates to #4611

# Breaking changes

None.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR