### PR TITLE
fix(core): Do not release inherited QueryRunner in TransactionWrapper

### DIFF
--- a/packages/core/e2e/database-transactions.e2e-spec.ts
+++ b/packages/core/e2e/database-transactions.e2e-spec.ts
@@ -249,6 +249,29 @@ describe('Transaction infrastructure', () => {
         expect(TransactionTestPlugin.errorHandler).not.toHaveBeenCalled();
     });
 
+    // Regression test for #4708:
+    // A resolver decorated with @Transaction('manual') that starts a transaction
+    // and then calls a service using `connection.withTransaction(ctx, …)` must
+    // remain able to perform DB operations on the same `ctx` after the inner
+    // wrapper returns. The bug was that the inner wrapper released the inherited
+    // QueryRunner, breaking any further DB op with QueryRunnerAlreadyReleasedError.
+    // Only runs on real drivers — the sqljs `release()` is a no-op and hides the bug.
+    // Placed near the end of the suite because it adds two admins to the shared
+    // verifyTestDocument-visible state.
+    itIfDb(['postgres', 'mysql'])(
+        'inner withTransaction does not release inherited QueryRunner from manual outer transaction',
+        async () => {
+            const { createTestAdministrator6 } = await adminClient.query(createTestAdministrator6Document, {
+                emailAddress: 'test-manual-inherited',
+            });
+            createdAdminGuard.assertSuccess(createTestAdministrator6);
+
+            const { verify } = await adminClient.query(verifyTestDocument);
+            expect(!!verify.admins.find(a => a.emailAddress === 'test-manual-inherited_a')).toBe(true);
+            expect(!!verify.admins.find(a => a.emailAddress === 'test-manual-inherited_b')).toBe(true);
+        },
+    );
+
     // Testing https://github.com/vendurehq/vendure/issues/1107
     it('passing transaction via EventBus with delay in committing transaction', async () => {
         TransactionTestPlugin.reset();
@@ -325,6 +348,17 @@ const createTestAdministrator5Document = graphql(
     `
         mutation CreateTestAdmin5($emailAddress: String!, $fail: Boolean!, $noContext: Boolean!) {
             createTestAdministrator5(emailAddress: $emailAddress, fail: $fail, noContext: $noContext) {
+                ...CreatedAdmin
+            }
+        }
+    `,
+    [createdAdminFragment],
+);
+
+const createTestAdministrator6Document = graphql(
+    `
+        mutation CreateTestAdmin6($emailAddress: String!) {
+            createTestAdministrator6(emailAddress: $emailAddress) {
                 ...CreatedAdmin
             }
         }

--- a/packages/core/e2e/fixtures/test-plugins/transaction-test-plugin.ts
+++ b/packages/core/e2e/fixtures/test-plugins/transaction-test-plugin.ts
@@ -148,6 +148,24 @@ class TestResolver {
     }
 
     @Mutation()
+    @Transaction('manual')
+    async createTestAdministrator6(@Ctx() ctx: RequestContext, @Args() args: any) {
+        // Regression test for #4708:
+        // In manual mode the TransactionInterceptor attaches a QueryRunner to the
+        // ctx without starting a transaction on it. When an inner
+        // `withTransaction(ctx, ...)` runs in this state, the buggy wrapper
+        // committed and *released* that inherited QR — so any subsequent DB op
+        // on the same ctx threw QueryRunnerAlreadyReleasedError. We intentionally
+        // do NOT call `startTransaction` here so the inner wrapper hits the
+        // BEGIN/COMMIT path (not a savepoint) and triggers the regression.
+        const first = await this.connection.withTransaction(ctx, _ctx =>
+            this.testAdminService.createAdministrator(_ctx, `${args.emailAddress}_a`, false),
+        );
+        const second = await this.testAdminService.createAdministrator(ctx, `${args.emailAddress}_b`, false);
+        return first ?? second;
+    }
+
+    @Mutation()
     @Transaction()
     async createNTestAdministrators(@Ctx() ctx: RequestContext, @Args() args: any) {
         let error: any;
@@ -295,6 +313,7 @@ class TestResolver {
                     fail: Boolean!
                     noContext: Boolean!
                 ): Administrator
+                createTestAdministrator6(emailAddress: String!): Administrator
                 createNTestAdministrators(emailAddress: String!, failFactor: Float!, n: Int!): JSON
                 createNTestAdministrators2(emailAddress: String!, failFactor: Float!, n: Int!): JSON
                 createNTestAdministrators3(emailAddress: String!, failFactor: Float!, n: Int!): JSON

--- a/packages/core/src/connection/transaction-wrapper.ts
+++ b/packages/core/src/connection/transaction-wrapper.ts
@@ -34,10 +34,11 @@ export class TransactionWrapper {
         const ctx = originalCtx.copy();
 
         const entityManager: EntityManager | undefined = (ctx as any)[TRANSACTION_MANAGER_KEY];
-        let queryRunner = entityManager?.queryRunner;
-        if (!queryRunner || queryRunner.isReleased) {
-            queryRunner = connection.createQueryRunner();
-        }
+        const inheritedQueryRunner =
+            entityManager?.queryRunner && !entityManager.queryRunner.isReleased
+                ? entityManager.queryRunner
+                : undefined;
+        const queryRunner = inheritedQueryRunner ?? connection.createQueryRunner();
         if (mode === 'auto') {
             await this.startTransaction(queryRunner, isolationLevel);
         }
@@ -69,10 +70,15 @@ export class TransactionWrapper {
             }
             throw error;
         } finally {
-            if (!queryRunner.isTransactionActive && queryRunner.isReleased === false) {
-                // There is a check for an active transaction
-                // because this could be a nested transaction (savepoint).
-
+            // Only release the QueryRunner if we created it ourselves. If it was inherited
+            // from an outer transaction (e.g. a @Transaction('manual') caller), releasing it
+            // would invalidate the caller's context. The active-transaction check additionally
+            // covers the nested-savepoint case where the parent transaction is still open.
+            if (
+                !inheritedQueryRunner &&
+                !queryRunner.isTransactionActive &&
+                queryRunner.isReleased === false
+            ) {
                 await queryRunner.release();
             }
         }


### PR DESCRIPTION
## Summary

Regression in 3.6.3: \`TransactionWrapper.executeInTransaction\` always releases its \`QueryRunner\` in the \`finally\` block, regardless of whether it created the QR locally or inherited one from the caller's \`RequestContext\` (e.g. a \`@Transaction('manual')\` handler that called \`connection.startTransaction(ctx)\`).

After #4686 wrapped \`OrderService.transitionToState\` in \`withTransaction(ctx, …)\`, any caller using manual-mode transactions and then calling \`transitionToState\` had its shared \`QueryRunner\` released by the inner wrapper. Subsequent DB ops on the same \`ctx\` then threw:

\`\`\`
QueryRunnerAlreadyReleasedError: Query runner already released. Cannot run queries anymore.
\`\`\`

Reported with concrete production impact (#4708): a custom \`addAtomicPaymentsToOrder\` resolver lost 207 payment attempts over ~31 hours before a workaround was deployed.

## Fix

\`packages/core/src/connection/transaction-wrapper.ts\` now tracks whether the \`QueryRunner\` was inherited from \`originalCtx[TRANSACTION_MANAGER_KEY]\` and only releases it in the locally-created case. The existing nested-savepoint guard (\`!queryRunner.isTransactionActive\`) is preserved so the no-savepoint path is unchanged.

## Regression test

Added a new e2e case in \`packages/core/e2e/database-transactions.e2e-spec.ts\` plus a fixture mutation \`createTestAdministrator6\` in the transaction test plugin. The case is gated to \`postgres\` / \`mysql\` because the sqljs driver's \`release()\` is a no-op (\`AbstractSqliteQueryRunner.release()\` doesn't flip \`isReleased\`), which hides the bug in default test runs.

Fixes #4708

## Test plan

- [ ] \`DB=postgres bun run e2e -- database-transactions.e2e-spec.ts\` — new case passes; pre-fix it would throw \`QueryRunnerAlreadyReleasedError\` on the second \`createAdministrator\` call.
- [ ] All existing e2e cases in the same suite still pass on sqljs / postgres / mysql.
- [ ] Manual sanity: a \`@Transaction('manual')\` resolver that calls \`orderService.transitionToState(ctx, …)\` followed by another DB op on \`ctx\` no longer throws.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->