### PR TITLE
fix(core): Avoid OOM in product-to-channel assign/remove via query relation strategy

### DIFF
--- a/packages/core/src/service/services/product.service.ts
+++ b/packages/core/src/service/services/product.service.ts
@@ -331,6 +331,8 @@ export class ProductService {
         const productsWithVariants = await this.connection.getRepository(ctx, Product).find({
             where: { id: In(input.productIds) },
             relations: ['variants', 'assets', 'optionGroups', 'optionGroups.options'],
+            relationLoadStrategy: 'query',
+            loadEagerRelations: false,
         });
         const productIds = unique(productsWithVariants.map(p => p.id));
         await Promise.all(
@@ -379,6 +381,8 @@ export class ProductService {
         const productsWithVariants = await this.connection.getRepository(ctx, Product).find({
             where: { id: In(input.productIds) },
             relations: ['variants', 'optionGroups', 'optionGroups.options'],
+            relationLoadStrategy: 'query',
+            loadEagerRelations: false,
         });
         await this.productVariantService.removeProductVariantsFromChannel(ctx, {
             productVariantIds: ([] as ID[]).concat(


### PR DESCRIPTION
## Description

`ProductService.assignProductsToChannel` and `removeProductsFromChannel` load products with relations `['variants', 'assets', 'optionGroups', 'optionGroups.options']` using TypeORM's default join strategy. This produces a cartesian product (variant × asset × optionGroup × option) — TypeORM hydrates every duplicated row into entities before deduping, so heap usage scales with join-row count, not distinct entities. Even single-product calls can spike memory severely; batched channel assignment OOMs.

Switching to `relationLoadStrategy: 'query'` with `loadEagerRelations: false` makes TypeORM issue one query per relation, eliminating the cartesian blow-up. Downstream code in both methods only consumes the IDs of the explicitly-listed relations, so disabling eager relations on these reads is safe.

### Benchmark (1 product, 20 variants, 2 option groups, `@vendure/core` 3.6.2)

| Strategy | Time | Heap delta |
|---|---|---|
| default join | 1956 ms | +274.7 MB |
| query + no eager | 44 ms | ~0 MB |

**Testing:** ran locally — `packages/core` unit suite (811/811), plus `product-channel`, `asset-channel`, and `channel` e2e suites (62/62) all pass against the fix.

## Breaking changes

None. Public API and behavior unchanged; only the internal relation-load strategy changes.

## Screenshots

N/A (backend perf fix).

## Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [ ] I have added or updated test cases
- [x] I have updated the README if needed