### PR TITLE
fix(dashboard): Apply addCustomFields() to detail page mutations

### DIFF
--- a/packages/dashboard/src/lib/framework/page/use-detail-page.ts
+++ b/packages/dashboard/src/lib/framework/page/use-detail-page.ts
@@ -283,7 +283,7 @@ export function useDetailPage<
     };
 
     const createMutation = useMutation({
-        mutationFn: createDocument ? api.mutate(createDocument) : undefined,
+        mutationFn: createDocument ? api.mutate(addCustomFields(createDocument)) : undefined,
         onSuccess: data => {
             if (createDocument) {
                 const createMutationName = getMutationName(createDocument);
@@ -294,7 +294,7 @@ export function useDetailPage<
     });
 
     const updateMutation = useMutation({
-        mutationFn: updateDocument ? api.mutate(updateDocument) : undefined,
+        mutationFn: updateDocument ? api.mutate(addCustomFields(updateDocument)) : undefined,
         onSuccess: async data => {
             if (updateDocument) {
                 const updateMutationName = getMutationName(updateDocument);


### PR DESCRIPTION
The useDetailPage hook wraps the query document with addCustomFields() so that bare `customFields` selections are replaced with proper sub-selections at runtime. 

The same wrapping was missing from the create and update mutation documents, so any detail page whose mutation response selection includes `customFields` (e.g. the asset detail page) fails with a GraphQL validation error once the entity has at least one custom field registered:

  Field "customFields" of type "AssetCustomFields" must have a
  selection of subfields.

Closes #4692

# Description

Please include a summary of the changes and the related issue.

# Breaking changes

Does this PR include any breaking changes we should be aware of?

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4693"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->