### PR TITLE
fix(core): Create job queues in onModuleInit instead of onApplicationBootstrap

### DIFF
--- a/docs/docs/reference/typescript-api/services/session-service.mdx
+++ b/docs/docs/reference/typescript-api/services/session-service.mdx
@@ -7,9 +7,9 @@ generated: true
 Contains methods relating to [Session](/reference/typescript-api/entities/session#session) entities.
 
 ```ts title="Signature"
-class SessionService implements EntitySubscriberInterface, OnApplicationBootstrap {
+class SessionService implements EntitySubscriberInterface, OnModuleInit {
     constructor(connection: TransactionalConnection, configService: ConfigService, orderService: OrderService, jobQueueService: JobQueueService, requestContextService: RequestContextService)
-    onApplicationBootstrap() => ;
+    onModuleInit() => ;
     createNewAuthenticatedSession(ctx: RequestContext, user: User, authenticationStrategyName: string, sessionToken?: string) => Promise<AuthenticatedSession>;
     createAnonymousSession() => Promise<CachedSession>;
     getSessionFromToken(sessionToken: string) => Promise<CachedSession | undefined>;
@@ -24,13 +24,13 @@ class SessionService implements EntitySubscriberInterface, OnApplicationBootstra
     cleanExpiredSessions(ctx: RequestContext, batchSize: number) => ;
 }
 ```
-* Implements: EntitySubscriberInterface, OnApplicationBootstrap
+* Implements: EntitySubscriberInterface, OnModuleInit
 
 
 
 <div className="members-wrapper">
 
-### onApplicationBootstrap
+### onModuleInit
 
 <MemberInfo kind="method" type={`() => `}   />
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2986,7 +2986,7 @@
                   "title": "SessionService",
                   "slug": "session-service",
                   "file": "docs/reference/typescript-api/services/session-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-04-28T15:23:52Z"
                 },
                 {
                   "title": "SettingsStoreService",

--- a/packages/core/src/plugin/default-search-plugin/indexer/search-index.service.ts
+++ b/packages/core/src/plugin/default-search-plugin/indexer/search-index.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ID } from '@vendure/common/lib/shared-types';
 import { assertNever } from '@vendure/common/lib/shared-utils';
 import { Observable } from 'rxjs';
@@ -6,8 +6,8 @@ import { Observable } from 'rxjs';
 import { RequestContext } from '../../../api/common/request-context';
 import { Logger } from '../../../config/logger/vendure-logger';
 import { Asset } from '../../../entity/asset/asset.entity';
-import { Product } from '../../../entity/product/product.entity';
 import { ProductVariant } from '../../../entity/product-variant/product-variant.entity';
+import { Product } from '../../../entity/product/product.entity';
 import { Job } from '../../../job-queue/job';
 import { JobQueue } from '../../../job-queue/job-queue';
 import { JobQueueService } from '../../../job-queue/job-queue.service';
@@ -19,12 +19,15 @@ import { IndexerController } from './indexer.controller';
  * This service is responsible for messaging the {@link IndexerController} with search index updates.
  */
 @Injectable()
-export class SearchIndexService implements OnApplicationBootstrap {
+export class SearchIndexService implements OnModuleInit {
     private updateIndexQueue: JobQueue<UpdateIndexQueueJobData>;
 
-    constructor(private jobService: JobQueueService, private indexerController: IndexerController) {}
+    constructor(
+        private jobService: JobQueueService,
+        private indexerController: IndexerController,
+    ) {}
 
-    async onApplicationBootstrap() {
+    async onModuleInit() {
         this.updateIndexQueue = await this.jobService.createQueue({
             name: 'update-search-index',
             process: job => {
@@ -71,83 +74,110 @@ export class SearchIndexService implements OnApplicationBootstrap {
     }
 
     updateProduct(ctx: RequestContext, product: Product) {
-        return this.updateIndexQueue.add({
-            type: 'update-product',
-            ctx: ctx.serialize(),
-            productId: product.id,
-        },
-        {   ctx   });
+        return this.updateIndexQueue.add(
+            {
+                type: 'update-product',
+                ctx: ctx.serialize(),
+                productId: product.id,
+            },
+            { ctx },
+        );
     }
 
     updateVariants(ctx: RequestContext, variants: ProductVariant[]) {
         const variantIds = variants.map(v => v.id);
-        return this.updateIndexQueue.add({ type: 'update-variants', ctx: ctx.serialize(), variantIds }, { ctx });
+        return this.updateIndexQueue.add(
+            { type: 'update-variants', ctx: ctx.serialize(), variantIds },
+            { ctx },
+        );
     }
 
     deleteProduct(ctx: RequestContext, product: Product) {
-        return this.updateIndexQueue.add({
-            type: 'delete-product',
-            ctx: ctx.serialize(),
-            productId: product.id,
-        },
-        {   ctx   });
+        return this.updateIndexQueue.add(
+            {
+                type: 'delete-product',
+                ctx: ctx.serialize(),
+                productId: product.id,
+            },
+            { ctx },
+        );
     }
 
     deleteVariant(ctx: RequestContext, variants: ProductVariant[]) {
         const variantIds = variants.map(v => v.id);
-        return this.updateIndexQueue.add({ type: 'delete-variant', ctx: ctx.serialize(), variantIds }, { ctx });
+        return this.updateIndexQueue.add(
+            { type: 'delete-variant', ctx: ctx.serialize(), variantIds },
+            { ctx },
+        );
     }
 
     updateVariantsById(ctx: RequestContext, ids: ID[]) {
-        return this.updateIndexQueue.add({ type: 'update-variants-by-id', ctx: ctx.serialize(), ids }, { ctx });
+        return this.updateIndexQueue.add(
+            { type: 'update-variants-by-id', ctx: ctx.serialize(), ids },
+            { ctx },
+        );
     }
 
     updateAsset(ctx: RequestContext, asset: Asset) {
-        return this.updateIndexQueue.add({ type: 'update-asset', ctx: ctx.serialize(), asset: asset as any }, { ctx });
+        return this.updateIndexQueue.add(
+            { type: 'update-asset', ctx: ctx.serialize(), asset: asset as any },
+            { ctx },
+        );
     }
 
     deleteAsset(ctx: RequestContext, asset: Asset) {
-        return this.updateIndexQueue.add({ type: 'delete-asset', ctx: ctx.serialize(), asset: asset as any }, { ctx });
+        return this.updateIndexQueue.add(
+            { type: 'delete-asset', ctx: ctx.serialize(), asset: asset as any },
+            { ctx },
+        );
     }
 
     assignProductToChannel(ctx: RequestContext, productId: ID, channelId: ID) {
-        return this.updateIndexQueue.add({
-            type: 'assign-product-to-channel',
-            ctx: ctx.serialize(),
-            productId,
-            channelId,
-        },
-        {   ctx   });
+        return this.updateIndexQueue.add(
+            {
+                type: 'assign-product-to-channel',
+                ctx: ctx.serialize(),
+                productId,
+                channelId,
+            },
+            { ctx },
+        );
     }
 
     removeProductFromChannel(ctx: RequestContext, productId: ID, channelId: ID) {
-        return this.updateIndexQueue.add({
-            type: 'remove-product-from-channel',
-            ctx: ctx.serialize(),
-            productId,
-            channelId,
-        },
-        {   ctx   });
+        return this.updateIndexQueue.add(
+            {
+                type: 'remove-product-from-channel',
+                ctx: ctx.serialize(),
+                productId,
+                channelId,
+            },
+            { ctx },
+        );
     }
 
     assignVariantToChannel(ctx: RequestContext, productVariantId: ID, channelId: ID) {
-        return this.updateIndexQueue.add({
-            type: 'assign-variant-to-channel',
-            ctx: ctx.serialize(),
-            productVariantId,
-            channelId,
-        },
-        {   ctx   });
+        return this.updateIndexQueue.add(
+            {
+                type: 'assign-variant-to-channel',
+                ctx: ctx.serialize(),
+                productVariantId,
+                channelId,
+            },
+            { ctx },
+        );
     }
 
     removeVariantFromChannel(ctx: RequestContext, productVariantId: ID, channelId: ID) {
-        return this.updateIndexQueue.add({
-            type: 'remove-variant-from-channel',
-            ctx: ctx.serialize(),
-            productVariantId,
-            channelId,
-        },
-        {   ctx   });
+        return this.updateIndexQueue.add(
+            {
+                type: 'remove-variant-from-channel',
+                ctx: ctx.serialize(),
+                productVariantId,
+                channelId,
+            },
+            { ctx },
+        );
     }
 
     private jobWithProgress(

--- a/packages/core/src/service/services/session.service.ts
+++ b/packages/core/src/service/services/session.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, OnApplicationBootstrap } from '@nestjs/common';
+import { Injectable, OnModuleInit } from '@nestjs/common';
 import { ID } from '@vendure/common/lib/shared-types';
 import crypto from 'crypto';
 import ms, { type StringValue } from 'ms';
@@ -33,7 +33,7 @@ import { OrderService } from './order.service';
  */
 @Injectable()
 @Instrument()
-export class SessionService implements EntitySubscriberInterface, OnApplicationBootstrap {
+export class SessionService implements EntitySubscriberInterface, OnModuleInit {
     private sessionCacheStrategy: SessionCacheStrategy;
     private cleanSessionsJobQueue: JobQueue<{ batchSize: number }>;
     private readonly sessionDurationInMs: number;
@@ -57,7 +57,7 @@ export class SessionService implements EntitySubscriberInterface, OnApplicationB
         this.connection.rawConnection.subscribers.push(this);
     }
 
-    async onApplicationBootstrap() {
+    async onModuleInit() {
         this.cleanSessionsJobQueue = await this.jobQueueService.createQueue({
             name: 'clean-sessions',
             process: async job => {


### PR DESCRIPTION
## Summary
- `SessionService` and `SearchIndexService` were creating their `JobQueue` instances inside `onApplicationBootstrap`, but the canonical pattern documented on `JobQueueService` itself (see the `VideoTranscoderService` example in `job-queue.service.ts`) is to create queues during `onModuleInit`.
- Switched both services to `OnModuleInit` so queues are registered earlier in the Nest lifecycle, before any `onApplicationBootstrap` hook runs.
- Audited the rest of `@vendure/core` — `CollectionService` already uses `onModuleInit`, and the other `onApplicationBootstrap` users (e.g. `DefaultSearchPlugin`) only register event subscriptions, which is the correct hook for that.

## Why it matters
`onModuleInit` runs as each module is constructed (bottom-up). `onApplicationBootstrap` only runs after **every** module has finished `onModuleInit`. Anything wired up at bootstrap that wants to inspect or schedule against existing queues — including external `JobQueueStrategy` implementations that perform their own startup hand-off — needs the queue registry to be populated by the time `onApplicationBootstrap` fires. Creating the queue in the same phase makes ordering depend on the module dependency graph, which is fragile when plugins reshuffle imports.

This is the same root cause addressed for the Advanced Search queues in [vendurehq/vendure-platform#271](https://github.com/vendurehq/vendure-platform/pull/271) ("create Advanced Search queues during module init so DBOS sees them at startup"). This PR brings core in line with that pattern.

## Changes
- `packages/core/src/service/services/session.service.ts` — `OnApplicationBootstrap` → `OnModuleInit` for the `clean-sessions` queue.
- `packages/core/src/plugin/default-search-plugin/indexer/search-index.service.ts` — `OnApplicationBootstrap` → `OnModuleInit` for the `update-search-index` queue.

## Test plan
- [ ] Existing core e2e tests pass (session expiry / clean-sessions, default search plugin reindex)
- [ ] No new TypeScript errors introduced (verified locally)
- [ ] Smoke-test against the platform repo's DBOS workflow-engine to confirm the timing fix carries through