### PR TITLE
fix: Prevent facet value chip remove button from being hidden on long…

### DIFF
--- a/packages/dashboard/src/lib/components/shared/assigned-facet-values.tsx
+++ b/packages/dashboard/src/lib/components/shared/assigned-facet-values.tsx
@@ -45,7 +45,7 @@ export function AssignedFacetValues({
                     const facetValue = knownFacetValues.find(fv => fv.id === id);
                     if (!facetValue) return null;
                     return (
-                        <div className="mb-2 mr-1" key={facetValue.id}>
+                        <div className="mb-2 mr-1 max-w-full" key={facetValue.id}>
                             <FacetValueChip
                                 facetValue={facetValue}
                                 removable={canUpdate}

--- a/packages/dashboard/src/lib/components/shared/facet-value-chip.tsx
+++ b/packages/dashboard/src/lib/components/shared/facet-value-chip.tsx
@@ -36,10 +36,10 @@ export function FacetValueChip({
     return (
         <Badge
             variant="secondary"
-            className="flex items-center gap-2 py-0.5 pl-2 pr-1 h-6 hover:bg-secondary/80"
+            className="flex items-center gap-2 py-0.5 pl-2 pr-1 h-6 max-w-full shrink hover:bg-secondary/80"
         >
-            <div className="flex items-center gap-1.5">
-                <span className="font-medium">{facetValue.name}</span>
+            <div className="flex items-center gap-1.5 min-w-0">
+                <span className="font-medium truncate">{facetValue.name}</span>
                 {displayFacetName && (
                     <span className="text-muted-foreground text-xs">in {facetValue.facet.name}</span>
                 )}
@@ -47,7 +47,7 @@ export function FacetValueChip({
             {removable && (
                 <button
                     type="button"
-                    className="ml-0.5 inline-flex h-4 w-4 items-center justify-center rounded-full hover:bg-muted/30"
+                    className="ml-0.5 inline-flex h-4 w-4 shrink-0 items-center justify-center rounded-full hover:bg-muted/30"
                     onClick={() => onRemove?.(facetValue.id)}
                     aria-label={`Remove ${facetValue.name} from ${facetValue.facet.name}`}
                 >

--- a/packages/dashboard/src/lib/components/shared/facet-value-chip.tsx
+++ b/packages/dashboard/src/lib/components/shared/facet-value-chip.tsx
@@ -38,10 +38,10 @@ export function FacetValueChip({
             variant="secondary"
             className="flex items-center gap-2 py-0.5 pl-2 pr-1 h-6 max-w-full shrink hover:bg-secondary/80"
         >
-            <div className="flex items-center gap-1.5 min-w-0">
+            <div className="flex items-center gap-1.5 min-w-0 truncate">
                 <span className="font-medium truncate">{facetValue.name}</span>
                 {displayFacetName && (
-                    <span className="text-muted-foreground text-xs">in {facetValue.facet.name}</span>
+                    <span className="text-muted-foreground text-xs truncate">in {facetValue.facet.name}</span>
                 )}
             </div>
             {removable && (

--- a/packages/dashboard/src/lib/components/shared/facet-value-chip.tsx
+++ b/packages/dashboard/src/lib/components/shared/facet-value-chip.tsx
@@ -39,9 +39,9 @@ export function FacetValueChip({
             className="flex items-center gap-2 py-0.5 pl-2 pr-1 h-6 max-w-full shrink hover:bg-secondary/80"
         >
             <div className="flex items-center gap-1.5 min-w-0 truncate">
-                <span className="font-medium truncate">{facetValue.name}</span>
+                <span className="font-medium truncate" title={facetValue.name}>{facetValue.name}</span>
                 {displayFacetName && (
-                    <span className="text-muted-foreground text-xs truncate">in {facetValue.facet.name}</span>
+                    <span className="text-muted-foreground text-xs truncate" title={facetValue.facet.name}>in {facetValue.facet.name}</span>
                 )}
             </div>
             {removable && (


### PR DESCRIPTION
# Description

Fixes #4711

When a facet value name is very long (e.g. "Sports & Outdoor & Swimming & Gym & Fashion..."), the × remove button gets clipped and becomes invisible. This is because the Badge base component uses `shrink-0` and `overflow-hidden`, so the text pushes the button outside the visible area.

This PR constrains the chip to its parent width and truncates long names with an ellipsis, ensuring the remove button is always visible.

**Changes:**
- `facet-value-chip.tsx`: Added `max-w-full shrink` on Badge, `min-w-0` on text container, `truncate` on name span, `shrink-0` on remove button
- `assigned-facet-values.tsx`: Added `max-w-full` on chip wrapper div

# Breaking changes

None.

# Screenshots

Before:
<img width="980" height="1306" alt="image" src="https://github.com/user-attachments/assets/b21a74b6-d734-49a6-a743-f9b22aa0f9d9" />


After:
<img width="323" height="257" alt="image" src="https://github.com/user-attachments/assets/78a47486-2cf5-4c9c-a898-85b694911ce3" />


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4712"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->