### PR TITLE
fix(dashboard): Check required permissions when rendering custom page…

### DIFF
--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
@@ -12,6 +12,7 @@ import { PageContext } from './page-provider.js';
 
 const useIsMobileMock = vi.hoisted(() => vi.fn(() => false));
 const useCopyToClipboardMock = vi.hoisted(() => vi.fn(() => [null, vi.fn()]));
+const hasPermissionsMock = vi.hoisted(() => vi.fn(() => true));
 
 vi.mock('@/vdb/hooks/use-mobile.js', () => ({
     useIsMobile: useIsMobileMock,
@@ -23,7 +24,7 @@ vi.mock('@uidotdev/usehooks', () => ({
 
 vi.mock('@/vdb/hooks/use-permissions.js', () => ({
     usePermissions: () => ({
-        hasPermissions: () => true,
+        hasPermissions: hasPermissionsMock,
     }),
 }));
 
@@ -33,7 +34,12 @@ vi.mock('@/vdb/hooks/use-local-format.js', () => ({
     }),
 }));
 
-function registerBlock(id: string, order: 'before' | 'after' | 'replace', pageId = 'customer-list'): void {
+function registerBlock(
+    id: string,
+    order: 'before' | 'after' | 'replace',
+    pageId = 'customer-list',
+    requiresPermission: string[] = [],
+): void {
     registerDashboardPageBlock({
         id,
         title: id,
@@ -43,6 +49,7 @@ function registerBlock(id: string, order: 'before' | 'after' | 'replace', pageId
             position: { blockId: 'list-table', order },
         },
         component: ({ context }) => <div data-testid={`page-block-${id}`}>{context.pageId}</div>,
+        requiresPermission: requiresPermission,
     });
 }
 
@@ -157,6 +164,7 @@ describe('PageLayout', () => {
         useIsMobileMock.mockReset();
         useCopyToClipboardMock.mockReset();
         useCopyToClipboardMock.mockReturnValue([null, vi.fn()]);
+        hasPermissionsMock.mockReset();
         const pageBlockRegistry = globalRegistry.get('dashboardPageBlockRegistry');
         pageBlockRegistry.clear();
         const actionBarItemRegistry = globalRegistry.get('dashboardActionBarItemRegistry');
@@ -213,6 +221,24 @@ describe('PageLayout', () => {
             'page-block-original',
             'page-block-after-mobile',
         ]);
+    });
+
+    it("won't render blocks without required permissions", () => {
+        hasPermissionsMock.mockReturnValueOnce(false);
+
+        registerBlock('permission-guard', 'before', 'customer-list', ['permission-2']);
+
+        const markup = renderPageLayout(
+            <PageBlock column="main" blockId="list-table">
+                <div data-testid="page-block-original">original</div>
+            </PageBlock>,
+            { isDesktop: true },
+        );
+
+        const blockIds = getRenderedBlockIds(markup);
+
+        expect(blockIds).toEqual(['page-block-original']);
+        expect(blockIds).not.toContain('page-block-permission-guard');
     });
 
     it('positions an extension action bar item before another extension item', () => {

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { ActionBarItem } from './action-bar-item-wrapper.js';
-import { PageActionBar, PageBlock, PageLayout } from './page-layout.js';
-import { registerDashboardActionBarItem, registerDashboardPageBlock } from './layout-extensions.js';
-import { PageContext } from './page-provider.js';
-import { globalRegistry } from '../registry/global-registry.js';
 import { UserSettingsContext, type UserSettingsContextType } from '../../providers/user-settings.js';
 import type { ActionBarItemPosition } from '../extension-api/types/layout.js';
+import { globalRegistry } from '../registry/global-registry.js';
+import { ActionBarItem } from './action-bar-item-wrapper.js';
+import { registerDashboardActionBarItem, registerDashboardPageBlock } from './layout-extensions.js';
+import { PageActionBar, PageBlock, PageLayout } from './page-layout.js';
+import { PageContext } from './page-provider.js';
 
 const useIsMobileMock = vi.hoisted(() => vi.fn(() => false));
 const useCopyToClipboardMock = vi.hoisted(() => vi.fn(() => [null, vi.fn()]));
@@ -33,11 +33,7 @@ vi.mock('@/vdb/hooks/use-local-format.js', () => ({
     }),
 }));
 
-function registerBlock(
-    id: string,
-    order: 'before' | 'after' | 'replace',
-    pageId = 'customer-list',
-): void {
+function registerBlock(id: string, order: 'before' | 'after' | 'replace', pageId = 'customer-list'): void {
     registerDashboardPageBlock({
         id,
         title: id,
@@ -47,14 +43,10 @@ function registerBlock(
             position: { blockId: 'list-table', order },
         },
         component: ({ context }) => <div data-testid={`page-block-${id}`}>{context.pageId}</div>,
-});
+    });
 }
 
-function registerActionBarItem(
-    id: string,
-    position?: ActionBarItemPosition,
-    pageId = 'customer-list',
-): void {
+function registerActionBarItem(id: string, position?: ActionBarItemPosition, pageId = 'customer-list'): void {
     registerDashboardActionBarItem({
         pageId,
         id,
@@ -178,10 +170,10 @@ describe('PageLayout', () => {
 
         const markup = renderPageLayout(
             <PageBlock column="main" blockId="list-table">
-        <div data-testid="page-block-original">original</div>
+                <div data-testid="page-block-original">original</div>
             </PageBlock>,
-        { isDesktop: true },
-    );
+            { isDesktop: true },
+        );
 
         expect(getRenderedBlockIds(markup)).toEqual([
             'page-block-before-1',
@@ -197,10 +189,10 @@ describe('PageLayout', () => {
 
         const markup = renderPageLayout(
             <PageBlock column="main" blockId="list-table">
-        <div data-testid="page-block-original">original</div>
+                <div data-testid="page-block-original">original</div>
             </PageBlock>,
-        { isDesktop: true },
-    );
+            { isDesktop: true },
+        );
 
         expect(getRenderedBlockIds(markup)).toEqual(['page-block-replacement-1', 'page-block-replacement-2']);
     });
@@ -211,10 +203,10 @@ describe('PageLayout', () => {
 
         const markup = renderPageLayout(
             <PageBlock column="main" blockId="list-table">
-        <div data-testid="page-block-original">original</div>
+                <div data-testid="page-block-original">original</div>
             </PageBlock>,
-        { isDesktop: false },
-    );
+            { isDesktop: false },
+        );
 
         expect(getRenderedBlockIds(markup)).toEqual([
             'page-block-before-mobile',

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
@@ -284,7 +284,8 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
                     const ExtensionBlock =
                         extensionBlock.component &&
                         extensionBlockShouldRender &&
-                        hasPermissions(permissions ?? []) ? (
+                        // using `hasPermissions` over `PermissionGuard` as this would defeat the `isPageBlock` typeguard
+                        hasPermissions(permissions) ? (
                             <BlockComponent
                                 key={extensionBlock.id}
                                 column={extensionBlock.location.column}

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
@@ -277,14 +277,18 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
 
                     const ExtensionBlock =
                         extensionBlock.component && extensionBlockShouldRender ? (
-                            <BlockComponent
+                            <PermissionGuard
                                 key={extensionBlock.id}
-                                column={extensionBlock.location.column}
-                                blockId={extensionBlock.id}
-                                title={extensionBlock.title}
+                                requires={extensionBlock.requiresPermission ?? []}
                             >
-                                {<extensionBlock.component context={page} />}
-                            </BlockComponent>
+                                <BlockComponent
+                                    column={extensionBlock.location.column}
+                                    blockId={extensionBlock.id}
+                                    title={extensionBlock.title}
+                                >
+                                    {<extensionBlock.component context={page} />}
+                                </BlockComponent>
+                            </PermissionGuard>
                         ) : undefined;
 
                     if (extensionBlockShouldRender && ExtensionBlock) {

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
@@ -7,6 +7,7 @@ import { useCustomFieldConfig } from '@/vdb/hooks/use-custom-field-config.js';
 import { useLocalFormat } from '@/vdb/hooks/use-local-format.js';
 import { useIsMobile } from '@/vdb/hooks/use-mobile.js';
 import { usePage } from '@/vdb/hooks/use-page.js';
+import { usePermissions } from '@/vdb/hooks/use-permissions.js';
 import { cn } from '@/vdb/lib/utils.js';
 import { useCopyToClipboard } from '@uidotdev/usehooks';
 import { CheckIcon, CopyIcon, EllipsisVerticalIcon, InfoIcon } from 'lucide-react';
@@ -218,6 +219,7 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
     // Separate blocks into categories
     const childArray: React.ReactElement<PageBlockProps>[] = [];
     const extensionBlocks = getDashboardPageBlocks(page.pageId ?? '');
+    const { hasPermissions } = usePermissions();
     React.Children.forEach(children, child => {
         if (isPageBlock(child)) {
             childArray.push(child);
@@ -274,21 +276,23 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
 
                     const isFullWidth = extensionBlock.location.column === 'full';
                     const BlockComponent = isFullWidth ? FullWidthPageBlock : PageBlock;
+                    const requiresPermission = extensionBlock.requiresPermission ?? [];
+                    const permissions = Array.isArray(requiresPermission)
+                        ? requiresPermission
+                        : [requiresPermission];
 
                     const ExtensionBlock =
-                        extensionBlock.component && extensionBlockShouldRender ? (
-                            <PermissionGuard
+                        extensionBlock.component &&
+                        extensionBlockShouldRender &&
+                        hasPermissions(permissions ?? []) ? (
+                            <BlockComponent
                                 key={extensionBlock.id}
-                                requires={extensionBlock.requiresPermission ?? []}
+                                column={extensionBlock.location.column}
+                                blockId={extensionBlock.id}
+                                title={extensionBlock.title}
                             >
-                                <BlockComponent
-                                    column={extensionBlock.location.column}
-                                    blockId={extensionBlock.id}
-                                    title={extensionBlock.title}
-                                >
-                                    {<extensionBlock.component context={page} />}
-                                </BlockComponent>
-                            </PermissionGuard>
+                                {<extensionBlock.component context={page} />}
+                            </BlockComponent>
                         ) : undefined;
 
                     if (extensionBlockShouldRender && ExtensionBlock) {


### PR DESCRIPTION
# Description

Considers `requiresPermission` when rendering page blocks.

Fixes https://github.com/vendurehq/vendure/issues/4678

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed
