### PR TITLE
fix(dashboard): set default sort on promotions list

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions.tsx
@@ -27,6 +27,7 @@ function PromotionListPage() {
             listQuery={promotionListDocument}
             route={Route}
             title={<Trans>Promotions</Trans>}
+            defaultSort={[{ id: 'createdAt', desc: true }]}
             defaultVisibility={{
                 name: true,
                 couponCode: true,


### PR DESCRIPTION
# Description

Set the default sort order for the promotions list page. This matches the default sort of the Angular admin.

# Breaking changes

Nope

# Screenshots

/

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Promotions list now sorts by creation date in descending order by default, displaying the newest promotions first.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->