### PR TITLE
fix(core): Fix race condition in manual task trigger

### DIFF
--- a/packages/core/src/plugin/default-scheduler-plugin/default-scheduler-strategy.ts
+++ b/packages/core/src/plugin/default-scheduler-plugin/default-scheduler-strategy.ts
@@ -200,10 +200,6 @@ export class DefaultSchedulerStrategy implements SchedulerStrategy {
         Logger.debug(`Checking for manually triggered tasks: ${taskEntities.length}`);
 
         for (const taskEntity of taskEntities) {
-            await this.connection.rawConnection
-                .getRepository(ScheduledTaskRecord)
-                .update({ taskId: taskEntity.taskId }, { manuallyTriggeredAt: null });
-
             const task = this.tasks.get(taskEntity.taskId);
             if (task) {
                 Logger.info(`Executing manually triggered task: ${task.task.id}`);
@@ -264,10 +260,12 @@ export class DefaultSchedulerStrategy implements SchedulerStrategy {
                     return false;
                 }
 
-                // Now update the lock within the same transaction
+                // Now update the lock within the same transaction.
+                // Also clear manuallyTriggeredAt so that if the task was manually triggered,
+                // the flag is only cleared once the lock is actually acquired.
                 await manager
                     .getRepository(ScheduledTaskRecord)
-                    .update({ id: taskRecord.id }, { lockedAt: new Date() });
+                    .update({ id: taskRecord.id }, { lockedAt: new Date(), manuallyTriggeredAt: null });
 
                 return true;
             });
@@ -279,7 +277,7 @@ export class DefaultSchedulerStrategy implements SchedulerStrategy {
                 .getRepository(ScheduledTaskRecord)
                 .createQueryBuilder('task')
                 .update()
-                .set({ lockedAt: new Date() })
+                .set({ lockedAt: new Date(), manuallyTriggeredAt: null })
                 .where('taskId = :taskId', { taskId: task.id })
                 .andWhere('lockedAt IS NULL')
                 .andWhere('enabled = TRUE')


### PR DESCRIPTION
## Problem

`runScheduledTask` mutation returns `success: true` but the task only executes ~50% of the time. The `manuallyTriggeredAt` flag is cleared in `checkForManuallyTriggeredTasks` **before** `executeTask` attempts to acquire the lock. If a concurrent cron execution holds the lock at that moment, `tryAcquireLock` fails silently and the trigger is permanently lost with no retry.

## Fix

Move the `manuallyTriggeredAt = null` clearing into `tryAcquireLock` itself, so the flag is only cleared atomically when the lock is successfully acquired. If the lock fails (cron holds it), the flag remains set and the next polling cycle retries.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4704"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->