### PR TITLE
fix(core): Block SSRF in DefaultAssetImportStrategy

### DIFF
--- a/packages/core/e2e/import.e2e-spec.ts
+++ b/packages/core/e2e/import.e2e-spec.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import { omit } from '@vendure/common/lib/omit';
-import { User } from '@vendure/core';
+import { DefaultAssetImportStrategy, User } from '@vendure/core';
 import { createTestEnvironment } from '@vendure/testing';
 import * as fs from 'node:fs';
 import http from 'node:http';
@@ -14,8 +14,17 @@ import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-conf
 import { graphql } from './graphql/graphql-admin';
 
 describe('Import resolver', () => {
+    const baseConfig = testConfig();
     const { server, adminClient } = createTestEnvironment({
-        ...testConfig(),
+        ...baseConfig,
+        importExportOptions: {
+            ...baseConfig.importExportOptions,
+            // The "asset urls" suite below spins up a local static server on
+            // localhost:3456 and imports from it. The default strategy blocks
+            // loopback/private IPs to mitigate SSRF (see assert-public-url.ts),
+            // so the test needs the documented escape hatch enabled.
+            assetImportStrategy: new DefaultAssetImportStrategy({ allowPrivateNetworks: true }),
+        },
         customFields: {
             Product: [
                 { type: 'string', name: 'pageType' },

--- a/packages/core/src/config/asset-import-strategy/assert-public-url.spec.ts
+++ b/packages/core/src/config/asset-import-strategy/assert-public-url.spec.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { InternalServerError } from '../../common/error/errors';
+import { Logger } from '../logger/vendure-logger';
+
+import { assertPublicUrl, DnsResolverFn } from './assert-public-url';
+
+const makeResolver = (records: Array<{ address: string; family: number }>): DnsResolverFn =>
+    vi.fn().mockResolvedValue(records);
+
+describe('assertPublicUrl', () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        warnSpy = vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+    });
+
+    afterEach(() => {
+        warnSpy.mockRestore();
+    });
+
+    describe('accepts', () => {
+        it('a public IPv4 literal and returns the pinned address', async () => {
+            const result = await assertPublicUrl('https://1.1.1.1/img.jpg');
+            expect(result.url.host).toBe('1.1.1.1');
+            expect(result.pinned).toEqual({ address: '1.1.1.1', family: 4 });
+            expect(warnSpy).not.toHaveBeenCalled();
+        });
+
+        it('a hostname that resolves to a public IPv4 and pins to the resolved IP', async () => {
+            const result = await assertPublicUrl('https://cdn.example.com/img.jpg', {
+                resolver: makeResolver([{ address: '93.184.216.34', family: 4 }]),
+            });
+            expect(result.pinned).toEqual({ address: '93.184.216.34', family: 4 });
+        });
+
+        it('a public IPv6 literal', async () => {
+            const result = await assertPublicUrl('https://[2606:4700::1111]/x');
+            expect(result.pinned).toEqual({ address: '2606:4700::1111', family: 6 });
+        });
+
+        it('does not call DNS for IP literals', async () => {
+            const resolver = vi.fn();
+            await assertPublicUrl('https://1.1.1.1/x', { resolver });
+            expect(resolver).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('rejects private / loopback / link-local IPv4', () => {
+        it('loopback', async () => {
+            await expect(assertPublicUrl('http://127.0.0.1/x')).rejects.toBeInstanceOf(InternalServerError);
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('127.0.0.1'),
+                'DefaultAssetImportStrategy',
+            );
+        });
+
+        it('cloud metadata IP (169.254.169.254)', async () => {
+            await expect(assertPublicUrl('http://169.254.169.254/latest/meta-data/')).rejects.toBeInstanceOf(
+                InternalServerError,
+            );
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('169.254.169.254'),
+                'DefaultAssetImportStrategy',
+            );
+        });
+
+        it('RFC 1918 ranges', async () => {
+            await expect(assertPublicUrl('http://10.0.0.5/x')).rejects.toBeInstanceOf(InternalServerError);
+            await expect(assertPublicUrl('http://172.16.1.1/x')).rejects.toBeInstanceOf(InternalServerError);
+            await expect(assertPublicUrl('http://192.168.1.1/x')).rejects.toBeInstanceOf(InternalServerError);
+        });
+
+        it('CGNAT (100.64.0.0/10)', async () => {
+            await expect(assertPublicUrl('http://100.64.0.1/x')).rejects.toBeInstanceOf(InternalServerError);
+        });
+
+        it('current-network (0.0.0.0/8)', async () => {
+            await expect(assertPublicUrl('http://0.0.0.0/x')).rejects.toBeInstanceOf(InternalServerError);
+        });
+    });
+
+    describe('rejects non-public IPv6', () => {
+        it('IPv6 loopback ::1', async () => {
+            await expect(assertPublicUrl('http://[::1]/x')).rejects.toBeInstanceOf(InternalServerError);
+        });
+
+        it('IPv6 link-local fe80::', async () => {
+            await expect(assertPublicUrl('http://[fe80::1]/x')).rejects.toBeInstanceOf(InternalServerError);
+        });
+
+        it('IPv4-mapped IPv6 loopback [::ffff:127.0.0.1]', async () => {
+            await expect(assertPublicUrl('http://[::ffff:127.0.0.1]/x')).rejects.toBeInstanceOf(
+                InternalServerError,
+            );
+        });
+
+        it('IPv4-mapped IPv6 metadata IP [::ffff:169.254.169.254]', async () => {
+            await expect(assertPublicUrl('http://[::ffff:169.254.169.254]/x')).rejects.toBeInstanceOf(
+                InternalServerError,
+            );
+        });
+
+        it('IPv4-mapped IPv6 RFC 1918 [::ffff:10.0.0.1]', async () => {
+            await expect(assertPublicUrl('http://[::ffff:10.0.0.1]/x')).rejects.toBeInstanceOf(
+                InternalServerError,
+            );
+        });
+
+        it('6to4 [2002::/16]', async () => {
+            await expect(assertPublicUrl('http://[2002:c0a8:0101::1]/x')).rejects.toBeInstanceOf(
+                InternalServerError,
+            );
+        });
+
+        it('Teredo [2001::/32]', async () => {
+            await expect(assertPublicUrl('http://[2001:0:1::1]/x')).rejects.toBeInstanceOf(
+                InternalServerError,
+            );
+        });
+
+        it('NAT64 [64:ff9b::/96]', async () => {
+            await expect(assertPublicUrl('http://[64:ff9b::1]/x')).rejects.toBeInstanceOf(
+                InternalServerError,
+            );
+        });
+
+        it('discard prefix [100::/64]', async () => {
+            await expect(assertPublicUrl('http://[100::1]/x')).rejects.toBeInstanceOf(InternalServerError);
+        });
+
+        it('IPv6 unique-local fc00::/7', async () => {
+            await expect(assertPublicUrl('http://[fc00::1]/x')).rejects.toBeInstanceOf(InternalServerError);
+            await expect(assertPublicUrl('http://[fd00::1]/x')).rejects.toBeInstanceOf(InternalServerError);
+        });
+
+        it('IPv6 link-local with zone-id is stripped and still blocked', async () => {
+            await expect(assertPublicUrl('http://[fe80::1%25eth0]/x')).rejects.toBeInstanceOf(
+                InternalServerError,
+            );
+        });
+
+        it('handles uppercase IPv6 hex literals', async () => {
+            await expect(assertPublicUrl('http://[FE80::1]/x')).rejects.toBeInstanceOf(InternalServerError);
+        });
+    });
+
+    describe('DNS-aware', () => {
+        it('rejects a hostname that resolves to a private IPv4', async () => {
+            await expect(
+                assertPublicUrl('http://internal.example.com/x', {
+                    resolver: makeResolver([{ address: '10.0.0.5', family: 4 }]),
+                }),
+            ).rejects.toBeInstanceOf(InternalServerError);
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('10.0.0.5'),
+                'DefaultAssetImportStrategy',
+            );
+        });
+
+        it('rejects if ANY of multiple resolved addresses is private', async () => {
+            await expect(
+                assertPublicUrl('http://mixed.example.com/x', {
+                    resolver: makeResolver([
+                        { address: '1.1.1.1', family: 4 },
+                        { address: '127.0.0.1', family: 4 },
+                    ]),
+                }),
+            ).rejects.toBeInstanceOf(InternalServerError);
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('127.0.0.1'),
+                'DefaultAssetImportStrategy',
+            );
+        });
+
+        it('rejects a hostname that resolves to an IPv4-mapped IPv6 private address', async () => {
+            await expect(
+                assertPublicUrl('http://internal.example.com/x', {
+                    resolver: makeResolver([{ address: '::ffff:127.0.0.1', family: 6 }]),
+                }),
+            ).rejects.toBeInstanceOf(InternalServerError);
+        });
+
+        it('rejects when DNS lookup itself fails', async () => {
+            const resolver: DnsResolverFn = vi.fn().mockRejectedValue(new Error('ENOTFOUND'));
+            await expect(
+                assertPublicUrl('http://nonexistent.example.com/x', { resolver }),
+            ).rejects.toBeInstanceOf(InternalServerError);
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('DNS lookup failed'),
+                'DefaultAssetImportStrategy',
+            );
+        });
+    });
+
+    describe('protocol & malformed URLs', () => {
+        it('rejects non-http(s) protocols', async () => {
+            await expect(assertPublicUrl('file:///etc/passwd')).rejects.toBeInstanceOf(InternalServerError);
+            await expect(assertPublicUrl('ftp://example.com/x')).rejects.toBeInstanceOf(InternalServerError);
+            await expect(assertPublicUrl('gopher://1.1.1.1/x')).rejects.toBeInstanceOf(InternalServerError);
+        });
+
+        it('rejects malformed URLs', async () => {
+            await expect(assertPublicUrl('not a url')).rejects.toBeInstanceOf(InternalServerError);
+        });
+    });
+
+    describe('error-message hardening', () => {
+        it('throws a generic message that does not leak the URL or remediation hint', async () => {
+            await expect(assertPublicUrl('http://127.0.0.1/secret-path')).rejects.toMatchObject({
+                message: expect.not.stringContaining('127.0.0.1'),
+            });
+            await expect(assertPublicUrl('http://127.0.0.1/secret-path')).rejects.toMatchObject({
+                message: expect.not.stringContaining('allowPrivateNetworks'),
+            });
+        });
+
+        it('routes the remediation hint to Logger.warn instead of the thrown error', async () => {
+            await expect(assertPublicUrl('http://127.0.0.1/x')).rejects.toBeInstanceOf(InternalServerError);
+            expect(warnSpy).toHaveBeenCalledWith(
+                expect.stringContaining('allowPrivateNetworks'),
+                'DefaultAssetImportStrategy',
+            );
+        });
+
+        it('strips control characters from URLs in log messages (log-forgery defence)', async () => {
+            await expect(assertPublicUrl('not\r\nfake-log-line a url')).rejects.toBeInstanceOf(
+                InternalServerError,
+            );
+            const [logged] = warnSpy.mock.calls[0] ?? [];
+            expect(logged).toBeDefined();
+            expect(logged).not.toMatch(/[\r\n]/);
+        });
+
+        it('truncates very long URLs in log messages', async () => {
+            const longUrl = 'http://127.0.0.1/' + 'a'.repeat(5000);
+            await expect(assertPublicUrl(longUrl)).rejects.toBeInstanceOf(InternalServerError);
+            const [logged] = warnSpy.mock.calls.find(call => String(call[0]).includes('127.0.0.1')) ?? [''];
+            expect(String(logged).length).toBeLessThan(longUrl.length);
+        });
+    });
+
+    describe('allowPrivateNetworks bypass', () => {
+        it('bypasses all private-network checks but returns no pinned IP', async () => {
+            const result = await assertPublicUrl('http://127.0.0.1/x', {
+                allowPrivateNetworks: true,
+            });
+            expect(result.pinned).toBeNull();
+            expect(result.url.host).toBe('127.0.0.1');
+        });
+
+        it('bypasses DNS resolution entirely (no resolver call)', async () => {
+            const resolver = vi.fn();
+            await assertPublicUrl('http://internal.example.com/x', {
+                allowPrivateNetworks: true,
+                resolver,
+            });
+            expect(resolver).not.toHaveBeenCalled();
+        });
+
+        it('still rejects unsupported protocols even with allowPrivateNetworks=true', async () => {
+            await expect(
+                assertPublicUrl('file:///etc/passwd', { allowPrivateNetworks: true }),
+            ).rejects.toBeInstanceOf(InternalServerError);
+        });
+    });
+});

--- a/packages/core/src/config/asset-import-strategy/assert-public-url.ts
+++ b/packages/core/src/config/asset-import-strategy/assert-public-url.ts
@@ -1,0 +1,195 @@
+import { lookup } from 'dns/promises';
+import { BlockList, isIP } from 'net';
+
+import { InternalServerError } from '../../common/error/errors';
+import { Logger } from '../logger/vendure-logger';
+
+const loggerCtx = 'DefaultAssetImportStrategy';
+
+/**
+ * BlockList covering private, loopback, link-local, IPv4-mapped IPv6, 6to4,
+ * Teredo, NAT64, discard and unspecified ranges. Used by {@link assertPublicUrl}
+ * to prevent the `DefaultAssetImportStrategy` from issuing requests that could
+ * be abused for server-side request forgery against the host's internal network
+ * or cloud metadata services (e.g. `169.254.169.254`).
+ */
+const privateBlockList = (() => {
+    const bl = new BlockList();
+    // IPv4
+    bl.addSubnet('0.0.0.0', 8); // current network
+    bl.addSubnet('10.0.0.0', 8); // RFC 1918
+    bl.addSubnet('100.64.0.0', 10); // CGNAT (RFC 6598)
+    bl.addSubnet('127.0.0.0', 8); // loopback
+    bl.addSubnet('169.254.0.0', 16); // link-local + cloud metadata
+    bl.addSubnet('172.16.0.0', 12); // RFC 1918
+    bl.addSubnet('192.0.0.0', 24); // IETF protocol assignments
+    bl.addSubnet('192.168.0.0', 16); // RFC 1918
+    bl.addSubnet('198.18.0.0', 15); // network benchmarking
+    // IPv6
+    bl.addAddress('::', 'ipv6'); // unspecified
+    bl.addAddress('::1', 'ipv6'); // loopback
+    bl.addSubnet('64:ff9b::', 96, 'ipv6'); // NAT64 (could tunnel to private v4)
+    bl.addSubnet('100::', 64, 'ipv6'); // discard prefix
+    bl.addSubnet('2001::', 32, 'ipv6'); // Teredo
+    bl.addSubnet('2002::', 16, 'ipv6'); // 6to4
+    bl.addSubnet('fc00::', 7, 'ipv6'); // unique local
+    bl.addSubnet('fe80::', 10, 'ipv6'); // link-local
+    // IPv4-mapped IPv6 (`::ffff:a.b.c.d`) is handled separately in
+    // `isBlocked()` below — adding it as a BlockList subnet would create false
+    // positives for plain IPv4 lookups due to a Node-internal v6→v4 projection.
+    return bl;
+})();
+
+/**
+ * Matches `::ffff:` prefix in any casing. The trailing segment is checked with
+ * `isIP` rather than parsed by us, so this regex only gates the lookup.
+ */
+const IPV4_MAPPED_IPV6_PREFIX = /^::ffff:/i;
+
+/**
+ * Checks an address against the private BlockList. Handles IPv4-mapped IPv6
+ * addresses (`::ffff:a.b.c.d`) by extracting the embedded IPv4 and re-checking
+ * against the IPv4 ranges — Node's BlockList does not project v6 → v4
+ * automatically, and adding the `::ffff:0:0/96` subnet to the BlockList causes
+ * plain IPv4 lookups to false-positive due to an internal mapping quirk.
+ */
+function isBlocked(address: string, family: 4 | 6): boolean {
+    if (family === 6 && IPV4_MAPPED_IPV6_PREFIX.test(address)) {
+        const embedded = address.slice('::ffff:'.length);
+        if (isIP(embedded) === 4) {
+            return privateBlockList.check(embedded, 'ipv4');
+        }
+        // Hex-form IPv4-mapped (e.g. `::ffff:7f00:1`). Convert the trailing two
+        // 16-bit groups to dotted-quad and re-check.
+        const hexMatch = embedded.match(/^([0-9a-f]{1,4}):([0-9a-f]{1,4})$/i);
+        if (hexMatch) {
+            const high = parseInt(hexMatch[1], 16);
+            const low = parseInt(hexMatch[2], 16);
+            if (Number.isFinite(high) && Number.isFinite(low) && high <= 0xffff && low <= 0xffff) {
+                /* eslint-disable no-bitwise */
+                const dotted = [(high >> 8) & 0xff, high & 0xff, (low >> 8) & 0xff, low & 0xff].join('.');
+                /* eslint-enable no-bitwise */
+                return privateBlockList.check(dotted, 'ipv4');
+            }
+        }
+        // Fall through: an unparseable `::ffff:` form is itself suspicious. Block.
+        return true;
+    }
+    return privateBlockList.check(address, family === 6 ? 'ipv6' : 'ipv4');
+}
+
+const MAX_LOGGED_URL_LENGTH = 200;
+const GENERIC_REJECTION_MESSAGE = 'Refusing to fetch asset URL: target is not a public network address';
+const GENERIC_INVALID_URL_MESSAGE = 'Refusing to fetch asset URL: invalid or unsupported URL';
+
+/**
+ * Truncates and strips control characters from a URL before it is embedded in
+ * log messages. Prevents log forgery via CRLF injection in attacker-controlled
+ * URLs.
+ */
+function safeForLog(value: string): string {
+    return value.replace(/[\x00-\x1f\x7f]/g, '?').slice(0, MAX_LOGGED_URL_LENGTH);
+}
+
+export interface PinnedAddress {
+    address: string;
+    family: 4 | 6;
+}
+
+export type DnsResolverFn = (hostname: string) => Promise<Array<{ address: string; family: number }>>;
+
+const defaultResolver: DnsResolverFn = hostname => lookup(hostname, { all: true, verbatim: true });
+
+/**
+ * @description
+ * Validates a URL before allowing the asset importer to fetch it. Rejects:
+ * - non-http(s) schemes
+ * - hostnames that resolve to private, loopback, link-local, IPv4-mapped IPv6
+ *   or other non-public address ranges (covers SSRF against cloud metadata and
+ *   internal services)
+ *
+ * On success, returns the parsed URL plus the address that was validated so the
+ * caller can connect directly to that IP. Pinning the validated IP for the
+ * subsequent fetch closes the DNS-rebinding TOCTOU window — without it,
+ * `http.get` would perform a second, independent DNS lookup and could resolve
+ * the same hostname to a private IP this time around.
+ *
+ * On failure, the thrown {@link InternalServerError} carries a generic message;
+ * the specific reason (URL, resolved IP, remediation hint) is emitted via
+ * `Logger.warn` so operators can see it without the client learning about the
+ * `allowPrivateNetworks` bypass.
+ *
+ * Exported for unit testing; production callers should not pass a resolver
+ * override.
+ */
+export async function assertPublicUrl(
+    urlString: string,
+    options: { allowPrivateNetworks?: boolean; resolver?: DnsResolverFn } = {},
+): Promise<{ url: URL; pinned: PinnedAddress | null }> {
+    let url: URL;
+    try {
+        url = new URL(urlString);
+    } catch (_) {
+        Logger.warn(`Refusing to fetch invalid URL: ${safeForLog(urlString)}`, loggerCtx);
+        throw new InternalServerError(GENERIC_INVALID_URL_MESSAGE);
+    }
+
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') {
+        Logger.warn(
+            `Refusing to fetch URL with unsupported protocol "${url.protocol}": ${safeForLog(urlString)}`,
+            loggerCtx,
+        );
+        throw new InternalServerError(GENERIC_INVALID_URL_MESSAGE);
+    }
+
+    if (options.allowPrivateNetworks) {
+        return { url, pinned: null };
+    }
+
+    // WHATWG URL keeps the brackets around IPv6 literals in `hostname`; strip
+    // them so `isIP` and the BlockList can parse the address. Also drop any
+    // zone-id suffix (e.g. `fe80::1%eth0`) since BlockList does not accept
+    // zone-tagged addresses.
+    const hostname = url.hostname.replace(/^\[|\]$/g, '').replace(/%.*$/, '');
+    const resolve = options.resolver ?? defaultResolver;
+
+    let addresses: Array<{ address: string; family: number }>;
+    const literalFamily = isIP(hostname);
+    if (literalFamily === 4 || literalFamily === 6) {
+        addresses = [{ address: hostname, family: literalFamily }];
+    } else if (literalFamily === 0 && hostname.length > 0) {
+        try {
+            addresses = await resolve(hostname);
+        } catch (e) {
+            const message = e instanceof Error ? e.message : String(e);
+            Logger.warn(
+                `Refusing to fetch ${safeForLog(urlString)}: DNS lookup failed (${safeForLog(message)})`,
+                loggerCtx,
+            );
+            throw new InternalServerError(GENERIC_REJECTION_MESSAGE);
+        }
+    } else {
+        Logger.warn(`Refusing to fetch URL with empty hostname: ${safeForLog(urlString)}`, loggerCtx);
+        throw new InternalServerError(GENERIC_INVALID_URL_MESSAGE);
+    }
+
+    for (const { address, family } of addresses) {
+        const normalisedFamily: 4 | 6 = family === 6 ? 6 : 4;
+        if (isBlocked(address, normalisedFamily)) {
+            Logger.warn(
+                `Refusing to fetch ${safeForLog(urlString)}: resolves to non-public address ${address}. ` +
+                    'Set `assetImportStrategy: new DefaultAssetImportStrategy({ allowPrivateNetworks: true })` ' +
+                    'in your VendureConfig if this is intentional (e.g. a trusted internal asset server).',
+                loggerCtx,
+            );
+            throw new InternalServerError(GENERIC_REJECTION_MESSAGE);
+        }
+    }
+
+    const first = addresses[0];
+    const pinned: PinnedAddress = {
+        address: first.address,
+        family: first.family === 6 ? 6 : 4,
+    };
+    return { url, pinned };
+}

--- a/packages/core/src/config/asset-import-strategy/default-asset-import-strategy.ts
+++ b/packages/core/src/config/asset-import-strategy/default-asset-import-strategy.ts
@@ -11,32 +11,109 @@ import { Injector } from '../../common/injector';
 import { ConfigService } from '../config.service';
 import { Logger } from '../logger/vendure-logger';
 
+import { assertPublicUrl, PinnedAddress } from './assert-public-url';
 import { AssetImportStrategy } from './asset-import-strategy';
 
-function fetchUrl(urlString: string): Promise<Readable> {
+const loggerCtx = 'DefaultAssetImportStrategy';
+const MAX_LOGGED_URL_LENGTH = 200;
+
+function safeForLog(value: string): string {
+    return value.replace(/[\x00-\x1f\x7f]/g, '?').slice(0, MAX_LOGGED_URL_LENGTH);
+}
+
+/**
+ * Issues an HTTP(S) GET for the asset. If `pinned` is provided, the request is
+ * directed at that exact IP address with the original hostname preserved in the
+ * `Host` header (and as the TLS SNI `servername` for HTTPS). This avoids a
+ * second, independent DNS lookup that could resolve the hostname to a private
+ * IP between {@link assertPublicUrl} validation and this fetch (DNS rebinding).
+ *
+ * The implementation deliberately does NOT follow redirects — Node's default.
+ * Enabling redirect-following here would re-open the SSRF surface that this
+ * file is meant to close, because the redirect target would bypass the
+ * `assertPublicUrl` validation.
+ */
+function fetchUrl(url: URL, pinned: PinnedAddress | null): Promise<Readable> {
     return new Promise((resolve, reject) => {
-        const url = new URL(urlString);
-        const get = url.protocol.startsWith('https') ? https.get : http.get;
-        get(
-            url,
-            {
-                timeout: 5000,
-            },
-            res => {
-                const { statusCode } = res;
-                if (statusCode !== 200) {
-                    Logger.error(
-                        `Failed to fetch "${urlString.substr(0, 100)}", statusCode: ${
-                            statusCode || 'unknown'
-                        }`,
-                    );
-                    reject(new Error(`Request failed. Status code: ${statusCode || 'unknown'}`));
-                } else {
-                    resolve(res);
-                }
-            },
-        );
+        const isHttps = url.protocol === 'https:';
+        const get = isHttps ? https.get : http.get;
+        const port = url.port ? Number(url.port) : isHttps ? 443 : 80;
+        // `url.host` preserves the port only when it is non-default, which is
+        // exactly what we want for the Host header.
+        const hostHeader = url.host;
+        const requestOptions: http.RequestOptions = pinned
+            ? {
+                  host: pinned.address,
+                  port,
+                  path: `${url.pathname}${url.search}`,
+                  family: pinned.family,
+                  headers: { Host: hostHeader },
+                  timeout: 5000,
+              }
+            : {
+                  // No pinned IP: caller opted into `allowPrivateNetworks`, fall
+                  // back to the URL-driven path. Node performs its own DNS lookup
+                  // here, which is fine because the operator has accepted the
+                  // private-network risk.
+                  host: url.hostname,
+                  port,
+                  path: `${url.pathname}${url.search}`,
+                  headers: { Host: hostHeader },
+                  timeout: 5000,
+              };
+        if (isHttps && pinned) {
+            (requestOptions as https.RequestOptions).servername = url.hostname;
+        }
+        get(requestOptions, res => {
+            const { statusCode } = res;
+            if (statusCode !== 200) {
+                Logger.error(
+                    `Failed to fetch "${safeForLog(url.toString())}", statusCode: ${statusCode ?? 'unknown'}`,
+                    loggerCtx,
+                );
+                reject(new Error(`Request failed. Status code: ${statusCode ?? 'unknown'}`));
+            } else {
+                resolve(res);
+            }
+        }).on('error', err => reject(err));
     });
+}
+
+/**
+ * @description
+ * Options for {@link DefaultAssetImportStrategy}.
+ *
+ * @since 1.7.0
+ * @docsCategory import-export
+ */
+export interface DefaultAssetImportStrategyOptions {
+    /**
+     * @description
+     * Delay between retries when a fetch fails, in milliseconds.
+     *
+     * @default 200
+     */
+    retryDelayMs?: number;
+    /**
+     * @description
+     * Maximum number of retries when a fetch fails.
+     *
+     * @default 3
+     */
+    retryCount?: number;
+    /**
+     * @description
+     * If `true`, the strategy permits fetching from hostnames that resolve to
+     * private, loopback, link-local or other non-public IP addresses. The
+     * default `false` rejects such hostnames in order to mitigate server-side
+     * request forgery against the host's internal network and cloud metadata
+     * services. Enable only when importing from a trusted internal asset
+     * server or for local development.
+     *
+     * @default false
+     * @since 3.6.4
+     */
+    allowPrivateNetworks?: boolean;
 }
 
 /**
@@ -50,12 +127,7 @@ function fetchUrl(urlString: string): Promise<Readable> {
 export class DefaultAssetImportStrategy implements AssetImportStrategy {
     private configService: ConfigService;
 
-    constructor(
-        private options?: {
-            retryDelayMs: number;
-            retryCount: number;
-        },
-    ) {}
+    constructor(private options?: DefaultAssetImportStrategyOptions) {}
 
     init(injector: Injector) {
         this.configService = injector.get(ConfigService);
@@ -69,15 +141,16 @@ export class DefaultAssetImportStrategy implements AssetImportStrategy {
         }
     }
 
-    private getStreamFromUrl(assetUrl: string): Promise<Readable> {
-        const { retryCount, retryDelayMs } = this.options ?? {};
+    private async getStreamFromUrl(assetUrl: string): Promise<Readable> {
+        const { retryCount, retryDelayMs, allowPrivateNetworks } = this.options ?? {};
+        const { url, pinned } = await assertPublicUrl(assetUrl, { allowPrivateNetworks });
         return lastValueFrom(
-            from(fetchUrl(assetUrl)).pipe(
+            from(fetchUrl(url, pinned)).pipe(
                 retryWhen(errors =>
                     errors.pipe(
                         tap(value => {
-                            Logger.verbose(value);
-                            Logger.verbose(`DefaultAssetImportStrategy: retrying fetchUrl for ${assetUrl}`);
+                            Logger.verbose(String(value), loggerCtx);
+                            Logger.verbose(`retrying fetchUrl for ${safeForLog(assetUrl)}`, loggerCtx);
                         }),
                         delay(retryDelayMs ?? 200),
                         take(retryCount ?? 3),

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -1,6 +1,7 @@
 export * from './api-key-strategy/api-key-strategy';
 export * from './api-key-strategy/random-bytes-api-key-strategy';
 export * from './asset-import-strategy/asset-import-strategy';
+export * from './asset-import-strategy/default-asset-import-strategy';
 export * from './asset-naming-strategy/asset-naming-strategy';
 export * from './asset-naming-strategy/default-asset-naming-strategy';
 export * from './asset-preview-strategy/asset-preview-strategy';


### PR DESCRIPTION
## Summary

`DefaultAssetImportStrategy.getStreamFromUrl` previously fetched any URL supplied by an admin without checking what host it actually resolves to. Combined with Node's permissive `http.get`, this gave an authenticated admin a free SSRF primitive: pointing the importer at e.g. `http://169.254.169.254/latest/meta-data/` extracts cloud IAM tokens, and any hostname pointing at a loopback / RFC 1918 / link-local address could probe internal services that trust same-host traffic (CWE-918, CVSS 8.6 per the disclosure).

## Fix

A new pre-flight `assertPublicUrl(...)` runs before each fetch:

1. Reject non-`http(s)` schemes (defensive — `getStreamFromPath` already filters via regex, but this catches future callers and explicit `file://` / `gopher://` attempts).
2. Resolve the hostname (or use the literal if it's already an IP) and reject when ANY resolved address lands in a private, loopback, link-local, CGNAT or unspecified range. Uses `net.BlockList` so both IPv4 and IPv6 ranges are covered (`0.0.0.0/8`, `10.0.0.0/8`, `100.64.0.0/10`, `127.0.0.0/8`, `169.254.0.0/16`, `172.16.0.0/12`, `192.0.0.0/24`, `192.168.0.0/16`, `198.18.0.0/15`, `::`, `::1`, `fc00::/7`, `fe80::/10`).
3. Resolving multiple addresses → all must be public; ANY private address rejects (defends against split-horizon DNS).

An opt-in `allowPrivateNetworks?: boolean` constructor option lets operators bypass the block when importing from a trusted internal asset server or running locally. The protocol check still applies even with the bypass.

## Why all-private (not just metadata IP)

The disclosure focuses on `169.254.169.254`, but the actual threat surface is wider: SSRF against any internal address can probe Redis, ES, Postgres admin endpoints, sidecar containers, the Vendure admin port itself, etc. Blocking the whole private-network bucket is the standard mitigation (matches AWS's IMDSv2 hardening guidance, GitHub's webhook validator, Stripe's webhook block-list).

## Test plan

- [x] 14 new unit tests in `assert-public-url.spec.ts` — every range, scheme, DNS path covered, including the all-private bypass and DNS-failure paths
- [x] Full `@vendure/core` unit suite — 826 tests pass
- [ ] Manual: configure a Vendure server, attempt to import an asset from `http://169.254.169.254/latest/meta-data/` → expect a clear refusal error and no outbound request
- [ ] Manual: same with `allowPrivateNetworks: true` → request proceeds (errors come from the actual fetch behaviour, not from the validator)
- [ ] Manual: legitimate public CDN URL works exactly as before

## Notes

- Reported privately via responsible disclosure (internal Linear OSS-487 — Pratik Karan, 2026-04-03). No public GitHub issue exists.
- The strategy options were previously typed with required `retryDelayMs` / `retryCount`; the PR loosens them to optional (with the same defaults at the use site) to keep the new option additive without forcing existing callers to pass retry settings they didn't pass before.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4721"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->