### PR TITLE
fix(dashboard): Fall back to original on denied replace extension

### DIFF
--- a/docs/docs/reference/dashboard/page-layout/index.mdx
+++ b/docs/docs/reference/dashboard/page-layout/index.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageLayout
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="215" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="216" packageName="@vendure/dashboard" since="3.3.0" />
 
 *
 This component governs the layout of the contents of a [Page](/reference/dashboard/page-layout/page#page) component.
@@ -21,7 +21,7 @@ Parameters
 
 ## PageLayoutProps
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="187" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="188" packageName="@vendure/dashboard" since="3.3.0" />
 
 **Status: Developer Preview**
 

--- a/docs/docs/reference/dashboard/page-layout/page-action-bar.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-action-bar.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageActionBar
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="384" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="385" packageName="@vendure/dashboard" since="3.3.0" />
 
 A component for displaying the main actions for a page. This should be used inside the [Page](/reference/dashboard/page-layout/page#page) component.
 
@@ -117,7 +117,7 @@ Parameters
 
 ## PageActionBarLeft
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="528" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="529" packageName="@vendure/dashboard" since="3.3.0" />
 
 The PageActionBarLeft component is not used and will be removed in a future version.
 
@@ -132,7 +132,7 @@ Parameters
 
 ## PageActionBarRight
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="768" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="769" packageName="@vendure/dashboard" since="3.3.0" />
 
 The PageActionBarRight component is used to display the right content of the action bar.
 

--- a/docs/docs/reference/dashboard/page-layout/page-action-bar.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-action-bar.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageActionBar
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="375" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="384" packageName="@vendure/dashboard" since="3.3.0" />
 
 A component for displaying the main actions for a page. This should be used inside the [Page](/reference/dashboard/page-layout/page#page) component.
 
@@ -117,7 +117,7 @@ Parameters
 
 ## PageActionBarLeft
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="519" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="528" packageName="@vendure/dashboard" since="3.3.0" />
 
 The PageActionBarLeft component is not used and will be removed in a future version.
 
@@ -132,7 +132,7 @@ Parameters
 
 ## PageActionBarRight
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="759" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="768" packageName="@vendure/dashboard" since="3.3.0" />
 
 The PageActionBarRight component is used to display the right content of the action bar.
 

--- a/docs/docs/reference/dashboard/page-layout/page-block.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-block.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="874" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="883" packageName="@vendure/dashboard" since="3.3.0" />
 
 *
 A component for displaying a block of content on a page. This should be used inside the [PageLayout](/reference/dashboard/page-layout/#pagelayout) component.
@@ -30,7 +30,7 @@ Parameters
 
 ## PageBlockProps
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="823" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="832" packageName="@vendure/dashboard" since="3.3.0" />
 
 Props used to configure the [PageBlock](/reference/dashboard/page-layout/page-block#pageblock) component.
 
@@ -82,7 +82,7 @@ An optional set of CSS classes to apply to the block.
 </div>
 ## FullWidthPageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="921" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="930" packageName="@vendure/dashboard" since="3.3.0" />
 
 **Status: Developer Preview**
 
@@ -100,7 +100,7 @@ Parameters
 
 ## CustomFieldsPageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="951" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="960" packageName="@vendure/dashboard" since="3.3.0" />
 
 *
 A component for displaying an auto-generated form for custom fields on a page.

--- a/docs/docs/reference/dashboard/page-layout/page-block.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-block.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="883" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="884" packageName="@vendure/dashboard" since="3.3.0" />
 
 *
 A component for displaying a block of content on a page. This should be used inside the [PageLayout](/reference/dashboard/page-layout/#pagelayout) component.
@@ -30,7 +30,7 @@ Parameters
 
 ## PageBlockProps
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="832" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="833" packageName="@vendure/dashboard" since="3.3.0" />
 
 Props used to configure the [PageBlock](/reference/dashboard/page-layout/page-block#pageblock) component.
 
@@ -82,7 +82,7 @@ An optional set of CSS classes to apply to the block.
 </div>
 ## FullWidthPageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="930" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="931" packageName="@vendure/dashboard" since="3.3.0" />
 
 **Status: Developer Preview**
 
@@ -100,7 +100,7 @@ Parameters
 
 ## CustomFieldsPageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="960" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="961" packageName="@vendure/dashboard" since="3.3.0" />
 
 *
 A component for displaying an auto-generated form for custom fields on a page.

--- a/docs/docs/reference/dashboard/page-layout/page-title.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-title.mdx
@@ -2,7 +2,7 @@
 title: "PageTitle"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="349" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="350" packageName="@vendure/dashboard" since="3.3.0" />
 
 A component for displaying the title of a page. This should be used inside the [Page](/reference/dashboard/page-layout/page#page) component.
 

--- a/docs/docs/reference/dashboard/page-layout/page-title.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-title.mdx
@@ -2,7 +2,7 @@
 title: "PageTitle"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="340" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="349" packageName="@vendure/dashboard" since="3.3.0" />
 
 A component for displaying the title of a page. This should be used inside the [Page](/reference/dashboard/page-layout/page#page) component.
 

--- a/docs/docs/reference/dashboard/page-layout/page.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## Page
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="95" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="96" packageName="@vendure/dashboard" since="3.3.0" />
 
 This component should be used to wrap _all_ pages in the dashboard. It provides
 a consistent layout as well as a context for the slot-based PageBlock system.
@@ -52,7 +52,7 @@ Parameters
 
 ## PageProps
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="42" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="43" packageName="@vendure/dashboard" since="3.3.0" />
 
 The props used to configure the [Page](/reference/dashboard/page-layout/page#page) component.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -4147,19 +4147,19 @@
                   "title": "PageActionBar",
                   "slug": "page-action-bar",
                   "file": "docs/reference/dashboard/page-layout/page-action-bar.mdx",
-                  "lastModified": "2026-05-05T09:36:55Z"
+                  "lastModified": "2026-05-05T09:48:54Z"
                 },
                 {
                   "title": "PageBlock",
                   "slug": "page-block",
                   "file": "docs/reference/dashboard/page-layout/page-block.mdx",
-                  "lastModified": "2026-05-05T09:36:55Z"
+                  "lastModified": "2026-05-05T09:48:54Z"
                 },
                 {
                   "title": "PageTitle",
                   "slug": "page-title",
                   "file": "docs/reference/dashboard/page-layout/page-title.mdx",
-                  "lastModified": "2026-05-05T09:36:55Z"
+                  "lastModified": "2026-05-05T09:48:54Z"
                 },
                 {
                   "title": "UsePageBlock",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -4141,25 +4141,25 @@
                   "title": "Page",
                   "slug": "page",
                   "file": "docs/reference/dashboard/page-layout/page.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-05-05T09:36:55Z"
                 },
                 {
                   "title": "PageActionBar",
                   "slug": "page-action-bar",
                   "file": "docs/reference/dashboard/page-layout/page-action-bar.mdx",
-                  "lastModified": "2026-04-30T17:21:55+02:00"
+                  "lastModified": "2026-05-05T09:36:55Z"
                 },
                 {
                   "title": "PageBlock",
                   "slug": "page-block",
                   "file": "docs/reference/dashboard/page-layout/page-block.mdx",
-                  "lastModified": "2026-04-30T17:21:55+02:00"
+                  "lastModified": "2026-05-05T09:36:55Z"
                 },
                 {
                   "title": "PageTitle",
                   "slug": "page-title",
                   "file": "docs/reference/dashboard/page-layout/page-title.mdx",
-                  "lastModified": "2026-03-23T10:11:25+01:00"
+                  "lastModified": "2026-05-05T09:36:55Z"
                 },
                 {
                   "title": "UsePageBlock",
@@ -4168,7 +4168,7 @@
                   "lastModified": "2026-01-28T14:49:21+01:00"
                 }
               ],
-              "lastModified": "2026-04-20T16:08:16+02:00"
+              "lastModified": "2026-05-05T09:36:55Z"
             },
             {
               "title": "Vite Plugin",

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
@@ -12,7 +12,7 @@ import { PageContext } from './page-provider.js';
 
 const useIsMobileMock = vi.hoisted(() => vi.fn(() => false));
 const useCopyToClipboardMock = vi.hoisted(() => vi.fn(() => [null, vi.fn()]));
-const hasPermissionsMock = vi.hoisted(() => vi.fn(() => true));
+const hasPermissionsMock = vi.hoisted(() => vi.fn((_perms: string[]) => true));
 
 vi.mock('@/vdb/hooks/use-mobile.js', () => ({
     useIsMobile: useIsMobileMock,
@@ -39,6 +39,7 @@ function registerBlock(
     order: 'before' | 'after' | 'replace',
     pageId = 'customer-list',
     requiresPermission: string[] = [],
+    shouldRender?: () => boolean,
 ): void {
     registerDashboardPageBlock({
         id,
@@ -49,7 +50,8 @@ function registerBlock(
             position: { blockId: 'list-table', order },
         },
         component: ({ context }) => <div data-testid={`page-block-${id}`}>{context.pageId}</div>,
-        requiresPermission: requiresPermission,
+        requiresPermission,
+        shouldRender,
     });
 }
 
@@ -224,7 +226,7 @@ describe('PageLayout', () => {
     });
 
     it("won't render blocks without required permissions", () => {
-        hasPermissionsMock.mockReturnValueOnce(false);
+        hasPermissionsMock.mockReturnValue(false);
 
         registerBlock('permission-guard', 'before', 'customer-list', ['permission-2']);
 
@@ -262,6 +264,53 @@ describe('PageLayout', () => {
 
         expect(blockIds).toEqual(['page-block-original']);
         expect(blockIds).not.toContain('page-block-permission-replacement');
+    });
+
+    it('renders only the allowed replacement when another replace-ordered block is permission-denied', () => {
+        hasPermissionsMock.mockImplementation(
+            (perms: string[]) => perms.length === 0 || perms.includes('allowed-perm'),
+        );
+
+        registerBlock('replacement-allowed', 'replace', 'customer-list', ['allowed-perm']);
+        registerBlock('replacement-denied', 'replace', 'customer-list', ['denied-perm']);
+
+        const markup = renderPageLayout(
+            <PageBlock column="main" blockId="list-table">
+                <div data-testid="page-block-original">original</div>
+            </PageBlock>,
+            { isDesktop: true },
+        );
+
+        expect(getRenderedBlockIds(markup)).toEqual(['page-block-replacement-allowed']);
+    });
+
+    it('falls back to the original block when a replace-ordered extension shouldRender returns false', () => {
+        registerBlock('replacement-disabled', 'replace', 'customer-list', [], () => false);
+
+        const markup = renderPageLayout(
+            <PageBlock column="main" blockId="list-table">
+                <div data-testid="page-block-original">original</div>
+            </PageBlock>,
+            { isDesktop: true },
+        );
+
+        expect(getRenderedBlockIds(markup)).toEqual(['page-block-original']);
+    });
+
+    it('renders only the original when both before- and replace-ordered extensions are permission-denied', () => {
+        hasPermissionsMock.mockReturnValue(false);
+
+        registerBlock('before-denied', 'before', 'customer-list', ['restricted']);
+        registerBlock('replace-denied', 'replace', 'customer-list', ['restricted']);
+
+        const markup = renderPageLayout(
+            <PageBlock column="main" blockId="list-table">
+                <div data-testid="page-block-original">original</div>
+            </PageBlock>,
+            { isDesktop: true },
+        );
+
+        expect(getRenderedBlockIds(markup)).toEqual(['page-block-original']);
     });
 
     it('positions an extension action bar item before another extension item', () => {

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
@@ -241,6 +241,29 @@ describe('PageLayout', () => {
         expect(blockIds).not.toContain('page-block-permission-guard');
     });
 
+    // #4679 follow-up — when a `replace`-ordered extension block requires a permission the user
+    // does not have, the slot is rendered empty instead of falling back to the original child.
+    // Root cause: `replacementBlockExists` is computed in page-layout.tsx without consulting
+    // `hasPermissions`, so the original block is suppressed even though the replacement is then
+    // filtered out by the new permission check at the `ExtensionBlock` resolution site.
+    it('falls back to the original block when a replace-ordered extension is denied by permissions', () => {
+        hasPermissionsMock.mockReturnValue(false);
+
+        registerBlock('permission-replacement', 'replace', 'customer-list', ['restricted-permission']);
+
+        const markup = renderPageLayout(
+            <PageBlock column="main" blockId="list-table">
+                <div data-testid="page-block-original">original</div>
+            </PageBlock>,
+            { isDesktop: true },
+        );
+
+        const blockIds = getRenderedBlockIds(markup);
+
+        expect(blockIds).toEqual(['page-block-original']);
+        expect(blockIds).not.toContain('page-block-permission-replacement');
+    });
+
     it('positions an extension action bar item before another extension item', () => {
         registerActionBarItem('a');
         registerActionBarItem('b', { itemId: 'a', order: 'before' });

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
@@ -237,10 +237,7 @@ describe('PageLayout', () => {
             { isDesktop: true },
         );
 
-        const blockIds = getRenderedBlockIds(markup);
-
-        expect(blockIds).toEqual(['page-block-original']);
-        expect(blockIds).not.toContain('page-block-permission-guard');
+        expect(getRenderedBlockIds(markup)).toEqual(['page-block-original']);
     });
 
     // #4679 follow-up — when a `replace`-ordered extension block requires a permission the user
@@ -260,16 +257,34 @@ describe('PageLayout', () => {
             { isDesktop: true },
         );
 
-        const blockIds = getRenderedBlockIds(markup);
-
-        expect(blockIds).toEqual(['page-block-original']);
-        expect(blockIds).not.toContain('page-block-permission-replacement');
+        expect(getRenderedBlockIds(markup)).toEqual(['page-block-original']);
     });
 
-    it('renders only the allowed replacement when another replace-ordered block is permission-denied', () => {
-        hasPermissionsMock.mockImplementation(
-            (perms: string[]) => perms.length === 0 || perms.includes('allowed-perm'),
+    // Multi-block variant of the regression test above. With the bug present, `replacementBlockExists`
+    // would be `true` (any block with `order === 'replace'` triggered it, regardless of permissions),
+    // suppressing the original. The expected result `[]` would have failed this assertion.
+    it('falls back to the original block when ALL replace-ordered extensions are permission-denied', () => {
+        hasPermissionsMock.mockReturnValue(false);
+
+        registerBlock('replacement-1', 'replace', 'customer-list', ['perm-1']);
+        registerBlock('replacement-2', 'replace', 'customer-list', ['perm-2']);
+
+        const markup = renderPageLayout(
+            <PageBlock column="main" blockId="list-table">
+                <div data-testid="page-block-original">original</div>
+            </PageBlock>,
+            { isDesktop: true },
         );
+
+        expect(getRenderedBlockIds(markup)).toEqual(['page-block-original']);
+    });
+
+    // Documents the mixed-permission case: when at least one replacement is allowed,
+    // the original child is suppressed (since a real replacement renders) and only
+    // permitted replacements appear. Note: this scenario passes both pre- and post-fix
+    // — it covers the per-block JSX gate, not `replacementBlockExists`.
+    it('renders only allowed replacements when replace permissions are mixed (original suppressed)', () => {
+        hasPermissionsMock.mockImplementation((perms: string[]) => perms.includes('allowed-perm'));
 
         registerBlock('replacement-allowed', 'replace', 'customer-list', ['allowed-perm']);
         registerBlock('replacement-denied', 'replace', 'customer-list', ['denied-perm']);
@@ -281,10 +296,16 @@ describe('PageLayout', () => {
             { isDesktop: true },
         );
 
+        // toEqual is exact — proves replacement-denied is absent AND original is absent
         expect(getRenderedBlockIds(markup)).toEqual(['page-block-replacement-allowed']);
     });
 
     it('falls back to the original block when a replace-ordered extension shouldRender returns false', () => {
+        // Explicit: hasPermissions must return true so that shouldRender is the *only* veto under test.
+        // Without this, the post-`mockReset` mock returns undefined (falsy) and the test would pass
+        // for the wrong reason if check ordering inside `willBlockRender` were ever changed.
+        hasPermissionsMock.mockReturnValue(true);
+
         registerBlock('replacement-disabled', 'replace', 'customer-list', [], () => false);
 
         const markup = renderPageLayout(

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
@@ -153,6 +153,15 @@ function renderActionBar(
     );
 }
 
+function renderWithOriginal({ isDesktop = true } = {}) {
+    return renderPageLayout(
+        <PageBlock column="main" blockId="list-table">
+            <div data-testid="page-block-original">original</div>
+        </PageBlock>,
+        { isDesktop },
+    );
+}
+
 function getRenderedBlockIds(markup: string) {
     return Array.from(markup.matchAll(/data-testid="(page-block-[^"]+)"/g)).map(match => match[1]);
 }
@@ -230,14 +239,7 @@ describe('PageLayout', () => {
 
         registerBlock('permission-guard', 'before', 'customer-list', ['permission-2']);
 
-        const markup = renderPageLayout(
-            <PageBlock column="main" blockId="list-table">
-                <div data-testid="page-block-original">original</div>
-            </PageBlock>,
-            { isDesktop: true },
-        );
-
-        expect(getRenderedBlockIds(markup)).toEqual(['page-block-original']);
+        expect(getRenderedBlockIds(renderWithOriginal())).toEqual(['page-block-original']);
     });
 
     // #4679 follow-up — when a `replace`-ordered extension block requires a permission the user
@@ -250,14 +252,7 @@ describe('PageLayout', () => {
 
         registerBlock('permission-replacement', 'replace', 'customer-list', ['restricted-permission']);
 
-        const markup = renderPageLayout(
-            <PageBlock column="main" blockId="list-table">
-                <div data-testid="page-block-original">original</div>
-            </PageBlock>,
-            { isDesktop: true },
-        );
-
-        expect(getRenderedBlockIds(markup)).toEqual(['page-block-original']);
+        expect(getRenderedBlockIds(renderWithOriginal())).toEqual(['page-block-original']);
     });
 
     // Multi-block variant of the regression test above. With the bug present, `replacementBlockExists`
@@ -269,14 +264,7 @@ describe('PageLayout', () => {
         registerBlock('replacement-1', 'replace', 'customer-list', ['perm-1']);
         registerBlock('replacement-2', 'replace', 'customer-list', ['perm-2']);
 
-        const markup = renderPageLayout(
-            <PageBlock column="main" blockId="list-table">
-                <div data-testid="page-block-original">original</div>
-            </PageBlock>,
-            { isDesktop: true },
-        );
-
-        expect(getRenderedBlockIds(markup)).toEqual(['page-block-original']);
+        expect(getRenderedBlockIds(renderWithOriginal())).toEqual(['page-block-original']);
     });
 
     // Documents the mixed-permission case: when at least one replacement is allowed,
@@ -289,15 +277,8 @@ describe('PageLayout', () => {
         registerBlock('replacement-allowed', 'replace', 'customer-list', ['allowed-perm']);
         registerBlock('replacement-denied', 'replace', 'customer-list', ['denied-perm']);
 
-        const markup = renderPageLayout(
-            <PageBlock column="main" blockId="list-table">
-                <div data-testid="page-block-original">original</div>
-            </PageBlock>,
-            { isDesktop: true },
-        );
-
         // toEqual is exact — proves replacement-denied is absent AND original is absent
-        expect(getRenderedBlockIds(markup)).toEqual(['page-block-replacement-allowed']);
+        expect(getRenderedBlockIds(renderWithOriginal())).toEqual(['page-block-replacement-allowed']);
     });
 
     it('falls back to the original block when a replace-ordered extension shouldRender returns false', () => {
@@ -308,14 +289,7 @@ describe('PageLayout', () => {
 
         registerBlock('replacement-disabled', 'replace', 'customer-list', [], () => false);
 
-        const markup = renderPageLayout(
-            <PageBlock column="main" blockId="list-table">
-                <div data-testid="page-block-original">original</div>
-            </PageBlock>,
-            { isDesktop: true },
-        );
-
-        expect(getRenderedBlockIds(markup)).toEqual(['page-block-original']);
+        expect(getRenderedBlockIds(renderWithOriginal())).toEqual(['page-block-original']);
     });
 
     it('renders only the original when both before- and replace-ordered extensions are permission-denied', () => {
@@ -324,14 +298,7 @@ describe('PageLayout', () => {
         registerBlock('before-denied', 'before', 'customer-list', ['restricted']);
         registerBlock('replace-denied', 'replace', 'customer-list', ['restricted']);
 
-        const markup = renderPageLayout(
-            <PageBlock column="main" blockId="list-table">
-                <div data-testid="page-block-original">original</div>
-            </PageBlock>,
-            { isDesktop: true },
-        );
-
-        expect(getRenderedBlockIds(markup)).toEqual(['page-block-original']);
+        expect(getRenderedBlockIds(renderWithOriginal())).toEqual(['page-block-original']);
     });
 
     it('positions an extension action bar item before another extension item', () => {

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
@@ -252,8 +252,12 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
                 return orderPriority[a.location.position.order] - orderPriority[b.location.position.order];
             });
 
+            type ExtensionBlockEntry = (typeof arrangedExtensionBlocks)[number];
+
             // using `hasPermissions` over `PermissionGuard` as this would defeat the `isPageBlock` typeguard
-            const willBlockRender = (block: (typeof arrangedExtensionBlocks)[number]) => {
+            const willBlockRender = (
+                block: ExtensionBlockEntry,
+            ): block is ExtensionBlockEntry & { component: NonNullable<ExtensionBlockEntry['component']> } => {
                 if (!block.component) return false;
                 if (typeof block.shouldRender === 'function' && !block.shouldRender(page)) {
                     return false;
@@ -281,24 +285,21 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
                         childBlockInserted = true;
                     }
 
+                    if (!willBlockRender(extensionBlock)) continue;
+
                     const isFullWidth = extensionBlock.location.column === 'full';
                     const BlockComponent = isFullWidth ? FullWidthPageBlock : PageBlock;
 
-                    const ExtensionBlock =
-                        willBlockRender(extensionBlock) && extensionBlock.component ? (
-                            <BlockComponent
-                                key={extensionBlock.id}
-                                column={extensionBlock.location.column}
-                                blockId={extensionBlock.id}
-                                title={extensionBlock.title}
-                            >
-                                {<extensionBlock.component context={page} />}
-                            </BlockComponent>
-                        ) : undefined;
-
-                    if (ExtensionBlock) {
-                        finalChildArray.push(ExtensionBlock);
-                    }
+                    finalChildArray.push(
+                        <BlockComponent
+                            key={extensionBlock.id}
+                            column={extensionBlock.location.column}
+                            blockId={extensionBlock.id}
+                            title={extensionBlock.title}
+                        >
+                            <extensionBlock.component context={page} />
+                        </BlockComponent>,
+                    );
                 }
 
                 // If all blocks were "before", insert child block at the end

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
@@ -252,18 +252,25 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
                 return orderPriority[a.location.position.order] - orderPriority[b.location.position.order];
             });
 
+            // using `hasPermissions` over `PermissionGuard` as this would defeat the `isPageBlock` typeguard
+            const willBlockRender = (block: (typeof arrangedExtensionBlocks)[number]) => {
+                if (!block.component) return false;
+                if (typeof block.shouldRender === 'function' && !block.shouldRender(page)) {
+                    return false;
+                }
+                const required = block.requiresPermission ?? [];
+                return hasPermissions(Array.isArray(required) ? required : [required]);
+            };
+
+            // A `replace`-ordered block only counts as a replacement when it would actually render —
+            // otherwise the original child must be kept as a fallback.
             const replacementBlockExists = arrangedExtensionBlocks.some(
-                block => block.location.position.order === 'replace',
+                block => block.location.position.order === 'replace' && willBlockRender(block),
             );
 
             let childBlockInserted = false;
             if (matchingExtensionBlocks.length > 0) {
                 for (const extensionBlock of arrangedExtensionBlocks) {
-                    let extensionBlockShouldRender = true;
-                    if (typeof extensionBlock?.shouldRender === 'function') {
-                        extensionBlockShouldRender = extensionBlock.shouldRender(page);
-                    }
-
                     // Insert child block before the first non-"before" block
                     if (
                         !childBlockInserted &&
@@ -276,16 +283,9 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
 
                     const isFullWidth = extensionBlock.location.column === 'full';
                     const BlockComponent = isFullWidth ? FullWidthPageBlock : PageBlock;
-                    const requiresPermission = extensionBlock.requiresPermission ?? [];
-                    const permissions = Array.isArray(requiresPermission)
-                        ? requiresPermission
-                        : [requiresPermission];
 
                     const ExtensionBlock =
-                        extensionBlock.component &&
-                        extensionBlockShouldRender &&
-                        // using `hasPermissions` over `PermissionGuard` as this would defeat the `isPageBlock` typeguard
-                        hasPermissions(permissions) ? (
+                        willBlockRender(extensionBlock) && extensionBlock.component ? (
                             <BlockComponent
                                 key={extensionBlock.id}
                                 column={extensionBlock.location.column}
@@ -296,7 +296,7 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
                             </BlockComponent>
                         ) : undefined;
 
-                    if (extensionBlockShouldRender && ExtensionBlock) {
+                    if (ExtensionBlock) {
                         finalChildArray.push(ExtensionBlock);
                     }
                 }


### PR DESCRIPTION
## Summary

Follow-up to #4679. When an extension page block is registered with `position.order === 'replace'` and the active user lacks the block's `requiresPermission`, the slot would render empty instead of falling back to the original child block.

The cause was a divergence between two checks in `page-layout.tsx`:
- `replacementBlockExists` (which suppresses the original child) was computed without consulting permissions/`shouldRender`.
- The `ExtensionBlock` resolution (added in #4679) gated the replacement on `hasPermissions(...)`.

When the replacement was permission-denied, the original was still suppressed but the replacement also rendered as `undefined` — leaving the slot empty.

The fix consolidates the "will this block render?" logic into a single `willBlockRender` helper used at both call sites, so they cannot drift apart again.

## Changes

- `page-layout.tsx`: extract `willBlockRender(block)` checking `component`, `shouldRender(page)`, and `hasPermissions(...)`. Use it for both `replacementBlockExists` and the per-block JSX guard.
- `page-layout.spec.tsx`: regression test covering `replace`-ordered + permission-denied → original child renders as fallback.

## Test plan

- [x] Existing 11 tests in `page-layout.spec.tsx` still pass
- [x] New regression test fails on master (without fix), passes after fix
- [x] Manually verified in dev-server across all permutations: `before/after/replace` × granted/denied
- [x] TypeScript clean on both changed files

Relates to #4679

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4694"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->