### PR TITLE
chore(dashboard): Drop direct @base-ui/react imports

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -367,7 +367,7 @@
         "@types/react-dom": "^19.0.4",
         "@uidotdev/usehooks": "^2.4.1",
         "@vendure-io/design-tokens": "^1.1.2",
-        "@vendure-io/ui": "^1.0.5",
+        "@vendure-io/ui": "^1.1.0",
         "@vitejs/plugin-react": "^5.2.0",
         "acorn": "^8.16.0",
         "acorn-walk": "^8.3.5",
@@ -2692,7 +2692,7 @@
 
     "@vendure-io/docs-generator": ["@vendure-io/docs-generator@0.1.1", "", { "dependencies": { "fs-extra": "^11.0.0", "klaw-sync": "^6.0.0", "typescript": "^5.0.0" } }, "sha512-tn1BUZuacKM4d99CuVQHb+rttZJANy5kuhfWmjwhyzXMx2Nvv41WguBxVpF9njT/E7iLfyvRtwin8dom4zJF2A=="],
 
-    "@vendure-io/ui": ["@vendure-io/ui@1.0.5", "", { "dependencies": { "@base-ui/react": "^1.2.0", "@vendure-io/design-tokens": "^1.1.1", "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "date-fns": "^4.1.0", "embla-carousel-react": "^8.6.0", "input-otp": "^1.4.2", "lucide-react": "^0.575.0", "motion": "^12.23.13", "react-day-picker": "^9.14.0", "react-resizable-panels": "^4.7.0", "recharts": "2.15.4", "sonner": "^2.0.7", "tailwind-merge": "^3.5.0", "vaul": "^1.1.2" }, "peerDependencies": { "next": ">=14", "next-themes": "^0.4.6", "react": ">=19", "react-dom": ">=19", "react-hook-form": ">=7" }, "optionalPeers": ["next"] }, "sha512-J789oO+7m400ONfqDwcfLX08gSbuppNJBHo4etaU3TCTNsIXZorivaqRYMUDnl5SAfw6d/NIcodLeYjBMqk1XQ=="],
+    "@vendure-io/ui": ["@vendure-io/ui@1.1.0", "", { "dependencies": { "@base-ui/react": "^1.2.0", "@vendure-io/design-tokens": "^1.1.2", "class-variance-authority": "^0.7.1", "clsx": "^2.1.1", "cmdk": "^1.1.1", "date-fns": "^4.1.0", "embla-carousel-react": "^8.6.0", "input-otp": "^1.4.2", "lucide-react": "^0.575.0", "motion": "^12.23.13", "react-day-picker": "^9.14.0", "react-resizable-panels": "^4.7.0", "recharts": "2.15.4", "sonner": "^2.0.7", "tailwind-merge": "^3.5.0", "vaul": "^1.1.2" }, "peerDependencies": { "next": ">=14", "next-themes": "^0.4.6", "react": ">=19", "react-dom": ">=19", "react-hook-form": ">=7" }, "optionalPeers": ["next", "next-themes", "react-hook-form"] }, "sha512-AIemgiSrSX7Vph+DfwO12wF58GTzwx1A/KmHLMv4U9q222VpCXWPA9bdrXG1qmJtSdazi56LiboSDAMNBQOWJA=="],
 
     "@vendure/admin-ui": ["@vendure/admin-ui@workspace:packages/admin-ui"],
 

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -96,7 +96,7 @@
         "@types/react-dom": "^19.0.4",
         "@uidotdev/usehooks": "^2.4.1",
         "@vendure-io/design-tokens": "^1.1.2",
-        "@vendure-io/ui": "^1.0.5",
+        "@vendure-io/ui": "^1.1.0",
         "@vitejs/plugin-react": "^5.2.0",
         "acorn": "^8.16.0",
         "acorn-walk": "^8.3.5",

--- a/packages/dashboard/src/lib/components/ui/alert-dialog.tsx
+++ b/packages/dashboard/src/lib/components/ui/alert-dialog.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/vdb/lib/utils.js';
-import { AlertDialog as AlertDialogPrimitive } from '@base-ui/react/alert-dialog';
+import { AlertDialogPrimitive } from '@vendure-io/ui/lib/base-ui';
 
 export {
     AlertDialog,

--- a/packages/dashboard/src/lib/components/ui/collapsible.tsx
+++ b/packages/dashboard/src/lib/components/ui/collapsible.tsx
@@ -1,4 +1,4 @@
-import { Collapsible as CollapsiblePrimitive } from '@base-ui/react/collapsible';
+import { CollapsiblePrimitive } from '@vendure-io/ui/lib/base-ui';
 import { cn } from '@/vdb/lib/utils.js';
 
 function Collapsible({ ...props }: CollapsiblePrimitive.Root.Props) {

--- a/packages/dashboard/src/lib/components/ui/dialog.tsx
+++ b/packages/dashboard/src/lib/components/ui/dialog.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/vdb/lib/utils.js';
-import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
+import { DialogPrimitive } from '@vendure-io/ui/lib/base-ui';
 
 export {
     Dialog,


### PR DESCRIPTION
## Summary

- Bumps `@vendure-io/ui` from `^1.0.5` to `^1.1.0` (which adds the new `lib/base-ui` barrel re-exporting `@base-ui/react` primitive namespaces — see https://github.com/vendurehq/design/pull/14).
- Updates the three dashboard wrapper components that previously imported primitive namespaces directly from `@base-ui/react` to import them from `@vendure-io/ui/lib/base-ui`:
  - `dialog.tsx` — `DialogPrimitive`
  - `alert-dialog.tsx` — `AlertDialogPrimitive`
  - `collapsible.tsx` — `CollapsiblePrimitive`

After this change, no source file in `@vendure/dashboard` imports from `@base-ui/react`. The package becomes a pure implementation detail of `@vendure-io/ui`, and consumer projects no longer hit the transitive-resolution issue from #4655.

## Why

`@vendure/dashboard` was reaching into `@base-ui/react` only to obtain primitive namespaces for type/component overrides on a handful of wrapper components. That forced the dashboard to depend on `@base-ui/react` being hoist-resolvable in the consumer's `node_modules` tree, which broke in projects with conflicting version ranges elsewhere. Routing those imports through `@vendure-io/ui/lib/base-ui` removes the implicit dependency entirely.

Fixes #4655

## Test plan

- [x] `bun install` resolves cleanly with `@vendure-io/ui@1.1.0`
- [x] `bun run check-types` in `packages/dashboard` produces no new errors (two pre-existing `Input` `null`-assignment errors in `_assets/assets_.$id.tsx` and `_products/products_.$id.tsx` are unrelated and reproduce on `master`)
- [x] `grep -r "@base-ui" packages/dashboard/src` returns no import statements
- [ ] Smoke test: open a Dialog, an AlertDialog, and an animated Collapsible in the running dashboard

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4697"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->