### PR TITLE
fix(dashboard): Inline route literal for tanstack router-generator

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -64,6 +64,7 @@
         "@babel/core": "^7.29.0",
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
+        "@base-ui/react": "^1.2.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -64,7 +64,6 @@
         "@babel/core": "^7.29.0",
         "@babel/preset-react": "^7.28.5",
         "@babel/preset-typescript": "^7.28.5",
-        "@base-ui/react": "^1.2.0",
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/modifiers": "^9.0.0",
         "@dnd-kit/sortable": "^10.0.0",

--- a/packages/dashboard/src/app/routes/_authenticated.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated.tsx
@@ -1,9 +1,10 @@
 import { AppLayout } from '@/vdb/components/layout/app-layout.js';
-import { AUTHENTICATED_ROUTE_PREFIX } from '@/vdb/constants.js';
 import { useAuth } from '@/vdb/hooks/use-auth.js';
 import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
 
-export const Route = createFileRoute(AUTHENTICATED_ROUTE_PREFIX)({
+// Must be a string literal to satisfy @tanstack/router-generator static analysis.
+// Keep in sync with AUTHENTICATED_ROUTE_PREFIX in @/vdb/constants.js.
+export const Route = createFileRoute('/_authenticated')({
     beforeLoad: ({ context, location }) => {
         if (!context.auth.isAuthenticated) {
             throw redirect({

--- a/packages/dashboard/src/lib/constants.ts
+++ b/packages/dashboard/src/lib/constants.ts
@@ -1,6 +1,7 @@
 import { schemaCurrencyCodes } from '@/vdb/graphql/schema-enums.js';
 
 export const NEW_ENTITY_PATH = 'new';
+// Must match the literal passed to createFileRoute() in src/app/routes/_authenticated.tsx.
 export const AUTHENTICATED_ROUTE_PREFIX = '/_authenticated';
 export const DEFAULT_CHANNEL_CODE = '__default_channel__';
 export const SUPER_ADMIN_ROLE_CODE = '__super_admin_role__';

--- a/packages/dashboard/src/lib/framework/page/use-extended-router.tsx
+++ b/packages/dashboard/src/lib/framework/page/use-extended-router.tsx
@@ -29,6 +29,15 @@ export const useExtendedRouter = (
         );
 
         if (authenticatedRouteIndex === -1) {
+            if (process.env.NODE_ENV !== 'production') {
+                console.error(
+                    `[Dashboard] Could not find authenticated route with id ` +
+                        `"${AUTHENTICATED_ROUTE_PREFIX}" in the route tree. Extension routes ` +
+                        `marked as authenticated will not be registered. This usually indicates a drift ` +
+                        `between AUTHENTICATED_ROUTE_PREFIX (src/lib/constants.ts) and the ` +
+                        `route id generated from src/app/routes/_authenticated.tsx.`,
+                );
+            }
             // No authenticated route found, return router with base tree
             return createExtendedRouter(routerOptions, routeTree);
         }

--- a/packages/dashboard/src/lib/framework/page/use-extended-router.tsx
+++ b/packages/dashboard/src/lib/framework/page/use-extended-router.tsx
@@ -33,7 +33,7 @@ export const useExtendedRouter = (
                 console.error(
                     `[Dashboard] Could not find authenticated route with id ` +
                         `"${AUTHENTICATED_ROUTE_PREFIX}" in the route tree. Extension routes ` +
-                        `marked as authenticated will not be registered. This usually indicates a drift ` +
+                        `will not be registered. This usually indicates a drift ` +
                         `between AUTHENTICATED_ROUTE_PREFIX (src/lib/constants.ts) and the ` +
                         `route id generated from src/app/routes/_authenticated.tsx.`,
                 );


### PR DESCRIPTION
## Summary
Inline the literal `'/_authenticated'` in `createFileRoute()` so `@tanstack/router-generator` v1.166+ stops erroring when building projects upgraded to v3.6.2. The `AUTHENTICATED_ROUTE_PREFIX` constant is kept — it's still used for extension-route lookup in `use-extended-router.tsx` and is a public API export.

Also adds a dev-mode `console.error` in `use-extended-router.tsx` when the authenticated route cannot be found during extension-route grafting. Previously this condition silently returned the un-extended tree, so any drift between the inlined route literal and the `AUTHENTICATED_ROUTE_PREFIX` constant would make all authenticated extension routes disappear with zero feedback.

## Context
The route literal and the constant now share an implicit invariant: the filename `_authenticated.tsx` → the tanstack-derived route id → the constant's value. Sync-reminder comments added in both locations; the dev-mode assertion catches any runtime drift.

## Scope narrowed — why the `@base-ui/react` half isn't here
The original issue also reported a "Rollup failed to resolve `@base-ui/react`" error. We could not reproduce this in a clean `@vendure/create@3.6.1 → 3.6.2` scaffold under either npm or pnpm — both resolve the package via `@vendure-io/ui`'s transitive install and Rollup bundles successfully.

The reporter's case (nested `node_modules/@vendure-io/ui/node_modules/@base-ui/react`) is the npm behaviour when hoisting is blocked — typically another top-level dep pinning a conflicting `@base-ui/react` version, a stale lockfile, or a custom `.npmrc`. An initial commit on this branch defensively declared `@base-ui/react` as a direct dep of `@vendure/dashboard`, but we reverted it because:
1. It papers over a symptom we can't reproduce or verify.
2. The real structural issue is that `@vendure/dashboard` shouldn't be touching `@base-ui/react` at all — it currently does so only for **type-only** references when overriding subcomponents of `@vendure-io/ui` wrappers (`DialogTitle`, `AlertDialogTitle`) and one full reimplementation (`collapsible.tsx`). That's a `@vendure-io/ui` API gap, not a resolution problem.

### Follow-ups (filed, not in this PR)
- **vendurehq/design#10** — `@vendure-io/ui` should re-export `DialogPrimitive`, `AlertDialogPrimitive`, `CollapsiblePrimitive` namespaces. Once done, `@vendure/dashboard` drops any `@base-ui/react` reference and this entire class of resolution issue disappears.
- Comment on #4655 requesting the reporter's lockfile / package manager info so we can reproduce and, if needed, ship a targeted fix.
- Internal tracker: `@vendure/create`'s scaffold template is missing `vite` as a direct dep, which breaks under pnpm strict. Filed separately.

## Test plan
- [x] Reproduced the original tanstack error: `npx @vendure/create@3.6.1 my-app --ci`, upgrade all `@vendure/*` packages to `3.6.2`, run `npm run build:dashboard` — error fires under npm and pnpm.
- [x] Patched the installed dashboard with the route-literal fix and rebuilt — error silenced, clean build.
- [ ] CI: lint + typecheck + tests pass.
- [ ] Manual smoke test: run dashboard dev server, confirm extension routes still graft under `_authenticated`.

## Commits in this PR
Two commits (will squash on merge); net effect is route-literal inlining + dev-mode guard + sync-reminder comments. `package.json` unchanged.

Fixes #4655