### PR TITLE
docs(license): Add GPLv3 §7(b) Admin Dashboard attribution clause

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -29,6 +29,12 @@ Additional permission under GNU GPL version 3 section 7:
 An additional exception under section 7 of the GPL is included in the plugin-exception.txt file,
 which allows you to distribute Vendure plugins (i.e. extensions) under a different license.
 
+Additional term under GNU GPL version 3 section 7(b):
+
+An additional term under section 7(b) of the GPL is included in the attribution-clause.txt file,
+which requires preservation of specified Vendure attribution notices in the Dashboard user
+interface (login screen and sidebar user menu).
+
 ## Vendure Commercial License (VCL)
 
 Alternatively, commercial and supported versions of the program - also known as
@@ -40,3 +46,4 @@ Please see also:
 
 - [Licensing FAQ - license-faq.md](license/license-faq.md)
 - [GNU GENERAL PUBLIC LICENSE Version 3, 29 June 2007 - gpl-3.0.txt](license/gpl-3.0.txt)
+- [Vendure Attribution Clause - attribution-clause.txt](license/attribution-clause.txt)

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -32,8 +32,8 @@ which allows you to distribute Vendure plugins (i.e. extensions) under a differe
 Additional term under GNU GPL version 3 section 7(b):
 
 An additional term under section 7(b) of the GPL is included in the attribution-clause.txt file,
-which requires preservation of specified Vendure attribution notices in the Dashboard user
-interface (login screen and sidebar user menu).
+which requires preservation of specified Vendure attribution notices in the Admin Dashboard
+(packages/dashboard) — specifically on the login screen and within the sidebar user menu.
 
 ## Vendure Commercial License (VCL)
 

--- a/license/attribution-clause.txt
+++ b/license/attribution-clause.txt
@@ -1,0 +1,49 @@
+Vendure Attribution Clause
+
+0. Definitions
+
+"Vendure Core" includes all the source code files included in this repository, which are licensed
+under the GPL v3.0 license.
+
+The "Dashboard" means the administrative user interface bundled with Vendure Core, including any
+work derived from it.
+
+"Appropriate Legal Notices" has the meaning given in Section 5 of the GNU General Public License
+version 3, and includes the visual notices identified in Section 1 below.
+
+1. Required Attribution Notices
+
+When you distribute, make available, or operate the Software (including any modified version of
+the Dashboard) such that users interact with the Dashboard through a graphical user interface,
+you must preserve the following Appropriate Legal Notices in their original form, location, and
+visibility:
+
+  a) The "Vendure" wordmark and logo, together with the version number of the Software, as
+     displayed on the Dashboard login screen.
+
+  b) The "Vendure" wordmark and logo, together with the version number of the Software, as
+     displayed in the Dashboard sidebar user menu.
+
+These notices must remain:
+
+  - visible to every interactive user of the Dashboard,
+  - legible and no smaller, less contrasted, or less prominent than in the unmodified Software,
+  - unaltered in wording, imagery, and link target (where applicable).
+
+2. Co-branding Permitted
+
+You may add your own branding, logos, product names, and notices alongside the required notices,
+provided the required notices remain clearly visible and are not obscured, replaced, cropped, or
+rendered less prominent.
+
+3. Grant of Additional Term
+
+In accordance with Section 7(b) of the GNU General Public License version 3, Vendure GmbH adds
+the requirements in Sections 1 and 2 above as additional terms applicable to the Software.
+
+Removing, hiding, replacing, or diminishing the prominence of the notices identified in
+Section 1 constitutes a violation of this license, and your rights under the GPL v3.0 will
+terminate automatically as provided in Section 8 of the GPL v3.0.
+
+(The GPL v3.0 restrictions continue to apply in all other respects; this clause adds to, and
+does not replace, those terms.)

--- a/license/attribution-clause.txt
+++ b/license/attribution-clause.txt
@@ -5,8 +5,9 @@ Vendure Attribution Clause
 "Vendure Core" includes all the source code files included in this repository, which are licensed
 under the GPL v3.0 license.
 
-The "Dashboard" means the administrative user interface bundled with Vendure Core, including any
-work derived from it.
+The "Admin Dashboard" means the administrative user interface bundled with Vendure Core, the
+source code for which is contained in the `packages/dashboard` directory of this repository,
+together with any work derived from it.
 
 "Appropriate Legal Notices" has the meaning given in Section 5 of the GNU General Public License
 version 3, and includes the visual notices identified in Section 1 below.
@@ -14,21 +15,35 @@ version 3, and includes the visual notices identified in Section 1 below.
 1. Required Attribution Notices
 
 When you distribute, make available, or operate the Software (including any modified version of
-the Dashboard) such that users interact with the Dashboard through a graphical user interface,
-you must preserve the following Appropriate Legal Notices in their original form, location, and
-visibility:
+the Admin Dashboard) such that users interact with the Admin Dashboard through a graphical user
+interface, you must preserve the following Appropriate Legal Notices in their original form,
+location, and visibility:
 
-  a) The "Vendure" wordmark and logo, together with the version number of the Software, as
-     displayed on the Dashboard login screen.
+  a) The "Vendure" wordmark and logo, as rendered by the `LogoMark` component
+     (packages/dashboard/src/lib/components/shared/logo-mark.tsx) on the Admin Dashboard
+     login screen.
 
-  b) The "Vendure" wordmark and logo, together with the version number of the Software, as
-     displayed in the Dashboard sidebar user menu.
+  b) The "Vendure" name together with the version number of the Software, as rendered by
+     the `LoginBranding` element of the `VendureBranding` component
+     (packages/dashboard/src/lib/components/shared/powered-by-vendure.tsx) on the Admin
+     Dashboard login screen.
+
+  c) The "Vendure" name together with the version number of the Software, as rendered by
+     the `MenuBranding` element of the `VendureBranding` component
+     (packages/dashboard/src/lib/components/shared/powered-by-vendure.tsx) within the
+     Admin Dashboard sidebar user menu.
 
 These notices must remain:
 
-  - visible to every interactive user of the Dashboard,
-  - legible and no smaller, less contrasted, or less prominent than in the unmodified Software,
-  - unaltered in wording, imagery, and link target (where applicable).
+  - visible to every interactive user of the Admin Dashboard,
+  - legible and no smaller, less contrasted, or less prominent than in the unmodified
+    Software,
+  - unaltered in wording, imagery, link target (where applicable), and version value.
+
+For the avoidance of doubt, removing or modifying the `data-vendure-branding` attribute, the
+associated tamper-resistance styles, or otherwise causing the notices identified above to be
+hidden, obscured, cropped, or rendered less prominent (whether through markup, stylesheet,
+script, build configuration, or any other means) constitutes a violation of this clause.
 
 2. Co-branding Permitted
 


### PR DESCRIPTION
# Description

Adds a GPLv3 §7(b) additional term that requires preservation of specified Vendure attribution notices in the Admin Dashboard (`packages/dashboard`).

The clause names the exact components currently rendering those notices so the obligation is unambiguous and cannot be circumvented through styling or markup tricks:

- **Login screen logo** — `LogoMark` (`packages/dashboard/src/lib/components/shared/logo-mark.tsx`)
- **Login screen wordmark + version** — `LoginBranding` (`packages/dashboard/src/lib/components/shared/powered-by-vendure.tsx`)
- **Sidebar user menu wordmark + version** — `MenuBranding` (`packages/dashboard/src/lib/components/shared/powered-by-vendure.tsx`)

The anti-circumvention paragraph explicitly references the existing `data-vendure-branding` attribute and tamper-resistance styles, formalising the intent already documented in the source comment in `powered-by-vendure.tsx` (*"This is a licensing requirement"*).

Co-branding alongside the required notices is explicitly permitted to keep the term reasonable under §7(b) and GPL-compatible.

### Files

- `license/attribution-clause.txt` — new file containing the §7(b) clause (mirrors the structure of `plugin-exception.txt`)
- `LICENSE.md` — adds a paragraph and a link in *"Please see also"* referencing the new clause

# Breaking changes

No code changes. License terms are extended (not replaced): existing GPLv3 obligations and the plugin exception remain unchanged. Downstream users who already preserve the Dashboard branding (the default behaviour) are not affected.

# Screenshots

N/A — license/documentation change only.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases (N/A)
- [ ] I have updated the README if needed (N/A)