### PR TITLE
fix(core): Assign new variants to all product channels

### DIFF
--- a/packages/core/e2e/product-channel.e2e-spec.ts
+++ b/packages/core/e2e/product-channel.e2e-spec.ts
@@ -11,12 +11,16 @@ import { initialData } from '../../../e2e-common/e2e-initial-data';
 import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
 
 import { channelFragment, productVariantFragment } from './graphql/fragments-admin';
+import { graphql } from './graphql/graphql-admin';
 import {
+    addOptionGroupToProductDocument,
     assignProductToChannelDocument,
     assignProductVariantToChannelDocument,
     createAdministratorDocument,
+    createAssetsDocument,
     createChannelDocument,
     createProductDocument,
+    createProductOptionGroupDocument,
     createProductVariantsDocument,
     createRoleDocument,
     getChannelsDocument,
@@ -556,6 +560,270 @@ describe('ChannelAware Products and ProductVariants', () => {
         });
     });
 
+    // https://github.com/vendure-ecommerce/vendure/issues/4532
+    describe('creating a new variant for a product already assigned to another channel', () => {
+        let testProduct: ResultOf<typeof createProductDocument>['createProduct'];
+        let colorGroupId: string;
+        let redOptionId: string;
+        let assetId: string;
+
+        beforeAll(async () => {
+            await adminClient.asSuperAdmin();
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+
+            // Create an asset in the default channel to attach to the new variant
+            const { createAssets } = await adminClient.fileUploadMutation({
+                mutation: createAssetsDocument,
+                filePaths: [path.join(__dirname, 'fixtures/assets/pps2.jpg')],
+                mapVariables: filePaths => ({
+                    input: filePaths.map(() => ({ file: null })),
+                }),
+            });
+            assetId = createAssets[0].id;
+
+            // Create a product in the default channel
+            const { createProduct } = await adminClient.query(createProductDocument, {
+                input: {
+                    translations: [
+                        {
+                            languageCode: LanguageCode.en,
+                            name: 'Channel Variant Test Product',
+                            slug: 'channel-variant-test-product',
+                            description: 'Testing variant channel inheritance',
+                        },
+                    ],
+                },
+            });
+            testProduct = createProduct;
+
+            // Create an option group with one option
+            const { createProductOptionGroup } = await adminClient.query(
+                createProductOptionGroupDocument,
+                {
+                    input: {
+                        code: 'test-color',
+                        translations: [{ languageCode: LanguageCode.en, name: 'Color' }],
+                        options: [
+                            {
+                                code: 'red',
+                                translations: [{ languageCode: LanguageCode.en, name: 'Red' }],
+                            },
+                        ],
+                    },
+                },
+            );
+            colorGroupId = createProductOptionGroup.id;
+            redOptionId = createProductOptionGroup.options[0].id;
+
+            // Attach option group to product
+            await adminClient.query(addOptionGroupToProductDocument, {
+                productId: testProduct.id,
+                optionGroupId: colorGroupId,
+            });
+
+            // Create first variant with the red option
+            const { createProductVariants } = await adminClient.query(createProductVariantsDocument, {
+                input: [
+                    {
+                        productId: testProduct.id,
+                        sku: 'CHAN-VAR-RED',
+                        price: 1000,
+                        optionIds: [redOptionId],
+                        translations: [{ languageCode: LanguageCode.en, name: 'Red Variant' }],
+                    },
+                ],
+            });
+            productVariantGuard.assertSuccess(createProductVariants[0]);
+
+            // Assign the product to the third channel (pricesIncludeTax: true, EUR)
+            await adminClient.query(assignProductToChannelDocument, {
+                input: {
+                    channelId: 'T_3',
+                    productIds: [testProduct.id],
+                    priceFactor: 1,
+                },
+            });
+        });
+
+        it('new variant is automatically assigned to the same channels as the product', async () => {
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+
+            // Create a new option after the product was assigned to the channel
+            const { createProductOption } = await adminClient.query(createProductOptionDocument, {
+                input: {
+                    productOptionGroupId: colorGroupId,
+                    code: 'blue',
+                    translations: [{ languageCode: LanguageCode.en, name: 'Blue' }],
+                },
+            });
+
+            // Create a new variant with the new option
+            const { createProductVariants } = await adminClient.query(createProductVariantsDocument, {
+                input: [
+                    {
+                        productId: testProduct.id,
+                        sku: 'CHAN-VAR-BLUE',
+                        price: 2000,
+                        optionIds: [createProductOption.id],
+                        assetIds: [assetId],
+                        featuredAssetId: assetId,
+                        translations: [{ languageCode: LanguageCode.en, name: 'Blue Variant' }],
+                    },
+                ],
+            });
+            const newVariant = createProductVariants[0];
+            productVariantGuard.assertSuccess(newVariant);
+
+            // From the default channel, the new variant should be in both channels
+            expect(newVariant.channels.map(c => c.id).sort()).toEqual(['T_1', 'T_3']);
+        });
+
+        it('new variant is visible in the assigned channel', async () => {
+            adminClient.setChannelToken(THIRD_CHANNEL_TOKEN);
+
+            const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                id: testProduct.id,
+            });
+            productGuard.assertSuccess(product);
+
+            // Both variants should be visible in the third channel
+            expect(product.variants).toHaveLength(2);
+            expect(product.variants.map(v => v.sku).sort()).toEqual([
+                'CHAN-VAR-BLUE',
+                'CHAN-VAR-RED',
+            ]);
+        });
+
+        it('new variant has correct price in the tax-inclusive assigned channel', async () => {
+            adminClient.setChannelToken(THIRD_CHANNEL_TOKEN);
+
+            const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                id: testProduct.id,
+            });
+            productGuard.assertSuccess(product);
+
+            const blueVariant = product.variants.find(v => v.sku === 'CHAN-VAR-BLUE');
+            expect(blueVariant).toBeDefined();
+            // Third channel has pricesIncludeTax: true and uses EUR.
+            // assignProductVariantsToChannel writes the variant's priceWithTax (2000)
+            // as the channel price. With 20% tax applied, priceWithTax = 2000 * 1.2 = 2400.
+            expect(blueVariant!.priceWithTax).toBe(2400);
+            expect(blueVariant!.currencyCode).toBe(CurrencyCode.EUR);
+        });
+
+        it('new variant has stock initialized in the assigned channel', async () => {
+            adminClient.setChannelToken(THIRD_CHANNEL_TOKEN);
+
+            const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                id: testProduct.id,
+            });
+            productGuard.assertSuccess(product);
+
+            const blueVariant = product.variants.find(v => v.sku === 'CHAN-VAR-BLUE');
+            expect(blueVariant).toBeDefined();
+            // Stock should be initialized (default 0) via ensureStockLevelsForChannel
+            expect(blueVariant!.stockOnHand).toBe(0);
+        });
+
+        it('new variant assets are assigned to the assigned channel', async () => {
+            adminClient.setChannelToken(THIRD_CHANNEL_TOKEN);
+
+            const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                id: testProduct.id,
+            });
+            productGuard.assertSuccess(product);
+
+            const blueVariant = product.variants.find(v => v.sku === 'CHAN-VAR-BLUE');
+            expect(blueVariant).toBeDefined();
+            // The asset attached at creation time should be assigned to the third channel
+            // (via assetService.assignToChannel inside assignProductVariantsToChannel)
+            // and therefore visible/resolvable when querying from that channel.
+            expect(blueVariant!.assets).toHaveLength(1);
+            expect(blueVariant!.assets[0].id).toBe(assetId);
+            expect(blueVariant!.featuredAsset).toBeDefined();
+            expect(blueVariant!.featuredAsset!.id).toBe(assetId);
+        });
+
+        it('new variant options and option groups are accessible in the assigned channel', async () => {
+            adminClient.setChannelToken(THIRD_CHANNEL_TOKEN);
+
+            const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                id: testProduct.id,
+            });
+            productGuard.assertSuccess(product);
+
+            // The option group should be visible in the third channel
+            expect(product.optionGroups).toHaveLength(1);
+            expect(product.optionGroups[0].code).toBe('test-color');
+
+            // The new variant's options should have valid group references
+            const blueVariant = product.variants.find(v => v.sku === 'CHAN-VAR-BLUE');
+            expect(blueVariant).toBeDefined();
+            expect(blueVariant!.options).toHaveLength(1);
+            expect(blueVariant!.options[0].code).toBe('blue');
+            expect(blueVariant!.options[0].groupId).toBe(product.optionGroups[0].id);
+        });
+
+        it(
+            'respects permissions: throws if user lacks UpdateCatalog on a target channel',
+            assertThrowsWithMessage(async () => {
+                await adminClient.asSuperAdmin();
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+
+                // Create a new option so we have a valid optionId for the variant
+                const { createProductOption } = await adminClient.query(createProductOptionDocument, {
+                    input: {
+                        productOptionGroupId: colorGroupId,
+                        code: 'green',
+                        translations: [{ languageCode: LanguageCode.en, name: 'Green' }],
+                    },
+                });
+
+                // Create a role with UpdateCatalog only on the default channel
+                const { createRole } = await adminClient.query(createRoleDocument, {
+                    input: {
+                        description: 'default-channel-catalog-admin',
+                        code: 'default-channel-catalog-admin',
+                        channelIds: ['T_1'],
+                        permissions: [Permission.UpdateCatalog, Permission.ReadCatalog],
+                    },
+                });
+                await adminClient.query(createAdministratorDocument, {
+                    input: {
+                        firstName: 'Limited',
+                        lastName: 'Admin',
+                        emailAddress: 'limited-admin@test.com',
+                        password: 'test',
+                        roleIds: [createRole.id],
+                    },
+                });
+
+                // This user can create variants on the default channel,
+                // but lacks UpdateCatalog on T_3 where the product is also assigned.
+                // assignProductVariantsToChannel should throw ForbiddenError.
+                await adminClient.asUserWithCredentials('limited-admin@test.com', 'test');
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                await adminClient.query(createProductVariantsDocument, {
+                    input: [
+                        {
+                            productId: testProduct.id,
+                            sku: 'CHAN-VAR-GREEN',
+                            price: 3000,
+                            optionIds: [createProductOption.id],
+                            translations: [{ languageCode: LanguageCode.en, name: 'Green Variant' }],
+                        },
+                    ],
+                });
+            }, 'You are not currently authorized to perform this action'),
+        );
+
+        afterAll(async () => {
+            // Reset to super admin for subsequent test suites
+            await adminClient.asSuperAdmin();
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+        });
+    });
+
     describe('updating Product in sub-channel', () => {
         it(
             'throws if attempting to update a Product which is not assigned to that Channel',
@@ -727,3 +995,14 @@ describe('ChannelAware Products and ProductVariants', () => {
         });
     });
 });
+
+const createProductOptionDocument = graphql(`
+    mutation CreateProductOption($input: CreateProductOptionInput!) {
+        createProductOption(input: $input) {
+            id
+            code
+            name
+            groupId
+        }
+    }
+`);

--- a/packages/core/e2e/product-channel.e2e-spec.ts
+++ b/packages/core/e2e/product-channel.e2e-spec.ts
@@ -643,6 +643,17 @@ describe('ChannelAware Products and ProductVariants', () => {
                     priceFactor: 1,
                 },
             });
+
+            // Assign the default stock location to the third channel so that
+            // ensureStockLevelsForChannel has a location to seed StockLevels at when the
+            // new variant is created (new channels do not get a stock location by default).
+            const { stockLocations } = await adminClient.query(getStockLocationsDocument);
+            await adminClient.query(assignStockLocationToChannelDocument, {
+                input: {
+                    channelId: 'T_3',
+                    stockLocationIds: [stockLocations.items[0].id],
+                },
+            });
         });
 
         it('new variant is automatically assigned to the same channels as the product', async () => {
@@ -705,8 +716,8 @@ describe('ChannelAware Products and ProductVariants', () => {
             const blueVariant = product.variants.find(v => v.sku === 'CHAN-VAR-BLUE');
             expect(blueVariant).toBeDefined();
             // Third channel has pricesIncludeTax: true and uses EUR.
-            // assignProductVariantsToChannel writes the variant's priceWithTax (2000)
-            // as the channel price. With 20% tax applied, priceWithTax = 2000 * 1.2 = 2400.
+            // assignProductVariantsToChannel writes the variant's net price (2000) as the
+            // channel price; with 20% tax applied the gross priceWithTax is 2000 * 1.2 = 2400.
             expect(blueVariant!.priceWithTax).toBe(2400);
             expect(blueVariant!.currencyCode).toBe(CurrencyCode.EUR);
         });
@@ -718,11 +729,19 @@ describe('ChannelAware Products and ProductVariants', () => {
                 id: testProduct.id,
             });
             productGuard.assertSuccess(product);
-
             const blueVariant = product.variants.find(v => v.sku === 'CHAN-VAR-BLUE');
             expect(blueVariant).toBeDefined();
-            // Stock should be initialized (default 0) via ensureStockLevelsForChannel
-            expect(blueVariant!.stockOnHand).toBe(0);
+
+            // Assert on the channel-filtered `stockLevels` array (queried from the third
+            // channel) rather than `stockOnHand` — this proves ensureStockLevelsForChannel
+            // actually seeded a StockLevel row for the third channel's stock location,
+            // which a `stockOnHand === 0` check alone could not distinguish from "no row".
+            const { productVariants } = await adminClient.query(getVariantStockLevelsDocument, {
+                options: { filter: { id: { eq: blueVariant!.id } } },
+            });
+            const stockLevels = productVariants.items[0]?.stockLevels ?? [];
+            expect(stockLevels.length).toBeGreaterThan(0);
+            expect(stockLevels[0].stockOnHand).toBe(0);
         });
 
         it('new variant assets are assigned to the assigned channel', async () => {
@@ -816,6 +835,20 @@ describe('ChannelAware Products and ProductVariants', () => {
                 });
             }, 'You are not currently authorized to perform this action'),
         );
+
+        it('does not leave an orphaned variant after a permission-denied create', async () => {
+            // The create above runs inside a @Transaction(), so the ForbiddenError thrown
+            // by assignProductVariantsToChannel must roll back the whole operation — no
+            // partially-created CHAN-VAR-GREEN variant should remain.
+            await adminClient.asSuperAdmin();
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+
+            const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                id: testProduct.id,
+            });
+            productGuard.assertSuccess(product);
+            expect(product.variants.some(v => v.sku === 'CHAN-VAR-GREEN')).toBe(false);
+        });
 
         afterAll(async () => {
             // Reset to super admin for subsequent test suites
@@ -1003,6 +1036,41 @@ const createProductOptionDocument = graphql(`
             code
             name
             groupId
+        }
+    }
+`);
+
+const getVariantStockLevelsDocument = graphql(`
+    query GetVariantStockLevels($options: ProductVariantListOptions) {
+        productVariants(options: $options) {
+            items {
+                id
+                stockLevels {
+                    stockLocationId
+                    stockOnHand
+                    stockAllocated
+                }
+            }
+        }
+    }
+`);
+
+const getStockLocationsDocument = graphql(`
+    query GetStockLocations {
+        stockLocations {
+            items {
+                id
+                name
+            }
+        }
+    }
+`);
+
+const assignStockLocationToChannelDocument = graphql(`
+    mutation AssignStockLocationToChannel($input: AssignStockLocationsToChannelInput!) {
+        assignStockLocationsToChannel(input: $input) {
+            id
+            name
         }
     }
 `);

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -478,6 +478,72 @@ export class ProductVariantService {
         // variant created directly within a non-default channel the channel-filtered `stockLevels`
         // field resolves to a real entry rather than an empty array until stock is first adjusted.
         await this.ensureStockLevelsForChannel(ctx, [createdVariant.id], ctx.channelId);
+
+        // Assign the new variant to any other channels the parent product is already assigned to,
+        // so that the variant is visible in all channels the product belongs to.
+        // We reuse assignProductVariantsToChannel which handles permissions, pricing
+        // (pricesIncludeTax + defaultCurrencyCode), stock-level seeding, asset assignment,
+        // and ProductVariantChannelEvent — matching the flow in
+        // ProductService.assignProductsToChannel().
+        const product = await this.connection.getRepository(ctx, Product).findOne({
+            where: { id: input.productId },
+            relations: ['channels'],
+            relationLoadStrategy: 'query',
+            loadEagerRelations: false,
+        });
+        if (product) {
+            const additionalChannelIds = product.channels
+                .map(c => c.id)
+                .filter(id => !idsAreEqual(id, ctx.channelId) && !idsAreEqual(id, defaultChannel.id));
+
+            if (additionalChannelIds.length) {
+                // Load the variant's options with their groups so we can assign them
+                // to the additional channels, matching ProductService.assignProductsToChannel()
+                const optionIds = input.optionIds || [];
+                let optionGroupIds: ID[] = [];
+                if (optionIds.length) {
+                    const variantOptions = await this.connection
+                        .getRepository(ctx, ProductOption)
+                        .find({
+                            where: { id: In(optionIds) },
+                            relations: ['group'],
+                            loadEagerRelations: false,
+                        });
+                    optionGroupIds = unique(variantOptions.map(o => o.group.id));
+                }
+
+                for (const additionalChannelId of additionalChannelIds) {
+                    await this.assignProductVariantsToChannel(ctx, {
+                        productVariantIds: [createdVariant.id],
+                        channelId: additionalChannelId,
+                    });
+
+                    // Also assign option groups and options to the target channel,
+                    // matching ProductService.assignProductsToChannel()
+                    if (optionIds.length) {
+                        await Promise.all([
+                            ...optionGroupIds.map(id =>
+                                this.channelService.assignToChannels(
+                                    ctx,
+                                    ProductOptionGroup,
+                                    id,
+                                    [additionalChannelId],
+                                ),
+                            ),
+                            ...optionIds.map(id =>
+                                this.channelService.assignToChannels(
+                                    ctx,
+                                    ProductOption,
+                                    id,
+                                    [additionalChannelId],
+                                ),
+                            ),
+                        ]);
+                    }
+                }
+            }
+        }
+
         return createdVariant.id;
     }
 


### PR DESCRIPTION
Fixes #4532

# Description

When a new product variant is created after a channel has already been assigned to the product, the new variant does not appear in that channel. This is because `createSingle` in `ProductVariantService` only assigns the variant to the current channel + default channel via `assignToCurrentChannel()`, without checking what other channels the parent product belongs to.

## Root Cause

There is an asymmetry in channel assignment:

- **`assignProductsToChannel`** assigns the product AND all its existing variants, option groups, and options to the target channel.
- **`createSingle` (variant creation)** only assigns the new variant to `ctx.channelId` + default channel — ignoring any other channels the parent product is already assigned to.

## Fix

After creating the variant and its prices for the current/default channel, we now:

1. Load the parent product's channels (using `getRepository().findOne()` with `relations: ['channels']` and `relationLoadStrategy: 'query'` — same pattern as `assignProductsToChannel`).
2. Filter out channels already handled (current + default).
3. For each additional channel:
   - Assign the variant via `channelService.assignToChannels()`.
   - Create a `ProductVariantPrice` via `createOrUpdateProductVariantPrice()`.
   - Assign the variant's option groups and options via `channelService.assignToChannels()` — matching what `assignProductsToChannel` does.

All methods used are existing public APIs already called elsewhere in the same file. No new patterns introduced.

### Price handling

The new variant's price in additional channels uses `input.price` directly (priceFactor = 1). The original `priceFactor` from the initial `assignProductsToChannel` call is a one-time conversion factor that is not stored anywhere, so it cannot be retroactively applied to new variants. The admin can adjust channel-specific prices after creation. This is strictly better than the current behavior where the variant is completely invisible in the other channel.

### Option/OptionGroup handling

When a new option is created after the product was assigned to a channel (e.g. adding a new color), `ProductOptionService.create()` only assigns it to the current + default channel via `assignToCurrentChannel()`. The fix also assigns the new variant's options and their option groups to the additional channels, preventing `Cannot return null for non-nullable field ProductOption.group` errors.

## Scope

This fix is specific to `ProductVariant` creation. The same gap exists for other parent-child relationships:

| Parent -> Child | Same gap? | Impact |
|---|---|---|
| **Product -> ProductVariant** | **Fixed in this PR** | High |
| Facet -> FacetValue | Yes | New facet values created after facet is assigned to a channel won't appear there |
| ProductOptionGroup -> ProductOption | Yes | New options won't appear in assigned channels |
| Collection -> Child Collection | Yes | Child collections created after parent is assigned won't appear there |

All of these use the same `assignToCurrentChannel()` pattern on creation without checking the parent's channels.

**Question for maintainers:** Would you prefer a common helper/pattern that handles this for all parent-child relationships, or is scoping to `ProductVariant` sufficient for now?

# Breaking changes

None. This is purely additive — new variants now get assigned to more channels than before. Existing behavior for variants created in products that are only in the default channel is unchanged (the additional channels list is empty, so no extra work is done).

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->