### PR TITLE
fix(dashboard): Support action bar positioning relative to extensions

### DIFF
--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
@@ -266,4 +266,23 @@ describe('PageLayout', () => {
 
         expect(getRenderedActionBarIds(markup)).toEqual(['b', 'a', 'save-button']);
     });
+
+    it('renders a positioned extension action bar item when its target is missing', () => {
+        registerActionBarItem('orphan', { itemId: 'missing', order: 'before' });
+
+        const markup = renderActionBar();
+
+        expect(getRenderedActionBarIds(markup)).toEqual(['save-button', 'orphan']);
+    });
+
+    it('renders cyclic positioned extension action bar items without dropping them', () => {
+        registerActionBarItem('a', { itemId: 'b', order: 'before' });
+        registerActionBarItem('b', { itemId: 'a', order: 'before' });
+
+        const markup = renderActionBar();
+        const renderedIds = getRenderedActionBarIds(markup);
+
+        expect(renderedIds).toHaveLength(3);
+        expect(renderedIds).toEqual(expect.arrayContaining(['a', 'b', 'save-button']));
+    });
 });

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { PageBlock, PageLayout } from './page-layout.js';
-import { registerDashboardPageBlock } from './layout-extensions.js';
+import { ActionBarItem } from './action-bar-item-wrapper.js';
+import { PageActionBar, PageBlock, PageLayout } from './page-layout.js';
+import { registerDashboardActionBarItem, registerDashboardPageBlock } from './layout-extensions.js';
 import { PageContext } from './page-provider.js';
 import { globalRegistry } from '../registry/global-registry.js';
 import { UserSettingsContext, type UserSettingsContextType } from '../../providers/user-settings.js';
+import type { ActionBarItemPosition } from '../extension-api/types/layout.js';
 
 const useIsMobileMock = vi.hoisted(() => vi.fn(() => false));
 const useCopyToClipboardMock = vi.hoisted(() => vi.fn(() => [null, vi.fn()]));
@@ -17,6 +19,18 @@ vi.mock('@/vdb/hooks/use-mobile.js', () => ({
 
 vi.mock('@uidotdev/usehooks', () => ({
     useCopyToClipboard: useCopyToClipboardMock,
+}));
+
+vi.mock('@/vdb/hooks/use-permissions.js', () => ({
+    usePermissions: () => ({
+        hasPermissions: () => true,
+    }),
+}));
+
+vi.mock('@/vdb/hooks/use-local-format.js', () => ({
+    useLocalFormat: () => ({
+        formatDate: (value: string | Date) => String(value),
+    }),
 }));
 
 function registerBlock(
@@ -34,6 +48,23 @@ function registerBlock(
         },
         component: ({ context }) => <div data-testid={`page-block-${id}`}>{context.pageId}</div>,
 });
+}
+
+function registerActionBarItem(
+    id: string,
+    position?: ActionBarItemPosition,
+    pageId = 'customer-list',
+): void {
+    registerDashboardActionBarItem({
+        pageId,
+        id,
+        position,
+        component: () => (
+            <button type="button" data-testid={`action-bar-${id}`}>
+                {id}
+            </button>
+        ),
+    });
 }
 
 function renderPageLayout(children: React.ReactNode, { isDesktop = true } = {}) {
@@ -74,8 +105,59 @@ function renderPageLayout(children: React.ReactNode, { isDesktop = true } = {}) 
     );
 }
 
+function renderActionBar(
+    children: React.ReactNode = (
+        <ActionBarItem itemId="save-button">
+            <button type="button" data-testid="action-bar-save-button">
+                Save
+            </button>
+        </ActionBarItem>
+    ),
+    { isDesktop = true } = {},
+) {
+    useIsMobileMock.mockReturnValue(!isDesktop);
+    const noop = () => undefined;
+    const contextValue = {
+        settings: {
+            displayLanguage: 'en',
+            contentLanguage: 'en',
+            theme: 'system',
+            displayUiExtensionPoints: false,
+            mainNavExpanded: true,
+            activeChannelId: '',
+            devMode: false,
+            hasSeenOnboarding: false,
+            tableSettings: {},
+        },
+        settingsStoreIsAvailable: true,
+        setDisplayLanguage: noop,
+        setDisplayLocale: noop,
+        setContentLanguage: noop,
+        setTheme: noop,
+        setDisplayUiExtensionPoints: noop,
+        setMainNavExpanded: noop,
+        setActiveChannelId: noop,
+        setDevMode: noop,
+        setHasSeenOnboarding: noop,
+        setTableSettings: () => undefined,
+        setWidgetLayout: noop,
+    } as UserSettingsContextType;
+
+    return renderToStaticMarkup(
+        <UserSettingsContext.Provider value={contextValue}>
+            <PageContext.Provider value={{ pageId: 'customer-list' }}>
+                <PageActionBar>{children}</PageActionBar>
+            </PageContext.Provider>
+        </UserSettingsContext.Provider>,
+    );
+}
+
 function getRenderedBlockIds(markup: string) {
     return Array.from(markup.matchAll(/data-testid="(page-block-[^"]+)"/g)).map(match => match[1]);
+}
+
+function getRenderedActionBarIds(markup: string) {
+    return Array.from(markup.matchAll(/data-testid="action-bar-([^"]+)"/g)).map(match => match[1]);
 }
 
 describe('PageLayout', () => {
@@ -85,6 +167,8 @@ describe('PageLayout', () => {
         useCopyToClipboardMock.mockReturnValue([null, vi.fn()]);
         const pageBlockRegistry = globalRegistry.get('dashboardPageBlockRegistry');
         pageBlockRegistry.clear();
+        const actionBarItemRegistry = globalRegistry.get('dashboardActionBarItemRegistry');
+        actionBarItemRegistry.clear();
     });
 
     it('renders multiple before/after extension blocks in registration order', () => {
@@ -137,5 +221,49 @@ describe('PageLayout', () => {
             'page-block-original',
             'page-block-after-mobile',
         ]);
+    });
+
+    it('positions an extension action bar item before another extension item', () => {
+        registerActionBarItem('a');
+        registerActionBarItem('b', { itemId: 'a', order: 'before' });
+
+        const markup = renderActionBar();
+
+        expect(getRenderedActionBarIds(markup)).toEqual(['b', 'a', 'save-button']);
+    });
+
+    it('positions an extension action bar item after another extension item', () => {
+        registerActionBarItem('a');
+        registerActionBarItem('b', { itemId: 'a', order: 'after' });
+
+        const markup = renderActionBar();
+
+        expect(getRenderedActionBarIds(markup)).toEqual(['a', 'b', 'save-button']);
+    });
+
+    it('replaces an extension action bar item with another extension item', () => {
+        registerActionBarItem('a');
+        registerActionBarItem('b', { itemId: 'a', order: 'replace' });
+
+        const markup = renderActionBar();
+
+        expect(getRenderedActionBarIds(markup)).toEqual(['b', 'save-button']);
+    });
+
+    it('keeps inline action bar item positioning behavior', () => {
+        registerActionBarItem('b', { itemId: 'save-button', order: 'before' });
+
+        const markup = renderActionBar();
+
+        expect(getRenderedActionBarIds(markup)).toEqual(['b', 'save-button']);
+    });
+
+    it('supports positioning relative to a positioned extension action bar item', () => {
+        registerActionBarItem('a', { itemId: 'save-button', order: 'before' });
+        registerActionBarItem('b', { itemId: 'a', order: 'before' });
+
+        const markup = renderActionBar();
+
+        expect(getRenderedActionBarIds(markup)).toEqual(['b', 'a', 'save-button']);
     });
 });

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
@@ -630,6 +630,15 @@ function mergeAndSortActionBarItems(
         renderItem(item);
     }
 
+    // A positioned extension can be unreachable from the root walk if its target id is
+    // missing, or if positioned extensions only reference each other in a cycle. Render
+    // any remaining extension items so they do not silently disappear.
+    for (const item of extensionActionItems) {
+        if (item.type === 'extension' && !renderedExtensionItems.has(item.item)) {
+            renderItem(item);
+        }
+    }
+
     return result;
 }
 

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
@@ -535,6 +535,17 @@ type MergedActionBarItem =
     | { type: 'inline'; element: React.ReactElement<ActionBarItemProps> }
     | { type: 'extension'; item: DashboardActionBarItem };
 
+type PositionedExtensionActionBarItem = {
+    type: 'extension';
+    item: DashboardActionBarItem & { position: ActionBarItemPosition };
+};
+
+function isPositionedExtensionActionBarItem(
+    item: MergedActionBarItem,
+): item is PositionedExtensionActionBarItem {
+    return item.type === 'extension' && !!item.item.position;
+}
+
 /**
  * Merges inline ActionBarItem children with extension items, applying position-based ordering.
  * Uses the same priority sorting as page blocks: before=1, replace=2, after=3.
@@ -545,43 +556,78 @@ function mergeAndSortActionBarItems(
 ): MergedActionBarItem[] {
     const result: MergedActionBarItem[] = [];
 
-    // First, add extension items WITHOUT a position (they go first, preserving current behavior)
-    const unpositionedExtensions = extensionItems.filter(ext => !ext.position);
-    for (const ext of unpositionedExtensions) {
-        result.push({ type: 'extension', item: ext });
+    // Treat inline ActionBarItem children and extension items as the same kind of sortable node.
+    // This lets position.itemId target either an inline ActionBarItem.itemId or another extension item's id.
+    const inlineItems: MergedActionBarItem[] = inlineElements.map(element => ({ type: 'inline', element }));
+    const extensionActionItems: MergedActionBarItem[] = extensionItems.map(item => ({
+        type: 'extension',
+        item,
+    }));
+    const getItemId = (item: MergedActionBarItem): string | undefined =>
+        item.type === 'inline' ? item.element.props.itemId : item.item.id;
+
+    // Sort by order priority: before=1, replace=2, after=3
+    const orderPriority: Record<ActionBarItemPosition['order'], number> = {
+        before: 1,
+        replace: 2,
+        after: 3,
+    };
+
+    // First, use extension items WITHOUT a position as root items (they still go first,
+    // preserving the previous behavior). Inline items are also root items.
+    const rootItems = [
+        ...extensionActionItems.filter(item => !isPositionedExtensionActionBarItem(item)),
+        ...inlineItems,
+    ];
+
+    // Group positioned extension items by their target id. The target id may refer to either
+    // an inline ActionBarItem.itemId or a DashboardActionBarItem.id.
+    const extensionsByTargetId = new Map<string, PositionedExtensionActionBarItem[]>();
+
+    for (const item of extensionActionItems.filter(isPositionedExtensionActionBarItem)) {
+        const targetItems = extensionsByTargetId.get(item.item.position.itemId) ?? [];
+        extensionsByTargetId.set(item.item.position.itemId, [...targetItems, item]);
     }
 
-    // Process each inline element and find extension items targeting it
-    for (const inlineElement of inlineElements) {
-        const itemId = inlineElement.props.itemId;
-        const matchingExtensions = extensionItems.filter(ext => ext.position?.itemId === itemId);
+    const renderedExtensionItems = new Set<DashboardActionBarItem>();
 
-        // Sort by order priority: before=1, replace=2, after=3
-        const sortedExtensions = matchingExtensions.sort((a, b) => {
-            const orderPriority: Record<ActionBarItemPosition['order'], number> = {
-                before: 1,
-                replace: 2,
-                after: 3,
-            };
-            return orderPriority[a.position!.order] - orderPriority[b.position!.order];
-        });
-
-        const hasReplacement = sortedExtensions.some(ext => ext.position?.order === 'replace');
-
-        let inlineInserted = false;
-        for (const ext of sortedExtensions) {
-            // Insert inline element before the first non-"before" extension (if not replaced)
-            if (!inlineInserted && !hasReplacement && ext.position?.order !== 'before') {
-                result.push({ type: 'inline', element: inlineElement });
-                inlineInserted = true;
+    function renderItem(item: MergedActionBarItem) {
+        // Prevent duplicate rendering if multiple paths reference the same extension item.
+        if (item.type === 'extension') {
+            if (renderedExtensionItems.has(item.item)) {
+                return;
             }
-            result.push({ type: 'extension', item: ext });
+            renderedExtensionItems.add(item.item);
         }
 
-        // If all extensions were "before" or there were no extensions, add inline at the end
-        if (!inlineInserted && !hasReplacement) {
-            result.push({ type: 'inline', element: inlineElement });
+        const itemId = getItemId(item);
+        const extensions = itemId
+            ? [...(extensionsByTargetId.get(itemId) ?? [])].sort((a, b) => {
+                  return orderPriority[a.item.position.order] - orderPriority[b.item.position.order];
+              })
+            : [];
+        const hasReplacement = extensions.some(ext => ext.item.position.order === 'replace');
+
+        // Render positioned items in before / replace / after order around their target.
+        for (const extension of extensions.filter(ext => ext.item.position.order === 'before')) {
+            renderItem(extension);
         }
+
+        if (hasReplacement) {
+            for (const extension of extensions.filter(ext => ext.item.position.order === 'replace')) {
+                renderItem(extension);
+            }
+        } else {
+            result.push(item);
+        }
+
+        for (const extension of extensions.filter(ext => ext.item.position.order === 'after')) {
+            renderItem(extension);
+        }
+    }
+
+    for (const item of rootItems) {
+        renderItem(item);
     }
 
     return result;


### PR DESCRIPTION
# Description

Fixes action bar extension positioning when one extension item targets another extension item via `position.itemId`.

Previously, `mergeAndSortActionBarItems()` only used inline `ActionBarItem.itemId` values as positioning targets. This worked when an extension item was positioned relative to a built-in or inline action bar item, but it failed when `position.itemId` pointed to another extension item's `id`. In that case, the positioned extension item was never matched during rendering and disappeared from the action bar.

This PR replaces the inline-only matching flow with a unified sortable item model:

- inline `ActionBarItem` children and dashboard extension action bar items are both converted into `MergedActionBarItem` nodes
- unpositioned extension items and inline items are used as root render items
- positioned extension items are grouped by their target id
- each root item renders its `before`, `replace`, and `after` extension items recursively

With this approach, `position.itemId` can target either an inline `ActionBarItem.itemId` or another `DashboardActionBarItem.id`, while preserving the previous behavior for inline targets and unpositioned extension items.

Test coverage has been added for extension-to-extension `before`, `after`, and `replace` positioning, as well as the existing inline target behavior.

Closes #4667

# Breaking changes

No.

# Screenshots

Not applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed