### PR TITLE
fix(core): Save Asset before running custom-field relation updates

### DIFF
--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -1409,6 +1409,24 @@ describe('Custom field relations', () => {
                 expect(asset.customFields.multi.length).toEqual(2);
             });
 
+            it('updating primitive and relation custom fields on Asset in the same mutation persists both', async () => {
+                const { updateAsset } = await adminClient.query(gql`
+                    mutation {
+                        updateAsset(
+                            input: {
+                                id: "T_1"
+                                customFields: { primitive: "updated-on-asset", singleId: "T_2" }
+                            }
+                        ) {
+                            id
+                            ${customFieldsSelection}
+                        }
+                    }
+                `);
+                expect(updateAsset.customFields.single).toEqual({ id: 'T_2' });
+                expect(updateAsset.customFields.primitive).toBe('updated-on-asset');
+            });
+
             // https://github.com/vendurehq/vendure/issues/1636
             it('calling TransactionalConnection.findOneInChannel() returns custom field relations', async () => {
                 TestPlugin1636_1664.testResolverSpy.mockReset();

--- a/packages/core/src/service/services/asset.service.ts
+++ b/packages/core/src/service/services/asset.service.ts
@@ -337,7 +337,6 @@ export class AssetService {
             input.focalPoint.y = to3dp(input.focalPoint.y);
         }
         patchEntity(asset, omit(input, ['tags', 'name', 'translations']));
-        await this.customFieldRelationService.updateRelations(ctx, Asset, input, asset);
         if (input.tags) {
             asset.tags = await this.tagService.valuesToTags(ctx, input.tags);
         }
@@ -347,8 +346,11 @@ export class AssetService {
         if (input.name != null && !translationsInput.some(t => t.languageCode === ctx.languageCode)) {
             translationsInput.push({ languageCode: ctx.languageCode, name: input.name });
         }
-        // Save asset first to ensure it exists for translation foreign key
+        // Save asset first to ensure it exists for translation foreign key, and so that
+        // updateRelations() sees the freshly-patched scalar custom fields when it reloads
+        // the entity from the DB.
         const savedAsset = await this.connection.getRepository(ctx, Asset).save(asset);
+        await this.customFieldRelationService.updateRelations(ctx, Asset, input, asset);
         if (translationsInput.length > 0) {
             await this.translatableSaver.update({
                 ctx,


### PR DESCRIPTION
## Summary

When `AssetService.update()` is called with an input containing both **scalar custom fields and a relation custom field**, the scalar values are silently dropped. The mutation returns 200 OK and reports success, but the scalar values never reach the database.

### Root cause

The order of operations in `AssetService.update()` is:

1. `getEntityOrThrow()` — load asset from DB
2. `patchEntity()` — apply input patches in memory (including scalar custom fields)
3. `customFieldRelationService.updateRelations()` — runs **before** the asset is saved
4. `getRepository().save(asset)` — final save

Step 3 reloads the entity from the DB to merge in any concurrent changes:

\`\`\`ts
const entityWithCustomFields = await this.connection
    .getRepository(ctx, entityType)
    .findOne({ where: { id: entity.id }, loadEagerRelations: false });
entity.customFields = {
    ...entity.customFields,                  // patched values
    ...entityWithCustomFields?.customFields, // stale DB load — wins
    [field.name]: relations,
};
await this.connection.getRepository(ctx, entityType)
    .save(pick(entity, ['id', 'customFields']), { reload: false });
\`\`\`

Because the asset hasn't been saved yet, the DB load returns the stale state and clobbers the just-patched scalar values. `updateRelations` then writes the stale values back to the DB, and the subsequent `save(asset)` doesn't restore them because `asset.customFields` was mutated in place.

`CollectionService.update()` doesn't have this problem because it uses `translatableSaver.update()` which saves the entity **before** `updateRelations` runs — so the DB load returns the freshly-saved values.

### Fix

Reorder `AssetService.update()` so the patched entity is saved before `updateRelations` is called. This matches Collection's pattern.

### Reproduction

Running the new e2e test against unpatched master:

\`\`\`
× Asset entity > updating primitive and relation custom fields on Asset in the same mutation persists both
  AssertionError: expected 'test' to be 'updated-on-asset'
\`\`\`

After the fix, the test passes alongside all 60 existing tests in \`custom-field-relations.e2e-spec.ts\` and all 6 in \`asset-custom-fields.e2e-spec.ts\`.

### Real-world impact

This caused the bug originally reported in #4692 to look "fixed but not working" in the dashboard: once an Asset has any relation custom field configured, every save from the asset detail page silently fails to persist scalar custom fields, because the dashboard always sends the full custom-field payload (including the relation id, even when null).

## Test plan

- [x] New e2e test in \`custom-field-relations.e2e-spec.ts\` covers the scalar+relation simultaneous-update case for Asset
- [x] All existing tests in \`custom-field-relations.e2e-spec.ts\` and \`asset-custom-fields.e2e-spec.ts\` continue to pass
- [ ] Manually verify in the dashboard: configure a relation custom field on Asset, edit a scalar custom field (e.g. caption), save, refresh, confirm the value persists

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4696"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->