### PR TITLE
fix(core): Fix shipping tax calculation in cancelShipping

### DIFF
--- a/packages/core/src/service/helpers/order-modifier/order-modifier.ts
+++ b/packages/core/src/service/helpers/order-modifier/order-modifier.ts
@@ -349,7 +349,9 @@ export class OrderModifier {
                     adjustmentSource: 'CANCEL_ORDER',
                     type: AdjustmentType.OTHER,
                     description: 'shipping cancellation',
-                    amount: -shippingLine.discountedPrice,
+                    amount: shippingLine.listPriceIncludesTax
+                        ? -shippingLine.discountedPriceWithTax
+                        : -shippingLine.discountedPrice,
                     data: {},
                 });
                 await this.connection.getRepository(ctx, ShippingLine).save(shippingLine, { reload: false });


### PR DESCRIPTION
# Description
Calling `cancelOrder` with `cancelShipping: true` on a channel where `pricesIncludeTax: true` leaves tax residue on the shipping line instead of fully zeroing it out. The order's `totalWithTax` is non-zero after "cancellation".

The bug manifests whenever the shipping line is tax-inclusive — either because the `ShippingMethod`'s `includesTax` is `include`, or because it's `inherit` and the channel's `pricesIncludeTax` is `true`. The same code path is used by `refundOrder` via order modifications, so that flow is affected too.

**Example:** 
shipping = `10 SEK incl. / 8 SEK excl.` (25% tax). 
After cancellation: discount `-8 SEK incl. / -6.40 SEK excl.` and shipping line `2 SEK incl. / 1.60 SEK excl.` remain — should be all zero.

# Breaking changes
No breaking changes.  

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
