### PR TITLE
fix(core): Handle undefined relation in entity hydrator

### DIFF
--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+
+import { EntityHydrator } from './entity-hydrator.service';
+
+describe('EntityHydrator', () => {
+    describe('getRelationEntityAtPath()', () => {
+        // https://github.com/vendurehq/vendure/issues/4661
+        it('treats undefined intermediate relations as terminal values', () => {
+            const hydrator = new EntityHydrator(undefined as any, undefined as any, undefined as any);
+            const translation = { languageCode: 'en', name: 'Laptop' };
+            const order = {
+                lines: [
+                    {
+                        productVariant: {
+                            translations: [translation],
+                        },
+                    },
+                    {
+                        productVariant: undefined,
+                    },
+                ],
+            };
+
+            const result = (hydrator as any).getRelationEntityAtPath(order, [
+                'lines',
+                'productVariant',
+                'translations',
+            ]);
+
+            expect(result).toEqual([translation, undefined]);
+        });
+    });
+});

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -277,7 +277,7 @@ export class EntityHydrator {
                         visit(item, parts.slice());
                     }
                 }
-            } else if (target === null) {
+            } else if (target == null) {
                 result.push(target);
             } else {
                 if (parts.length === 0) {


### PR DESCRIPTION
# Description

Fixes #4661.

This PR updates `EntityHydrator.getRelationEntityAtPath()` so that an `undefined` intermediate relation is treated the same way as `null`.

Previously, the helper stopped traversing when a relation was `null`, but continued traversing when it was `undefined`. For a path such as `lines.productVariant.translations`, this could cause a `TypeError` when one `OrderLine` had `productVariant: undefined`.

A focused regression test has been added for this case.

# Breaking changes

No breaking changes.

# Screenshots

N/A. This is a server-side bug fix.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
