### PR TITLE
fix(create): Add vite as direct dev dependency in scaffolded projects

### DIFF
--- a/packages/create/src/constants.ts
+++ b/packages/create/src/constants.ts
@@ -8,6 +8,16 @@ export const STOREFRONT_BRANCH = 'main';
  * introduce breaking changes.
  */
 export const TYPESCRIPT_VERSION = '5.8.2';
+/**
+ * Vite must be a direct dependency of the scaffolded project because the
+ * generated vite.config.mts imports `vite` directly, and strict
+ * (non-hoisting) package managers like pnpm don't expose transitive deps.
+ * The range tracks @vendure/dashboard's declaration so the scaffold stays
+ * on the same Vite major line as the dashboard (currently v7); the caret
+ * caps at <8.0.0, which is important because Vite 8 ships a Rolldown-based
+ * bundler with breaking changes.
+ */
+export const VITE_VERSION = '^7.3.1';
 
 // Port scanning
 export const PORT_SCAN_RANGE = 20;

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -12,7 +12,7 @@ import pc from 'picocolors';
 import semver from 'semver';
 import * as tar from 'tar';
 
-import { STOREFRONT_BRANCH, STOREFRONT_REPO, TYPESCRIPT_VERSION } from './constants';
+import { STOREFRONT_BRANCH, STOREFRONT_REPO, TYPESCRIPT_VERSION, VITE_VERSION } from './constants';
 import { log } from './logger';
 import { CliLogLevel, DbType } from './types';
 
@@ -236,6 +236,7 @@ export function getDependencies(
         'concurrently',
         'ts-node',
         `typescript@${TYPESCRIPT_VERSION}`,
+        `vite@${VITE_VERSION}`,
     ];
     return { dependencies, devDependencies };
 }


### PR DESCRIPTION
## Summary

Scaffolded projects from `@vendure/create` failed to build under pnpm strict (or yarn pnp) because the generated `vite.config.mts` imports `vite` directly, but `vite` was not declared as a direct dependency of the scaffold. Under npm's hoisting, `vite` was reachable transitively via `@vendure/dashboard`, masking the issue. Under strict layouts:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vite' imported from .../vite.config.mts
```

This PR adds `vite` as a direct devDependency in the scaffold output.

## Changes

- `packages/create/src/constants.ts` — added `VITE_VERSION = '^7.3.1'` constant. The range tracks `@vendure/dashboard`'s declaration so the scaffold stays on the same Vite major line as the dashboard. The caret caps at `<8.0.0`, important because Vite 8 ships a Rolldown-based bundler with breaking changes.
- `packages/create/src/helpers.ts` — added `vite@${VITE_VERSION}` to the devDependencies array in `getDependencies()`.

### Audit of scaffold imports vs declared deps

Reviewed all `packages/create/templates/*.hbs` for external imports:

| Import | Status |
|---|---|
| `@vendure/core`, `@vendure/asset-server-plugin`, `@vendure/email-plugin`, `@vendure/graphiql-plugin`, `@vendure/dashboard` | already in deps |
| `dotenv` | already in deps |
| `path`, `url` | Node builtins (no install needed) |
| **`vite`** | **missing — this PR adds it** |

No other gaps.

## Test plan

End-to-end verified locally:

- [x] Built `@vendure/create`; `getDependencies('postgres', '@3.6.3')` returns `vite@^7.3.1` in devDependencies
- [x] Ran scaffold: `node packages/create/index.js my-app --ci` → generated `package.json` lists `"vite": "7.3.3"` under `devDependencies`
- [x] `pnpm install && pnpm run build:dashboard` in the scaffolded project: build succeeded (18.98s, all chunks emitted)
- [x] **Negative test**: removed `vite` from the same scaffolded project's `package.json`, reinstalled with pnpm, ran `pnpm run build:dashboard` → reproduced the original `Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'vite'`. Confirms the dependency was indeed the cause.
- [x] `npx tsc --noEmit` clean for the changed files
- [x] `eslint` clean

## Follow-up worth considering (out of scope)

`@vendure/dashboard` declares `vite` under `dependencies` rather than `peerDependencies` (`packages/dashboard/package.json:129`). Arguably a Vite plugin that requires consumers to import `vite` in their own code should declare it as a peer dep. If that change were made upstream, the scaffold wouldn't need to know vite's version at all. Worth a separate issue.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4710"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->