### PR TITLE
fix(docs): Fix broken links and outdated type names in custom form components docs

### DIFF
--- a/docs/docs/guides/extending-the-dashboard/custom-form-components/index.mdx
+++ b/docs/docs/guides/extending-the-dashboard/custom-form-components/index.mdx
@@ -413,7 +413,7 @@ import {
     SingleRelationInput,
     createRelationSelectorConfig,
     graphql,
-    CustomFormComponentInputProps,
+    DashboardFormComponentProps,
 } from '@vendure/dashboard';
 
 const productConfig = createRelationSelectorConfig({
@@ -436,7 +436,7 @@ const productConfig = createRelationSelectorConfig({
     }),
 });
 
-export function ProductSelectorComponent({ value, onChange }: CustomFormComponentInputProps) {
+export function ProductSelectorComponent({ value, onChange }: DashboardFormComponentProps) {
     return <SingleRelationInput value={value} onChange={onChange} config={productConfig} />;
 }
 ```
@@ -453,5 +453,5 @@ Features include:
 
 For detailed information about specific types of custom form elements, see these dedicated guides:
 
-- **[Form component examples](./form-component-examples)** - Detailed examples of how to use the APIs available for custom form components.
-- **[Relation selectors](./relation-selectors)** - Build powerful entity selection components with search, pagination, and multi-select capabilities for custom fields and form inputs
+- **[Form component examples](/extending-the-dashboard/custom-form-components/form-component-examples)** - Detailed examples of how to use the APIs available for custom form components.
+- **[Relation selectors](/extending-the-dashboard/custom-form-components/relation-selectors)** - Build powerful entity selection components with search, pagination, and multi-select capabilities for custom fields and form inputs

--- a/docs/docs/guides/extending-the-dashboard/custom-form-components/relation-selectors.mdx
+++ b/docs/docs/guides/extending-the-dashboard/custom-form-components/relation-selectors.mdx
@@ -33,7 +33,7 @@ import {
     createRelationSelectorConfig,
     graphql,
     ResultOf,
-    CustomFormComponentInputProps,
+    DashboardFormComponentProps,
 } from '@vendure/dashboard';
 
 // Define your GraphQL query
@@ -65,7 +65,7 @@ const productConfig = createRelationSelectorConfig({
     }),
 });
 
-export function ProductSelectorComponent({ value, onChange, disabled }: CustomFormComponentInputProps) {
+export function ProductSelectorComponent({ value, onChange, disabled }: DashboardFormComponentProps) {
     return (
         <SingleRelationInput value={value} onChange={onChange} config={productConfig} disabled={disabled} />
     );
@@ -75,9 +75,9 @@ export function ProductSelectorComponent({ value, onChange, disabled }: CustomFo
 ### Multi Selection
 
 ```tsx title="src/plugins/my-plugin/dashboard/components/product-multi-selector.tsx"
-import { MultiRelationInput, CustomFormComponentInputProps } from '@vendure/dashboard';
+import { MultiRelationInput, DashboardFormComponentProps } from '@vendure/dashboard';
 
-export function ProductMultiSelectorComponent({ value, onChange, disabled }: CustomFormComponentInputProps) {
+export function ProductMultiSelectorComponent({ value, onChange, disabled }: DashboardFormComponentProps) {
     return (
         <MultiRelationInput
             value={value || []}
@@ -126,7 +126,7 @@ import {
     createRelationSelectorConfig,
     graphql,
     ResultOf,
-    CustomFormComponentInputProps,
+    DashboardFormComponentProps,
 } from '@vendure/dashboard';
 
 const productListQuery = graphql(`
@@ -184,7 +184,7 @@ const richProductConfig = createRelationSelectorConfig<
     }),
 });
 
-export function RichProductSelectorComponent({ value, onChange, disabled }: CustomFormComponentInputProps) {
+export function RichProductSelectorComponent({ value, onChange, disabled }: DashboardFormComponentProps) {
     return (
         <SingleRelationInput
             value={value}
@@ -204,7 +204,7 @@ import {
     createRelationSelectorConfig,
     graphql,
     ResultOf,
-    CustomFormComponentInputProps,
+    DashboardFormComponentProps,
 } from '@vendure/dashboard';
 
 const customerListQuery = graphql(`
@@ -270,7 +270,7 @@ export function CustomerSelectorWithStatusComponent({
     value,
     onChange,
     disabled,
-}: CustomFormComponentInputProps) {
+}: DashboardFormComponentProps) {
     return (
         <MultiRelationInput
             value={value || []}
@@ -292,7 +292,7 @@ import {
     createRelationSelectorConfig,
     graphql,
     ResultOf,
-    CustomFormComponentInputProps,
+    DashboardFormComponentProps,
 } from '@vendure/dashboard';
 
 const reviewFragment = graphql(`
@@ -338,7 +338,7 @@ const reviewConfig = createRelationSelectorConfig<ResultOf<typeof reviewFragment
     }),
 });
 
-export function ReviewSelectorComponent({ value, onChange }: CustomFormComponentInputProps) {
+export function ReviewSelectorComponent({ value, onChange }: DashboardFormComponentProps) {
     return <SingleRelationInput value={value} onChange={onChange} config={reviewConfig} />;
 }
 ```
@@ -350,7 +350,7 @@ import {
     graphql,
     createRelationSelectorConfig,
     SingleRelationInput,
-    CustomFormComponentInputProps,
+    DashboardFormComponentProps,
 } from '@vendure/dashboard';
 
 const assetListQuery = graphql(`
@@ -383,7 +383,7 @@ const imageAssetConfig = createRelationSelectorConfig({
     }),
 });
 
-export function ImageSelectorComponent({ value, onChange }: CustomFormComponentInputProps) {
+export function ImageSelectorComponent({ value, onChange }: DashboardFormComponentProps) {
     return <SingleRelationInput value={value} onChange={onChange} config={imageAssetConfig} />;
 }
 ```
@@ -395,7 +395,7 @@ import {
     MultiRelationInput,
     createRelationSelectorConfig,
     graphql,
-    CustomFormComponentInputProps,
+    DashboardFormComponentProps,
 } from '@vendure/dashboard';
 
 const customerListQuery = graphql(`
@@ -435,7 +435,7 @@ const activeCustomerConfig = createRelationSelectorConfig({
     }),
 });
 
-export function ActiveCustomerSelectorComponent({ value, onChange }: CustomFormComponentInputProps) {
+export function ActiveCustomerSelectorComponent({ value, onChange }: DashboardFormComponentProps) {
     return <MultiRelationInput value={value || []} onChange={onChange} config={activeCustomerConfig} />;
 }
 ```
@@ -500,15 +500,15 @@ import {
     collectionRelationConfig,
     SingleRelationInput,
     MultiRelationInput,
-    CustomFormComponentInputProps,
+    DashboardFormComponentProps,
 } from '@vendure/dashboard';
 
 // Use pre-built configurations
-export function QuickProductSelector({ value, onChange }: CustomFormComponentInputProps) {
+export function QuickProductSelector({ value, onChange }: DashboardFormComponentProps) {
     return <SingleRelationInput value={value} onChange={onChange} config={productRelationConfig} />;
 }
 
-export function QuickCustomerMultiSelector({ value, onChange }: CustomFormComponentInputProps) {
+export function QuickCustomerMultiSelector({ value, onChange }: DashboardFormComponentProps) {
     return <MultiRelationInput value={value || []} onChange={onChange} config={customerRelationConfig} />;
 }
 ```


### PR DESCRIPTION
# Description

Fixes two issues in the custom form components documentation:

1. **Broken relative links** — The "Further Reading" links at the bottom of the Custom Form Elements page (`/extending-the-dashboard/custom-form-components`) used relative `./` paths to link to child pages. Because the page URL has no trailing slash, the browser resolved these relative to the parent path, producing 404s:
   - `./form-component-examples` → `/extending-the-dashboard/form-component-examples` (broken)
   - `./relation-selectors` → `/extending-the-dashboard/relation-selectors` (broken)

   Fixed by using absolute paths (`/extending-the-dashboard/custom-form-components/form-component-examples`), matching the convention used across all other docs pages.

2. **Outdated type name** — Code examples referenced `CustomFormComponentInputProps` which has been renamed to `DashboardFormComponentProps`. Updated all occurrences in `index.mdx` and `relation-selectors.mdx`.

# Breaking changes

None.

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR