### PR TITLE
fix(dashboard): Skip rate limit for static assets and add long-lived cache

### DIFF
--- a/packages/dashboard/plugin/dashboard.plugin.ts
+++ b/packages/dashboard/plugin/dashboard.plugin.ts
@@ -189,10 +189,29 @@ export class DashboardPlugin implements NestModule {
             limit: this.rateLimitRequests,
             standardHeaders: true,
             legacyHeaders: false,
+            // Content-hashed bundles under /assets/ are immutable and a single
+            // page load fires ~190 chunk requests; counting them against the
+            // bucket exhausts it within a few tabs (see #4665).
+            skip: req => req.path.startsWith('/assets/'),
         });
 
         const dashboardServer = express.Router();
         dashboardServer.use(limiter);
+        // Serve hashed assets with a long-lived immutable Cache-Control header
+        // so CDNs and browsers can cache them indefinitely. This is safe because
+        // Vite emits content-hashed filenames into /assets — a missing chunk
+        // means a stale reference, so the explicit 404 handler below stops the
+        // request from falling through to the SPA index.html shell, which would
+        // otherwise be served with the asset's expected MIME and crash the app
+        // on "Unexpected token '<'".
+        dashboardServer.use(
+            '/assets',
+            express.static(path.join(dashboardPath, 'assets'), {
+                maxAge: '1y',
+                immutable: true,
+            }),
+        );
+        dashboardServer.use('/assets', (_req, res) => res.status(404).end());
         dashboardServer.use(express.static(dashboardPath));
         dashboardServer.use((req, res) => {
             res.sendFile('index.html', { root: dashboardPath });
@@ -271,6 +290,9 @@ export class DashboardPlugin implements NestModule {
             limit: this.rateLimitRequests,
             standardHeaders: true,
             legacyHeaders: false,
+            // See note in createStaticServer — /assets/* is immutable and a
+            // single page load fires ~190 chunk requests.
+            skip: req => req.path.startsWith('/assets/'),
         });
 
         // Pre-create handlers to avoid recreating them on each request


### PR DESCRIPTION
## Summary

The `DashboardPlugin` rate-limiters (`createStaticServer` + `createDynamicHandler`) count every hashed JS/CSS chunk request under `/assets/*` against the same bucket as page loads. With Vite producing ~190 chunks per dashboard page, opening 3 variant tabs in burst (~570 requests) exhausts the 500 req/60s production limit. The browser receives a mix of 429'd documents and 429'd chunks, leaving the React app crashed mid-load with `TypeError: Failed to fetch dynamically imported module`.

This PR fixes the issue at the routing layer.

## Changes

`packages/dashboard/plugin/dashboard.plugin.ts`:

1. **Skip rate-limiting for `/assets/*`** in both rate limiters (`createStaticServer` + `createDynamicHandler`). Hashed asset filenames are immutable by construction, so rate-limiting them serves no security purpose. Both predicates needed because the dynamic handler's outer limiter would otherwise count asset requests before they ever reach the inner static server.

2. **Long-lived immutable cache headers on `/assets/*`** (`Cache-Control: public, max-age=31536000, immutable`). Mounted explicitly before the catch-all `express.static(dashboardPath)` so the appropriate cache header is set for content-hashed chunks. Aligns with Vite's documented caching recommendation.

3. **Explicit 404 handler for `/assets/*`** after the static mount. Without this, a missing `/assets/X.js` would fall through to the SPA `index.html` shell and the browser would crash on `Unexpected token '<'` trying to parse HTML as JS. Tried `fallthrough: false` first but it triggers the framework exception filter and returns 500 with empty body — explicit `res.status(404).end()` gives a clean 404 instead.

`createDefaultPage`'s rate limiter is intentionally untouched: the default page serves a single hardcoded HTML response with no chunk references, so `/assets/*` cannot reach it.

## Test plan

Verified locally against a rebuilt dev-server in built mode:

- [x] `/dashboard/assets/<hashed>.js` → 200, `Cache-Control: public, max-age=31536000, immutable`, `Content-Type: text/javascript`, **no** `RateLimit-*` headers, body size matches file (5852 B)
- [x] `/dashboard/assets/missing.js` → clean 404
- [x] `/dashboard/` → 200, `RateLimit-*` headers present (regression check that root is still rate-limited)
- [x] `/dashboard/__status` → still rate-limited (skip is narrow, only `/assets/*`)
- [x] `/dashboard/products/1` → 200, SPA fallback returns `index.html` (text/html) — SPA routing unchanged
- [x] **Burst test (200 parallel requests, dev limit = 100k):**
  - 200 requests to `/dashboard/assets/<hashed>.js` → all 200, `RateLimit-Remaining` for `/dashboard/` dropped by exactly **1** (the sniffer between bursts) → asset requests do not consume the bucket at all
  - 200 requests to `/dashboard/` → all 200, `RateLimit-Remaining` dropped by **~200** → root path correctly rate-limited

In production mode (limit=500), the same 200-asset burst would have dropped remaining from 500→499 instead of 500→300, which is the original bug.

Fixes #4665

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4709"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->