### PR TITLE
fix(ci): Add gate job to unblock non-package PRs

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -51,8 +51,10 @@ jobs:
 
                   base="${{ github.event.pull_request.base.sha }}"
                   if [ -z "$base" ]; then base="${{ github.event.before }}"; fi
-                  if [ -z "$base" ]; then base="HEAD~1"; fi
-                  changed=$(git diff --name-only "$base" HEAD)
+                  if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+                    base="HEAD~1"
+                  fi
+                  changed=$(git diff --name-only "$(git merge-base "$base" HEAD)" HEAD)
 
                   if echo "$changed" | grep -qE '^(packages/|package\.json|package-lock\.json)'; then
                     echo "packages=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -15,10 +15,6 @@ on:
             - master
             - major
             - minor
-        paths:
-            - 'packages/**'
-            - 'package.json'
-            - 'package-lock.json'
 
 env:
     CI: true
@@ -32,10 +28,51 @@ concurrency:
 # When updating the service (version bumps, env changes, health checks), update ALL four copies:
 # e2e-sqljs, e2e-mariadb, e2e-mysql, e2e-postgres.
 jobs:
+    detect-changes:
+        name: detect changes
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+        outputs:
+            packages: ${{ steps.check.outputs.packages }}
+            dashboard: ${{ steps.check.outputs.dashboard }}
+        steps:
+            - uses: actions/checkout@v4
+              with:
+                  fetch-depth: 0
+            - name: Detect changed paths
+              id: check
+              run: |
+                  if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+                    echo "packages=true" >> "$GITHUB_OUTPUT"
+                    echo "dashboard=true" >> "$GITHUB_OUTPUT"
+                    exit 0
+                  fi
+
+                  base="${{ github.event.pull_request.base.sha }}"
+                  if [ -z "$base" ]; then base="${{ github.event.before }}"; fi
+                  if [ -z "$base" ]; then base="HEAD~1"; fi
+                  changed=$(git diff --name-only "$base" HEAD)
+
+                  if echo "$changed" | grep -qE '^(packages/|package\.json|package-lock\.json)'; then
+                    echo "packages=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "packages=false" >> "$GITHUB_OUTPUT"
+                  fi
+
+                  if echo "$changed" | grep -q '^packages/dashboard/'; then
+                    echo "dashboard=true" >> "$GITHUB_OUTPUT"
+                  else
+                    echo "dashboard=false" >> "$GITHUB_OUTPUT"
+                  fi
     codegen:
+        needs: detect-changes
+        if: needs.detect-changes.outputs.packages == 'true'
         uses: ./.github/workflows/codegen.yml
     build:
         name: build
+        needs: detect-changes
+        if: needs.detect-changes.outputs.packages == 'true'
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -46,6 +83,8 @@ jobs:
               run: npm run build
     unit-tests:
         name: unit tests
+        needs: detect-changes
+        if: needs.detect-changes.outputs.packages == 'true'
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -62,32 +101,10 @@ jobs:
               run: npx lerna run ci
             - name: Unit tests
               run: npm run test
-    dashboard-changes:
-        name: check dashboard changes
-        runs-on: ubuntu-latest
-        permissions:
-            contents: read
-        outputs:
-            changed: ${{ steps.check.outputs.changed }}
-        steps:
-            - uses: actions/checkout@v4
-              with:
-                  fetch-depth: 0
-            - name: Check for dashboard changes
-              id: check
-              run: |
-                  base="${{ github.event.pull_request.base.sha }}"
-                  if [ -z "$base" ]; then base="${{ github.event.before }}"; fi
-                  if [ -z "$base" ]; then base="HEAD~1"; fi
-                  if git diff --name-only "$base" HEAD | grep -q '^packages/dashboard/'; then
-                    echo "changed=true" >> "$GITHUB_OUTPUT"
-                  else
-                    echo "changed=false" >> "$GITHUB_OUTPUT"
-                  fi
     dashboard-i18n:
         name: dashboard i18n sync
-        needs: dashboard-changes
-        if: needs.dashboard-changes.outputs.changed == 'true'
+        needs: detect-changes
+        if: needs.detect-changes.outputs.dashboard == 'true'
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -99,8 +116,8 @@ jobs:
               run: bash scripts/check-i18n-sync.sh
     dashboard-e2e:
         name: dashboard e2e (${{ matrix.shard }})
-        needs: dashboard-changes
-        if: needs.dashboard-changes.outputs.changed == 'true'
+        needs: detect-changes
+        if: needs.detect-changes.outputs.dashboard == 'true'
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -133,7 +150,8 @@ jobs:
               working-directory: packages/dashboard
     sonarqube:
         name: SonarQube
-        if: github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork
+        needs: detect-changes
+        if: needs.detect-changes.outputs.packages == 'true' && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork)
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -147,6 +165,8 @@ jobs:
                   SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
     e2e-sqljs:
         name: e2e (sqljs)
+        needs: detect-changes
+        if: needs.detect-changes.outputs.packages == 'true'
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -173,6 +193,8 @@ jobs:
               run: npm run e2e
     e2e-mariadb:
         name: e2e (mariadb)
+        needs: detect-changes
+        if: needs.detect-changes.outputs.packages == 'true'
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -209,6 +231,8 @@ jobs:
               run: npm run e2e
     e2e-mysql:
         name: e2e (mysql)
+        needs: detect-changes
+        if: needs.detect-changes.outputs.packages == 'true'
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -243,6 +267,8 @@ jobs:
               run: npm run e2e
     e2e-postgres:
         name: e2e (postgres)
+        needs: detect-changes
+        if: needs.detect-changes.outputs.packages == 'true'
         runs-on: ubuntu-latest
         permissions:
             contents: read
@@ -276,3 +302,21 @@ jobs:
                   E2E_REDIS_PORT: ${{ job.services.redis.ports['6379'] }}
                   DB: postgres
               run: npm run e2e
+    all-passed:
+        name: all-passed
+        runs-on: ubuntu-latest
+        if: always()
+        needs:
+            - detect-changes
+            - codegen
+            - build
+            - unit-tests
+            - dashboard-i18n
+            - dashboard-e2e
+            - sonarqube
+            - e2e-sqljs
+            - e2e-mariadb
+            - e2e-mysql
+            - e2e-postgres
+        steps:
+            - run: exit ${{ (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) && 1 || 0 }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -307,6 +307,7 @@ jobs:
     all-passed:
         name: all-passed
         runs-on: ubuntu-latest
+        permissions: {}
         if: always()
         needs:
             - detect-changes


### PR DESCRIPTION
## Summary

- Adds an `all-passed` gate job to `build_and_test.yml` that replaces 7 individual required status checks with a single one
- Removes `paths` filter from `pull_request` trigger and adds a `detect-changes` job that conditionally skips expensive jobs (build, unit tests, e2e, codegen, SonarQube) when only non-package files changed
- Docs-only PRs like #4648 now get a passing `all-passed` check immediately instead of being stuck with missing required checks
- Merges the old `dashboard-changes` job into the unified `detect-changes` job
- Uses `git merge-base` for correct PR diff comparison and guards against zero-SHA on new branch pushes

**After merging**, update the Master Branch ruleset to replace the 7 individual required checks with just `all-passed`.

Fixes #4646

## Test plan

- [ ] Verify this PR itself triggers `Build & Test` workflow and `all-passed` reports success (this PR only touches `.github/`, so all package/dashboard jobs should be skipped)
- [ ] Verify a package-changing PR still runs all build/test/e2e jobs as before
- [ ] After merge, update Master Branch ruleset to require only `all-passed`