### PR TITLE
fix(dashboard): Align asset mutation selection set with other detail pages

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_assets/assets.graphql.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_assets/assets.graphql.ts
@@ -17,21 +17,13 @@ export const assetDetailDocument = graphql(
     [assetFragment],
 );
 
-export const assetUpdateDocument = graphql(
-    `
-        mutation AssetUpdate($input: UpdateAssetInput!) {
-            updateAsset(input: $input) {
-                ...Asset
-                tags {
-                    id
-                    value
-                }
-                customFields
-            }
+export const assetUpdateDocument = graphql(`
+    mutation AssetUpdate($input: UpdateAssetInput!) {
+        updateAsset(input: $input) {
+            id
         }
-    `,
-    [assetFragment],
-);
+    }
+`);
 
 export const deleteAssetsDocument = graphql(`
     mutation DeleteAssets($input: DeleteAssetsInput!) {


### PR DESCRIPTION
## Summary

The asset detail page's update mutation was selecting `...Asset`, `tags`, and `customFields` on the response. As soon as a custom field is registered for `Asset`, this fails with:

> Field "customFields" of type "AssetCustomFields" must have a selection of subfields.

because bare `customFields` selections aren't valid GraphQL once sub-fields exist. All other detail page mutations (`updateProduct`, `updateCustomer`, etc.) only select `{ id }` on the response and rely on the subsequent query refetch to hydrate the form. This brings the asset page in line with that convention and fixes the bug.

### Why this approach over wrapping with `addCustomFields()`

An alternative (PR #4693) is to wrap every detail page's mutation document with `addCustomFields()`. That works but has a cost: every detail page mutation would then return all custom fields on save, including potentially expensive relation custom fields, only to have the result thrown away when `useDetailPage` invalidates the TanStack Query cache and refetches. Selecting `{ id }` keeps mutations cheap and matches the existing pattern across the dashboard.

### Why this is safe

- `setValuesForUpdate` reads from the **query** result (which still selects `customFields`/`tags`).
- `onSuccess` doesn't read the mutation payload.
- The query is automatically invalidated and refetched after the mutation, so the form re-hydrates with fresh data.

Fixes #4692

## Test plan

- [ ] Register at least one custom field on `Asset` in the dev config
- [ ] Open the asset detail page and edit a field (name, tags, focal point, custom field)
- [ ] Save and confirm no GraphQL validation error and the form reflects the saved state

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4695"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->