### PR TITLE
fix(dashboard): fix tiptap toolbar not reacting to state changes

### DIFF
--- a/packages/dashboard/src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+++ b/packages/dashboard/src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
@@ -1,5 +1,5 @@
 import { Trans } from '@lingui/react/macro';
-import { Editor } from '@tiptap/react';
+import { Editor, useEditorState } from '@tiptap/react';
 import {
     BoldIcon,
     ImageIcon,
@@ -48,6 +48,21 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
     const [overflowItems, setOverflowItems] = useState<string[]>([]);
     const toolbarRef = useRef<HTMLDivElement>(null);
 
+    const editorState = useEditorState({
+        editor: editor!,
+        selector: (context) => ({
+            isBold: context.editor.isActive("bold"),
+            isItalic: context.editor.isActive("italic"),
+            isStrike: context.editor.isActive('strike'),
+            isBulletList: context.editor.isActive('bulletList'),
+            isOrderedList: context.editor.isActive('orderedList'),
+            isLink: context.editor.isActive('link'),
+            isImage: context.editor.isActive('image'),
+            isBlockquote: context.editor.isActive('blockquote'),
+            isTable: context.editor.isActive('table')
+        }),
+    })
+
     const handleHeadingChange = useCallback(
         (value: string) => {
             if (!editor) return;
@@ -94,7 +109,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                 id: 'bold',
                 priority: 1,
                 label: 'Bold',
-                isActive: editor.isActive('bold'),
+                isActive: editorState.isBold,
                 action: () => editor.chain().focus().toggleBold().run(),
                 element: (
                     <Button
@@ -103,7 +118,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                         variant="ghost"
                         size="sm"
                         onClick={() => editor.chain().focus().toggleBold().run()}
-                        className={`h-8 px-2 ${editor.isActive('bold') ? 'bg-accent' : ''}`}
+                        className={`h-8 px-2 ${editorState.isBold ? 'bg-accent' : ''}`}
                         disabled={disabled}
                     >
                         <BoldIcon className="h-4 w-4" />
@@ -114,7 +129,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                 id: 'italic',
                 priority: 2,
                 label: 'Italic',
-                isActive: editor.isActive('italic'),
+                isActive: editorState.isItalic,
                 action: () => editor.chain().focus().toggleItalic().run(),
                 element: (
                     <Button
@@ -123,7 +138,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                         variant="ghost"
                         size="sm"
                         onClick={() => editor.chain().focus().toggleItalic().run()}
-                        className={`h-8 px-2 ${editor.isActive('italic') ? 'bg-accent' : ''}`}
+                        className={`h-8 px-2 ${editorState.isItalic ? 'bg-accent' : ''}`}
                         disabled={disabled}
                     >
                         <ItalicIcon className="h-4 w-4" />
@@ -134,7 +149,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                 id: 'strike',
                 priority: 3,
                 label: 'Strikethrough',
-                isActive: editor.isActive('strike'),
+                isActive: editorState.isStrike,
                 action: () => editor.chain().focus().toggleStrike().run(),
                 element: (
                     <Button
@@ -143,7 +158,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                         variant="ghost"
                         size="sm"
                         onClick={() => editor.chain().focus().toggleStrike().run()}
-                        className={`h-8 px-2 ${editor.isActive('strike') ? 'bg-accent' : ''}`}
+                        className={`h-8 px-2 ${editorState.isStrike ? 'bg-accent' : ''}`}
                         disabled={disabled}
                     >
                         <StrikethroughIcon className="h-4 w-4" />
@@ -154,7 +169,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                 id: 'bulletList',
                 priority: 4,
                 label: 'Bullet List',
-                isActive: editor.isActive('bulletList'),
+                isActive: editorState.isBulletList,
                 action: () => editor.chain().focus().toggleBulletList().run(),
                 element: (
                     <Button
@@ -163,7 +178,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                         variant="ghost"
                         size="sm"
                         onClick={() => editor.chain().focus().toggleBulletList().run()}
-                        className={`h-8 px-2 ${editor.isActive('bulletList') ? 'bg-accent' : ''}`}
+                        className={`h-8 px-2 ${editorState.isBulletList ? 'bg-accent' : ''}`}
                         disabled={disabled}
                     >
                         <ListIcon className="h-4 w-4" />
@@ -174,7 +189,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                 id: 'orderedList',
                 priority: 5,
                 label: 'Ordered List',
-                isActive: editor.isActive('orderedList'),
+                isActive: editorState.isOrderedList,
                 action: () => editor.chain().focus().toggleOrderedList().run(),
                 element: (
                     <Button
@@ -183,7 +198,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                         variant="ghost"
                         size="sm"
                         onClick={() => editor.chain().focus().toggleOrderedList().run()}
-                        className={`h-8 px-2 ${editor.isActive('orderedList') ? 'bg-accent' : ''}`}
+                        className={`h-8 px-2 ${editorState.isOrderedList ? 'bg-accent' : ''}`}
                         disabled={disabled}
                     >
                         <ListOrderedIcon className="h-4 w-4" />
@@ -194,7 +209,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                 id: 'link',
                 priority: 6,
                 label: 'Link',
-                isActive: editor.isActive('link'),
+                isActive: editorState.isLink,
                 action: () => setLinkDialogOpen(true),
                 element: (
                     <Button
@@ -203,7 +218,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                         variant="ghost"
                         size="sm"
                         onClick={() => setLinkDialogOpen(true)}
-                        className={`h-8 px-2 ${editor.isActive('link') ? 'bg-accent' : ''}`}
+                        className={`h-8 px-2 ${editorState.isLink ? 'bg-accent' : ''}`}
                         disabled={disabled}
                     >
                         <LinkIcon className="h-4 w-4" />
@@ -214,7 +229,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                 id: 'image',
                 priority: 7,
                 label: 'Image',
-                isActive: editor.isActive('image'),
+                isActive: editor.isActive("image"),
                 action: () => setImageDialogOpen(true),
                 element: (
                     <Button
@@ -223,7 +238,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                         variant="ghost"
                         size="sm"
                         onClick={() => setImageDialogOpen(true)}
-                        className={`h-8 px-2 ${editor.isActive('image') ? 'bg-accent' : ''}`}
+                        className={`h-8 px-2 ${editor.isActive("image") ? 'bg-accent' : ''}`}
                         disabled={disabled}
                     >
                         <ImageIcon className="h-4 w-4" />
@@ -234,7 +249,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                 id: 'blockquote',
                 priority: 8,
                 label: 'Blockquote',
-                isActive: editor.isActive('blockquote'),
+                isActive: editorState.isBlockquote,
                 action: () => editor.chain().focus().toggleBlockquote().run(),
                 element: (
                     <Button
@@ -243,7 +258,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                         variant="ghost"
                         size="sm"
                         onClick={() => editor.chain().focus().toggleBlockquote().run()}
-                        className={`h-8 px-2 ${editor.isActive('blockquote') ? 'bg-accent' : ''}`}
+                        className={`h-8 px-2 ${editorState.isBlockquote ? 'bg-accent' : ''}`}
                         disabled={disabled}
                     >
                         <QuoteIcon className="h-4 w-4" />
@@ -254,7 +269,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                 id: 'table',
                 priority: 9,
                 label: 'Table',
-                isActive: editor.isActive('table'),
+                isActive: editorState.isTable,
                 action: () =>
                     editor.chain().focus().insertTable({ rows: 3, cols: 3, withHeaderRow: true }).run(),
                 element: (
@@ -274,7 +289,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                                 })
                                 .run()
                         }
-                        className={`h-8 px-2 ${editor.isActive('table') ? 'bg-accent' : ''}`}
+                        className={`h-8 px-2 ${editorState.isTable ? 'bg-accent' : ''}`}
                         disabled={disabled || !canInsertTable}
                     >
                         <TableIcon className="h-4 w-4" />
@@ -320,7 +335,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                 ),
             },
         ];
-    }, [editor, disabled, linkDialogOpen, imageDialogOpen, canUndo, canRedo, canInsertTable]);
+    }, [editor, disabled, linkDialogOpen, imageDialogOpen, canUndo, canRedo, canInsertTable, editorState]);
 
     useEffect(() => {
         const calculateVisibleItems = () => {

--- a/packages/dashboard/src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+++ b/packages/dashboard/src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
@@ -229,7 +229,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                 id: 'image',
                 priority: 7,
                 label: 'Image',
-                isActive: editor.isActive("image"),
+                isActive: editorState.isImage,
                 action: () => setImageDialogOpen(true),
                 element: (
                     <Button
@@ -238,7 +238,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
                         variant="ghost"
                         size="sm"
                         onClick={() => setImageDialogOpen(true)}
-                        className={`h-8 px-2 ${editor.isActive("image") ? 'bg-accent' : ''}`}
+                        className={`h-8 px-2 ${editorState.isImage ? 'bg-accent' : ''}`}
                         disabled={disabled}
                     >
                         <ImageIcon className="h-4 w-4" />

--- a/packages/dashboard/src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+++ b/packages/dashboard/src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
@@ -49,18 +49,24 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
     const toolbarRef = useRef<HTMLDivElement>(null);
 
     const editorState = useEditorState({
-        editor: editor!,
-        selector: (context) => ({
-            isBold: context.editor.isActive('bold'),
-            isItalic: context.editor.isActive('italic'),
-            isStrike: context.editor.isActive('strike'),
-            isBulletList: context.editor.isActive('bulletList'),
-            isOrderedList: context.editor.isActive('orderedList'),
-            isLink: context.editor.isActive('link'),
-            isImage: context.editor.isActive('image'),
-            isBlockquote: context.editor.isActive('blockquote'),
-            isTable: context.editor.isActive('table')
-        }),
+        editor: editor,
+        selector: (context) => {
+            if (context.editor == null) {
+                return;
+            }
+
+            return {
+                isBold: context.editor.isActive('bold'),
+                isItalic: context.editor.isActive('italic'),
+                isStrike: context.editor.isActive('strike'),
+                isBulletList: context.editor.isActive('bulletList'),
+                isOrderedList: context.editor.isActive('orderedList'),
+                isLink: context.editor.isActive('link'),
+                isImage: context.editor.isActive('image'),
+                isBlockquote: context.editor.isActive('blockquote'),
+                isTable: context.editor.isActive('table')
+            }
+        }
     })
 
     const handleHeadingChange = useCallback(
@@ -102,7 +108,7 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
     const canInsertTable = !!editor?.can().insertTable();
 
     const toolbarItems: ToolbarItem[] = useMemo(() => {
-        if (!editor) return [];
+        if (!editor || !editorState) return [];
 
         return [
             {

--- a/packages/dashboard/src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
+++ b/packages/dashboard/src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx
@@ -51,8 +51,8 @@ export function ResponsiveToolbar({ editor, disabled }: Readonly<ResponsiveToolb
     const editorState = useEditorState({
         editor: editor!,
         selector: (context) => ({
-            isBold: context.editor.isActive("bold"),
-            isItalic: context.editor.isActive("italic"),
+            isBold: context.editor.isActive('bold'),
+            isItalic: context.editor.isActive('italic'),
             isStrike: context.editor.isActive('strike'),
             isBulletList: context.editor.isActive('bulletList'),
             isOrderedList: context.editor.isActive('orderedList'),


### PR DESCRIPTION
# Description

Whenever the content inside Tiptap's Rich Text Editor changes, the toolbar does not seem to react to the state changes. This can be fixed using the useEditorState() hook provided by '@tiptap/react'.

# Screenshots

Broken:

https://github.com/user-attachments/assets/58820ccc-5cc4-4cc8-98af-59471a18f0af

Fixed:

https://github.com/user-attachments/assets/d3d5494f-3d76-4f17-9d69-682fb0573e4c

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4705"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->