### PR TITLE
fix(admin-ui): Handle tokenMethod array form when generating ui-config (#4656)

### DIFF
--- a/packages/admin-ui-plugin/src/plugin.ts
+++ b/packages/admin-ui-plugin/src/plugin.ts
@@ -305,14 +305,15 @@ export class AdminUiPlugin implements NestModule {
                 return partialConfig ? (partialConfig as AdminUiConfig)[prop] || defaultVal : defaultVal;
             }
         };
+        const serverTokenMethod = authOptions.tokenMethod;
+        const serverUsesBearer =
+            serverTokenMethod === 'bearer' ||
+            (Array.isArray(serverTokenMethod) && serverTokenMethod.includes('bearer'));
         return {
             adminApiPath: propOrDefault('adminApiPath', apiOptions.adminApiPath),
             apiHost: propOrDefault('apiHost', 'auto'),
             apiPort: propOrDefault('apiPort', 'auto'),
-            tokenMethod: propOrDefault(
-                'tokenMethod',
-                authOptions.tokenMethod === 'bearer' ? 'bearer' : 'cookie',
-            ),
+            tokenMethod: propOrDefault('tokenMethod', serverUsesBearer ? 'bearer' : 'cookie'),
             authTokenHeaderKey: propOrDefault(
                 'authTokenHeaderKey',
                 authOptions.authTokenHeaderKey || DEFAULT_AUTH_TOKEN_HEADER_KEY,

--- a/packages/dashboard/vite/utils/ui-config.ts
+++ b/packages/dashboard/vite/utils/ui-config.ts
@@ -19,13 +19,17 @@ export function getUiConfig(
 ): Omit<ResolvedUiConfig, 'version'> {
     const { authOptions, apiOptions } = config;
 
+    const serverTokenMethod = authOptions.tokenMethod;
+    const serverUsesBearer =
+        serverTokenMethod === 'bearer' ||
+        (Array.isArray(serverTokenMethod) && serverTokenMethod.includes('bearer'));
+
     // Merge API configuration with defaults
     const api = {
         adminApiPath: pluginOptions.api?.adminApiPath ?? apiOptions.adminApiPath ?? ADMIN_API_PATH,
         host: pluginOptions.api?.host ?? 'auto',
         port: pluginOptions.api?.port ?? 'auto',
-        tokenMethod:
-            pluginOptions.api?.tokenMethod ?? (authOptions.tokenMethod === 'bearer' ? 'bearer' : 'cookie'),
+        tokenMethod: pluginOptions.api?.tokenMethod ?? (serverUsesBearer ? 'bearer' : 'cookie'),
         authTokenHeaderKey:
             pluginOptions.api?.authTokenHeaderKey ??
             authOptions.authTokenHeaderKey ??


### PR DESCRIPTION
# Description

Fixes #4656.

When `authOptions.tokenMethod` is configured as an array (e.g. `['bearer']` or `['cookie', 'bearer']`), the Admin UI and Dashboard failed to recognize the bearer token method. The root cause was in the config-generation layer: both `AdminUiPlugin` (for the legacy Angular Admin UI) and the dashboard's Vite `getUiConfig()` helper used a strict `authOptions.tokenMethod === 'bearer'` comparison, which silently falls back to `'cookie'` for any array value. The resulting `ui-config.json` / virtual ui-config module therefore advertised `tokenMethod: 'cookie'` even when bearer was configured, so the UI never sent the `Authorization` header nor stored auth tokens from responses.

This PR normalizes the array form at the point where the server config is translated into the UI-facing config, mirroring the pattern already used elsewhere in core (`bootstrap.ts`, `set-session-token.ts`, `extract-session-token.ts`):

```ts
const serverUsesBearer =
    serverTokenMethod === 'bearer' ||
    (Array.isArray(serverTokenMethod) && serverTokenMethod.includes('bearer'));
```

Changes:
- `packages/admin-ui-plugin/src/plugin.ts` — normalize `authOptions.tokenMethod` before writing it into the generated `vendure-ui-config.json`.
- `packages/dashboard/vite/utils/ui-config.ts` — same normalization in the Dashboard's Vite ui-config builder.

Because the normalization happens before the value reaches the UI, no changes are needed in the Admin UI runtime (`data.module.ts`, `interceptor.ts`) or in the `AdminUiConfig` type — they continue to see a concrete `'cookie' | 'bearer'` value.

# Breaking changes

None. The change only affects the previously-broken path where `authOptions.tokenMethod` was supplied as an array — that path now behaves the same as the equivalent string form.

# Screenshots

N/A — server/build-time configuration change, no visual impact.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed