### PR TITLE
fix(dashboard): Handle empty customFields selection when all fields h…

### DIFF
--- a/packages/core/src/api/resolvers/admin/global-settings.resolver.ts
+++ b/packages/core/src/api/resolvers/admin/global-settings.resolver.ts
@@ -170,6 +170,11 @@ export class GlobalSettingsResolver {
                         }
                         return customFieldConfig;
                     });
+                if (!customFieldsConfig.length) {
+                    // All custom fields were filtered out (e.g. all marked as internal
+                    // or hidden from the dashboard), so skip this entity entirely.
+                    return;
+                }
                 return { entityName: entityType, customFields: customFieldsConfig };
             })
             .filter(notNullOrUndefined);

--- a/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.spec.ts
+++ b/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.spec.ts
@@ -756,6 +756,90 @@ describe('addCustomFields()', () => {
             expect(printed).toContain('vatNumber');
         });
 
+        // https://github.com/vendurehq/vendure/issues/4650
+        // When all custom fields have ui.dashboard: false, the server returns an empty array
+        // for that entity. The dashboard should remove the bare `customFields` field from the
+        // query to avoid a GraphQL error ("must have a selection of subfields").
+        it('Should remove bare customFields field when entity has no custom fields in the map', () => {
+            const documentNode = graphql(`
+                query GetOrder($id: ID!) {
+                    order(id: $id) {
+                        id
+                        code
+                        customFields
+                    }
+                }
+            `);
+
+            // Simulate: Order entity exists in the map but with no custom fields
+            // (all were filtered out due to ui.dashboard: false)
+            const customFieldsConfig = new Map<string, CustomFieldConfig[]>();
+            customFieldsConfig.set('Order', []);
+
+            const result = addCustomFields(documentNode, {
+                customFieldsMap: customFieldsConfig,
+            });
+            const printed = print(result);
+
+            // customFields should be removed entirely to avoid the empty selection set error
+            expect(printed).not.toContain('customFields');
+            expect(printed).toContain('id');
+            expect(printed).toContain('code');
+        });
+
+        // https://github.com/vendurehq/vendure/issues/4650
+        it('Should remove bare customFields field when entity has no custom fields in the map at all', () => {
+            const documentNode = graphql(`
+                query GetOrder($id: ID!) {
+                    order(id: $id) {
+                        id
+                        code
+                        customFields
+                    }
+                }
+            `);
+
+            // Simulate: Order entity is not in the map at all
+            const customFieldsConfig = new Map<string, CustomFieldConfig[]>();
+
+            const result = addCustomFields(documentNode, {
+                customFieldsMap: customFieldsConfig,
+            });
+            const printed = print(result);
+
+            // customFields should be removed entirely
+            expect(printed).not.toContain('customFields');
+        });
+
+        // https://github.com/vendurehq/vendure/issues/4650
+        it('Should remove bare customFields when includeCustomFields filter removes all fields', () => {
+            const documentNode = graphql(`
+                query GetOrder($id: ID!) {
+                    order(id: $id) {
+                        id
+                        code
+                        customFields
+                    }
+                }
+            `);
+
+            const customFieldsConfig = new Map<string, CustomFieldConfig[]>();
+            customFieldsConfig.set('Order', [
+                { name: 'field1', type: 'string', list: false },
+                { name: 'field2', type: 'string', list: false },
+            ]);
+
+            // includeCustomFields filter doesn't match any fields
+            const result = addCustomFields(documentNode, {
+                customFieldsMap: customFieldsConfig,
+                includeCustomFields: ['nonExistentField'],
+            });
+            const printed = print(result);
+
+            // customFields should be removed entirely
+            expect(printed).not.toContain('customFields');
+        });
+
         it('Works with the timing issue - called later when globalCustomFieldsMap is populated', () => {
             const orderLineFragment = graphql(`
                 fragment OrderLine on OrderLine {
@@ -910,6 +994,57 @@ describe('addCustomFieldsToFragment()', () => {
                 fragment Product on Product {
                     id
                     name
+                }
+            `),
+            );
+        });
+
+        // https://github.com/vendurehq/vendure/issues/4650
+        it('Removes bare customFields from fragment when entity has empty custom fields array', () => {
+            const fragmentDocument = graphql(`
+                fragment Order on Order {
+                    id
+                    code
+                    customFields
+                }
+            `);
+            const customFieldsConfig = new Map<string, CustomFieldConfig[]>();
+            customFieldsConfig.set('Order', []);
+
+            const result = addCustomFieldsToFragment(fragmentDocument, {
+                customFieldsMap: customFieldsConfig,
+            });
+
+            expect(print(result)).toBe(
+                normalizeIndentation(`
+                fragment Order on Order {
+                    id
+                    code
+                }
+            `),
+            );
+        });
+
+        // https://github.com/vendurehq/vendure/issues/4650
+        it('Removes bare customFields from fragment when entity is not in custom fields map', () => {
+            const fragmentDocument = graphql(`
+                fragment Order on Order {
+                    id
+                    code
+                    customFields
+                }
+            `);
+            const customFieldsConfig = new Map<string, CustomFieldConfig[]>();
+
+            const result = addCustomFieldsToFragment(fragmentDocument, {
+                customFieldsMap: customFieldsConfig,
+            });
+
+            expect(print(result)).toBe(
+                normalizeIndentation(`
+                fragment Order on Order {
+                    id
+                    code
                 }
             `),
             );

--- a/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.spec.ts
+++ b/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.spec.ts
@@ -756,6 +756,62 @@ describe('addCustomFields()', () => {
             expect(printed).toContain('vatNumber');
         });
 
+        it('Works with the timing issue - called later when globalCustomFieldsMap is populated', () => {
+            const orderLineFragment = graphql(`
+                fragment OrderLine on OrderLine {
+                    id
+                    quantity
+                }
+            `);
+
+            const orderDetailFragment = graphql(
+                `
+                    fragment OrderDetail on Order {
+                        id
+                        code
+                        lines {
+                            ...OrderLine
+                        }
+                    }
+                `,
+                [orderLineFragment],
+            );
+
+            const orderDetailDocument = graphql(
+                `
+                    query GetOrder($id: ID!) {
+                        order(id: $id) {
+                            ...OrderDetail
+                        }
+                    }
+                `,
+                [orderDetailFragment],
+            );
+
+            // Initially, globalCustomFieldsMap is empty (simulating module load time)
+            const customFieldsConfig = new Map<string, CustomFieldConfig[]>();
+            // Documents are created...
+
+            // Later, when server config is loaded and custom fields are available
+            customFieldsConfig.set('Order', [{ name: 'orderCustomField', type: 'string', list: false }]);
+            customFieldsConfig.set('OrderLine', [
+                { name: 'orderLineCustomField', type: 'string', list: false },
+            ]);
+
+            // Now when addCustomFields is called (e.g., in a component), it has access to custom fields
+            const result = addCustomFields(orderDetailDocument, {
+                customFieldsMap: customFieldsConfig,
+                includeNestedFragments: ['OrderLine'], // Explicitly include nested OrderLine fragment
+            });
+            const printed = print(result);
+
+            // Should add customFields to both Order and OrderLine
+            expect(printed).toContain('orderCustomField');
+            expect(printed).toContain('orderLineCustomField');
+        });
+    });
+
+    describe('Empty custom fields handling', () => {
         // https://github.com/vendurehq/vendure/issues/4650
         // When all custom fields have ui.dashboard: false, the server returns an empty array
         // for that entity. The dashboard should remove the bare `customFields` field from the
@@ -809,60 +865,6 @@ describe('addCustomFields()', () => {
 
             // customFields should be removed entirely
             expect(printed).not.toContain('customFields');
-        });
-
-        it('Works with the timing issue - called later when globalCustomFieldsMap is populated', () => {
-            const orderLineFragment = graphql(`
-                fragment OrderLine on OrderLine {
-                    id
-                    quantity
-                }
-            `);
-
-            const orderDetailFragment = graphql(
-                `
-                    fragment OrderDetail on Order {
-                        id
-                        code
-                        lines {
-                            ...OrderLine
-                        }
-                    }
-                `,
-                [orderLineFragment],
-            );
-
-            const orderDetailDocument = graphql(
-                `
-                    query GetOrder($id: ID!) {
-                        order(id: $id) {
-                            ...OrderDetail
-                        }
-                    }
-                `,
-                [orderDetailFragment],
-            );
-
-            // Initially, globalCustomFieldsMap is empty (simulating module load time)
-            const customFieldsConfig = new Map<string, CustomFieldConfig[]>();
-            // Documents are created...
-
-            // Later, when server config is loaded and custom fields are available
-            customFieldsConfig.set('Order', [{ name: 'orderCustomField', type: 'string', list: false }]);
-            customFieldsConfig.set('OrderLine', [
-                { name: 'orderLineCustomField', type: 'string', list: false },
-            ]);
-
-            // Now when addCustomFields is called (e.g., in a component), it has access to custom fields
-            const result = addCustomFields(orderDetailDocument, {
-                customFieldsMap: customFieldsConfig,
-                includeNestedFragments: ['OrderLine'], // Explicitly include nested OrderLine fragment
-            });
-            const printed = print(result);
-
-            // Should add customFields to both Order and OrderLine
-            expect(printed).toContain('orderCustomField');
-            expect(printed).toContain('orderLineCustomField');
         });
     });
 });

--- a/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.spec.ts
+++ b/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.spec.ts
@@ -811,35 +811,6 @@ describe('addCustomFields()', () => {
             expect(printed).not.toContain('customFields');
         });
 
-        // https://github.com/vendurehq/vendure/issues/4650
-        it('Should remove bare customFields when includeCustomFields filter removes all fields', () => {
-            const documentNode = graphql(`
-                query GetOrder($id: ID!) {
-                    order(id: $id) {
-                        id
-                        code
-                        customFields
-                    }
-                }
-            `);
-
-            const customFieldsConfig = new Map<string, CustomFieldConfig[]>();
-            customFieldsConfig.set('Order', [
-                { name: 'field1', type: 'string', list: false },
-                { name: 'field2', type: 'string', list: false },
-            ]);
-
-            // includeCustomFields filter doesn't match any fields
-            const result = addCustomFields(documentNode, {
-                customFieldsMap: customFieldsConfig,
-                includeCustomFields: ['nonExistentField'],
-            });
-            const printed = print(result);
-
-            // customFields should be removed entirely
-            expect(printed).not.toContain('customFields');
-        });
-
         it('Works with the timing issue - called later when globalCustomFieldsMap is populated', () => {
             const orderLineFragment = graphql(`
                 fragment OrderLine on OrderLine {

--- a/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.ts
+++ b/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.ts
@@ -115,12 +115,13 @@ function applyCustomFieldsToSelection(
     }
 
     const customFieldsForType = customFields.get(entityType);
+
+    // Check if there is already a customFields field in the fragment
+    const existingCustomFieldsField = selectionSet.selections.find(
+        selection => isFieldNode(selection) && selection.name.value === 'customFields',
+    ) as FieldNode | undefined;
+
     if (customFieldsForType && customFieldsForType.length) {
-        // Check if there is already a customFields field in the fragment
-        // to avoid duplication
-        const existingCustomFieldsField = selectionSet.selections.find(
-            selection => isFieldNode(selection) && selection.name.value === 'customFields',
-        ) as FieldNode | undefined;
         const selectionNodes: SelectionNode[] = customFieldsForType
             .filter(
                 field => !options?.includeCustomFields || options?.includeCustomFields.includes(field.name),
@@ -163,6 +164,19 @@ function applyCustomFieldsToSelection(
                             : {}),
                     }) as FieldNode,
             );
+
+        // If after filtering there are no custom fields to select,
+        // remove any existing bare customFields field to avoid an empty selection set
+        if (selectionNodes.length === 0) {
+            if (existingCustomFieldsField) {
+                const index = (selectionSet.selections as SelectionNode[]).indexOf(existingCustomFieldsField);
+                if (index >= 0) {
+                    (selectionSet.selections as SelectionNode[]).splice(index, 1);
+                }
+            }
+            return;
+        }
+
         if (!existingCustomFieldsField) {
             // If no customFields field exists, add one
             (selectionSet.selections as SelectionNode[]).push({
@@ -214,6 +228,14 @@ function applyCustomFieldsToSelection(
                     ),
                 },
             });
+        }
+    } else if (existingCustomFieldsField) {
+        // If there are no custom fields for this type (e.g. all marked with ui.dashboard: false),
+        // but there is a bare `customFields` field in the document, remove it to prevent
+        // a GraphQL error ("must have a selection of subfields")
+        const index = (selectionSet.selections as SelectionNode[]).indexOf(existingCustomFieldsField);
+        if (index >= 0) {
+            (selectionSet.selections as SelectionNode[]).splice(index, 1);
         }
     }
 }

--- a/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.ts
+++ b/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.ts
@@ -165,18 +165,6 @@ function applyCustomFieldsToSelection(
                     }) as FieldNode,
             );
 
-        // If after filtering there are no custom fields to select,
-        // remove any existing bare customFields field to avoid an empty selection set
-        if (selectionNodes.length === 0) {
-            if (existingCustomFieldsField) {
-                const index = (selectionSet.selections as SelectionNode[]).indexOf(existingCustomFieldsField);
-                if (index >= 0) {
-                    (selectionSet.selections as SelectionNode[]).splice(index, 1);
-                }
-            }
-            return;
-        }
-
         if (!existingCustomFieldsField) {
             // If no customFields field exists, add one
             (selectionSet.selections as SelectionNode[]).push({


### PR DESCRIPTION
# Description

Fixes https://github.com/vendurehq/vendure/issues/4650

When all custom fields of an entity have `ui: { dashboard: false }`, the dashboard's GraphQL queries include a bare `customFields` field with no subfield selections, causing a GraphQL error:

> Field "customFields" of type "OrderCustomFields" must have a selection of subfields. Did you mean "customFields { ... }"?

This happens because many GraphQL fragments (e.g. `orderDetailFragment`) contain a bare `customFields` placeholder that `addCustomFields()` is supposed to expand with the specific subfields. When all fields are filtered out, the bare `customFields` was left as-is, producing invalid GraphQL.

**Root cause:** Two gaps in the custom fields handling:

1. **Dashboard (`add-custom-fields.ts`):** `applyCustomFieldsToSelection()` did not remove pre-existing bare `customFields` fields when there were no visible custom fields to select. When `customFieldsForType` is empty or missing from the map, the main `if` block is skipped but the bare `customFields` in the fragment remains, causing the GraphQL error.

2. **Server (`global-settings.resolver.ts`):** `generateEntityCustomFieldConfig()` returned entities with empty `customFields` arrays when all fields had `dashboard: false`, instead of omitting them entirely.

**Fix:**

- In `applyCustomFieldsToSelection()`: added an `else if` branch that detects and removes bare `customFields` fields when the entity has no visible custom fields in the map (via `splice` on the selections array, consistent with existing in-place mutation pattern used throughout the function).
- In `generateEntityCustomFieldConfig()`: skip entities where all custom fields were filtered out after applying `internal` and `dashboard: false` filters.

> **_Note:_** _The same issue can also occur inside the main `if` block when the `includeCustomFields` option filters out all fields (resulting in an empty `selectionNodes` array that gets pushed as `customFields { }`). However, `includeCustomFields` is currently not used anywhere in the dashboard app — it only exists as an API for potential dashboard extensions. Happy to add a guard for that path as well if needed._

# Breaking changes

None. This is a bug fix. Custom fields with `ui: { dashboard: false }` now work correctly when applied to all fields of an entity.

# Checklist

📌 Always:

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:

- [x] I have added or updated test cases
- [ ] I have updated the README if needed
