### PR TITLE
fix(core): Refuse default superadmin credentials in production

### DIFF
--- a/packages/core/src/service/helpers/utils/check-superadmin-credentials.spec.ts
+++ b/packages/core/src/service/helpers/utils/check-superadmin-credentials.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { checkSuperadminCredentials } from './check-superadmin-credentials';
+
+const DEFAULTS = { identifier: 'superadmin', password: 'superadmin' };
+const SAFE = { identifier: 'admin@example.com', password: 'a-very-long-random-passphrase' };
+
+describe('checkSuperadminCredentials', () => {
+    it('throws in production when both identifier and password are default', () => {
+        expect(() => checkSuperadminCredentials(DEFAULTS, { nodeEnv: 'production' })).toThrow(
+            /Refusing to start/,
+        );
+    });
+
+    it('throws in production when only the password is default', () => {
+        expect(() =>
+            checkSuperadminCredentials(
+                { identifier: 'admin@example.com', password: 'superadmin' },
+                { nodeEnv: 'production' },
+            ),
+        ).toThrow(/Refusing to start/);
+    });
+
+    it('throws in production when only the identifier is default', () => {
+        expect(() =>
+            checkSuperadminCredentials(
+                { identifier: 'superadmin', password: 'something-strong-1234' },
+                { nodeEnv: 'production' },
+            ),
+        ).toThrow(/Refusing to start/);
+    });
+
+    it('warns in development when defaults are used', () => {
+        const logger = { warn: vi.fn() };
+        checkSuperadminCredentials(DEFAULTS, { nodeEnv: 'development', logger });
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+        expect(logger.warn.mock.calls[0][0]).toMatch(/Default superadmin credentials/);
+    });
+
+    it('warns in staging / non-production environments when defaults are used', () => {
+        const logger = { warn: vi.fn() };
+        checkSuperadminCredentials(DEFAULTS, { nodeEnv: 'staging', logger });
+        expect(logger.warn).toHaveBeenCalledTimes(1);
+    });
+
+    it('is silent in test environment even when defaults are used', () => {
+        const logger = { warn: vi.fn() };
+        checkSuperadminCredentials(DEFAULTS, { nodeEnv: 'test', logger });
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+
+    it('is silent (and does not throw) when credentials are non-default in production', () => {
+        const logger = { warn: vi.fn() };
+        expect(() => checkSuperadminCredentials(SAFE, { nodeEnv: 'production', logger })).not.toThrow();
+        expect(logger.warn).not.toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/service/helpers/utils/check-superadmin-credentials.spec.ts
+++ b/packages/core/src/service/helpers/utils/check-superadmin-credentials.spec.ts
@@ -21,20 +21,22 @@ describe('checkSuperadminCredentials', () => {
         ).toThrow(/Refusing to start/);
     });
 
-    it('throws in production when only the identifier is default', () => {
+    it('does not throw in production when the identifier is default but the password is strong', () => {
+        const logger = { warn: vi.fn() };
         expect(() =>
             checkSuperadminCredentials(
-                { identifier: 'superadmin', password: 'something-strong-1234' },
-                { nodeEnv: 'production' },
+                { identifier: 'superadmin', password: 'a-very-long-random-passphrase' },
+                { nodeEnv: 'production', logger },
             ),
-        ).toThrow(/Refusing to start/);
+        ).not.toThrow();
+        expect(logger.warn).not.toHaveBeenCalled();
     });
 
     it('warns in development when defaults are used', () => {
         const logger = { warn: vi.fn() };
         checkSuperadminCredentials(DEFAULTS, { nodeEnv: 'development', logger });
         expect(logger.warn).toHaveBeenCalledTimes(1);
-        expect(logger.warn.mock.calls[0][0]).toMatch(/Default superadmin credentials/);
+        expect(logger.warn.mock.calls[0][0]).toMatch(/Default superadmin password/);
     });
 
     it('warns in staging / non-production environments when defaults are used', () => {

--- a/packages/core/src/service/helpers/utils/check-superadmin-credentials.ts
+++ b/packages/core/src/service/helpers/utils/check-superadmin-credentials.ts
@@ -1,0 +1,45 @@
+import { SUPER_ADMIN_USER_IDENTIFIER, SUPER_ADMIN_USER_PASSWORD } from '@vendure/common/lib/shared-constants';
+
+import { Logger } from '../../../config/logger/vendure-logger';
+import { SuperadminCredentials } from '../../../config/vendure-config';
+
+const REMEDIATION_HINT =
+    'Set `authOptions.superadminCredentials` in your VendureConfig — typically wired from environment variables, e.g. ' +
+    '`{ identifier: process.env.SUPERADMIN_USERNAME, password: process.env.SUPERADMIN_PASSWORD }`.';
+
+/**
+ * @description
+ * Verifies that the configured `superadminCredentials` are not the well-known
+ * defaults shipped by `@vendure/common`. Used during bootstrap to fail loudly
+ * in production environments and warn otherwise.
+ *
+ * Exported for unit testing — production callers should rely on the default
+ * `process.env.NODE_ENV` and {@link Logger}.
+ */
+export function checkSuperadminCredentials(
+    credentials: Pick<SuperadminCredentials, 'identifier' | 'password'>,
+    options: { nodeEnv?: string; logger?: Pick<typeof Logger, 'warn'> } = {},
+): void {
+    const usingDefaults =
+        credentials.identifier === SUPER_ADMIN_USER_IDENTIFIER ||
+        credentials.password === SUPER_ADMIN_USER_PASSWORD;
+    if (!usingDefaults) {
+        return;
+    }
+
+    const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV;
+    const message =
+        'Default superadmin credentials are configured. This is INSECURE and must not be used in production. ' +
+        REMEDIATION_HINT;
+
+    if (nodeEnv === 'production') {
+        throw new Error(`[Vendure] Refusing to start: ${message}`);
+    }
+
+    if (nodeEnv === 'test') {
+        return;
+    }
+
+    const logger = options.logger ?? Logger;
+    logger.warn(message);
+}

--- a/packages/core/src/service/helpers/utils/check-superadmin-credentials.ts
+++ b/packages/core/src/service/helpers/utils/check-superadmin-credentials.ts
@@ -1,4 +1,4 @@
-import { SUPER_ADMIN_USER_IDENTIFIER, SUPER_ADMIN_USER_PASSWORD } from '@vendure/common/lib/shared-constants';
+import { SUPER_ADMIN_USER_PASSWORD } from '@vendure/common/lib/shared-constants';
 
 import { Logger } from '../../../config/logger/vendure-logger';
 import { SuperadminCredentials } from '../../../config/vendure-config';
@@ -9,9 +9,12 @@ const REMEDIATION_HINT =
 
 /**
  * @description
- * Verifies that the configured `superadminCredentials` are not the well-known
- * defaults shipped by `@vendure/common`. Used during bootstrap to fail loudly
- * in production environments and warn otherwise.
+ * Verifies that the configured `superadminCredentials.password` is not the
+ * well-known default shipped by `@vendure/common`. Used during bootstrap to
+ * fail loudly in production environments and warn otherwise.
+ *
+ * The default `superadmin` identifier is intentionally allowed — only a
+ * default password is treated as insecure.
  *
  * Exported for unit testing — production callers should rely on the default
  * `process.env.NODE_ENV` and {@link Logger}.
@@ -20,16 +23,14 @@ export function checkSuperadminCredentials(
     credentials: Pick<SuperadminCredentials, 'identifier' | 'password'>,
     options: { nodeEnv?: string; logger?: Pick<typeof Logger, 'warn'> } = {},
 ): void {
-    const usingDefaults =
-        credentials.identifier === SUPER_ADMIN_USER_IDENTIFIER ||
-        credentials.password === SUPER_ADMIN_USER_PASSWORD;
-    if (!usingDefaults) {
+    const usingDefaultPassword = credentials.password === SUPER_ADMIN_USER_PASSWORD;
+    if (!usingDefaultPassword) {
         return;
     }
 
     const nodeEnv = options.nodeEnv ?? process.env.NODE_ENV;
     const message =
-        'Default superadmin credentials are configured. This is INSECURE and must not be used in production. ' +
+        'Default superadmin password is configured. This is INSECURE and must not be used in production. ' +
         REMEDIATION_HINT;
 
     if (nodeEnv === 'production') {

--- a/packages/core/src/service/services/administrator.service.ts
+++ b/packages/core/src/service/services/administrator.service.ts
@@ -26,6 +26,7 @@ import { CustomFieldRelationService } from '../helpers/custom-field-relation/cus
 import { ListQueryBuilder } from '../helpers/list-query-builder/list-query-builder';
 import { PasswordCipher } from '../helpers/password-cipher/password-cipher';
 import { RequestContextService } from '../helpers/request-context/request-context.service';
+import { checkSuperadminCredentials } from '../helpers/utils/check-superadmin-credentials';
 import { getChannelPermissions } from '../helpers/utils/get-user-channels-permissions';
 import { patchEntity } from '../helpers/utils/patch-entity';
 
@@ -321,6 +322,8 @@ export class AdministratorService {
      */
     private async ensureSuperAdminExists() {
         const { superadminCredentials } = this.configService.authOptions;
+
+        checkSuperadminCredentials(superadminCredentials);
 
         const superAdminUser = await this.connection.rawConnection.getRepository(User).findOne({
             where: {


### PR DESCRIPTION
## Summary

Vendure ships with the well-known defaults `superadmin` / `superadmin` for the initial admin user and has no built-in guard against running with them in production. This is a hard-coded-credentials issue (CWE-798): anyone with network access to a vanilla 3.6.x deployment can log in as superadmin if the operator did not override `authOptions.superadminCredentials`.

This PR adds a bootstrap-time check that:

- **Refuses to start** the server when `NODE_ENV === 'production'` and the password matches the default constant from `@vendure/common`. The default `superadmin` identifier is intentionally allowed — only a default password is treated as insecure.
- **Logs a prominent `Logger.warn`** with remediation hints in development / staging / any other non-test environment.
- **Stays silent in `NODE_ENV === 'test'`** so the existing e2e suite (which uses the defaults by design) keeps a clean output.

The remediation hint points operators at wiring `superadminCredentials` from environment variables, which is the same pattern most starters already use.

## Scope

- No schema migration, no public API change.
- The well-known constants in `@vendure/common` are kept as-is — they are still exported because plugins and the e2e/testing layer rely on them.
- A more invasive follow-up (auto-generated random password on first init, forced password change on first login) is intentionally left for a future `major` change. This PR is the minimum-blast-radius patch that closes the critical concern.
- **Targets `minor`**: refusing to start in production on a default password is a behavioural change, so it ships in a minor release rather than a patch.

## Changes

- New helper `packages/core/src/service/helpers/utils/check-superadmin-credentials.ts` containing the pure check (testable, no DI).
- `AdministratorService.ensureSuperAdminExists` now calls the helper before creating / reconciling the superadmin user.
- 7 new unit tests in the paired spec file covering production / development / staging / test / safe-credentials paths.

## Test plan

- [x] `vitest run service/helpers/utils/check-superadmin-credentials.spec.ts` — 7/7 pass
- [x] Full `@vendure/core` unit suite (`vitest run`) — 819/819 pass; no existing tests regressed
- [ ] Manual smoke: boot dev server with default config (NODE_ENV unset) → expect a single `Logger.warn` line about the default password, server starts normally
- [ ] Manual smoke: boot with `NODE_ENV=production` and default password → expect bootstrap to throw `[Vendure] Refusing to start: Default superadmin password is configured…`
- [ ] Manual smoke: boot with `NODE_ENV=production` and explicit override → silent, server starts normally

## Notes

- Reported privately via responsible disclosure (internal Linear OSS-490 — Pratik Karan, 2026-04-03). No public GitHub issue exists.
- Only the default **password** is treated as insecure. Using the well-known `superadmin` identifier with a strong, non-default password is fully supported (per maintainer review). The guard cannot detect weak-but-custom passwords — enforcing "non-default" is the enforceable boundary; "strong" remains the operator's responsibility.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4718"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
