### PR TITLE
fix(core): Default languageCode in RequestContext.empty()

### DIFF
--- a/packages/core/e2e/asset.e2e-spec.ts
+++ b/packages/core/e2e/asset.e2e-spec.ts
@@ -1,10 +1,16 @@
-import { DeletionResult, LogicalOperator, SortOrder } from '@vendure/common/lib/generated-types';
+import {
+    DeletionResult,
+    LanguageCode,
+    LogicalOperator,
+    SortOrder,
+} from '@vendure/common/lib/generated-types';
 import { omit } from '@vendure/common/lib/omit';
 import { pick } from '@vendure/common/lib/pick';
-import { mergeConfig } from '@vendure/core';
+import { Asset, AssetService, AssetTranslation, mergeConfig, TransactionalConnection } from '@vendure/core';
 import { createErrorResultGuard, createTestEnvironment, ErrorResultGuard } from '@vendure/testing';
 import fs from 'fs-extra';
 import path from 'node:path';
+import { Readable } from 'node:stream';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
 import { initialData } from '../../../e2e-common/e2e-initial-data';
@@ -542,6 +548,33 @@ describe('Asset resolver', () => {
             productGuard.assertSuccess(product);
             expect(product.featuredAsset).toBeNull();
             expect(product.assets.length).toEqual(0);
+        });
+    });
+
+    // https://github.com/vendurehq/vendure/issues/4651
+    describe('createFromFileStream without RequestContext', () => {
+        it('uses default languageCode for the asset translation', async () => {
+            const assetService = server.app.get(AssetService);
+            const connection = server.app.get(TransactionalConnection);
+
+            const stream = new Readable();
+            stream.push('oss-499 content');
+            stream.push(null);
+
+            const result = await assetService.createFromFileStream(stream, 'oss-499.pdf');
+
+            if (!(result instanceof Asset)) {
+                throw new Error(`Expected Asset, got ${JSON.stringify(result)}`);
+            }
+            expect(result.id).toBeDefined();
+            expect(result.name).toBe('oss-499.pdf');
+
+            const translations = await connection.rawConnection
+                .getRepository(AssetTranslation)
+                .find({ where: { base: { id: result.id } } });
+            expect(translations.length).toBe(1);
+            expect(translations[0].languageCode).toBe(LanguageCode.en);
+            expect(translations[0].name).toBe('oss-499.pdf');
         });
     });
 });

--- a/packages/core/src/api/common/request-context.spec.ts
+++ b/packages/core/src/api/common/request-context.spec.ts
@@ -130,6 +130,13 @@ describe('RequestContext', () => {
         });
     });
 
+    describe('empty', () => {
+        // https://github.com/vendurehq/vendure/issues/4651
+        it('languageCode defaults to LanguageCode.en', () => {
+            expect(RequestContext.empty().languageCode).toBe(LanguageCode.en);
+        });
+    });
+
     describe('userHasPermissions', () => {
         it('returns false when no session', () => {
             const ctx = createRequestContextWithPermissions([], false);

--- a/packages/core/src/api/common/request-context.ts
+++ b/packages/core/src/api/common/request-context.ts
@@ -228,6 +228,11 @@ export class RequestContext {
             authorizedAsOwnerOnly: false,
             channel: new Channel(),
             isAuthorized: true,
+            // The `languageCode` getter is typed as `LanguageCode` (non-optional),
+            // so we provide a default here to avoid an undefined value when callers
+            // use `RequestContext.empty()` for programmatic operations such as
+            // `AssetService.createFromFileStream()`.
+            languageCode: LanguageCode.en,
         });
     }
 


### PR DESCRIPTION
## Summary

- `RequestContext.empty()` now defaults `languageCode` to `LanguageCode.en` so it produces a runtime-valid context. The `languageCode` getter is typed as `LanguageCode` (non-optional) but returned `undefined` at runtime when callers used `empty()`.
- Fixes `AssetService.createFromFileStream()` failing with `NOT NULL constraint failed: asset_translation.languageCode` when called without an explicit `RequestContext` (regression introduced in v3.6 by #4171 making `Asset` translatable).

## Root cause

`RequestContext.empty()` builds a context with `new Channel()` (no `defaultLanguageCode`). The constructor falls back to `channel.defaultLanguageCode` → `undefined`. Any downstream code that relies on `ctx.languageCode` for a NOT NULL column then crashes.

In `AssetService.createAssetInternal()` the default-translation path uses `ctx.languageCode` directly, so `createFromFileStream(stream, filename)` (no `ctx` arg) inserts `NULL` into `asset_translation.languageCode`.

## Test plan

- [x] Unit test in `request-context.spec.ts` pinning `RequestContext.empty().languageCode === LanguageCode.en`
- [x] E2E test in `asset.e2e-spec.ts` that reproduces the exact bug from the issue: calls `AssetService.createFromFileStream(stream, 'oss-499.pdf')` without a `RequestContext` and verifies the resulting `AssetTranslation` row has `languageCode: 'en'`. Confirmed to fail on `master` and pass with this change.
- [x] All 23 tests in `asset.e2e-spec.ts` pass (sqljs)
- [x] All 8 spec files that use `RequestContext.empty()` continue to pass (62 tests)

Fixes #4651

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->