### PR TITLE
fix(core): Skip v3.6 asset translation migration on empty DB

### DIFF
--- a/packages/core/e2e/migrate-asset-translations.e2e-spec.ts
+++ b/packages/core/e2e/migrate-asset-translations.e2e-spec.ts
@@ -103,6 +103,40 @@ describe('migrateAssetTranslationData()', () => {
         await migrateAssetTranslationData(queryRunner);
     });
 
+    // Reproduces https://github.com/vendurehq/vendure/issues/4647 (OSS-496):
+    // on a fresh install with no asset data and no default channel yet,
+    // the migration should be a no-op rather than throwing.
+    it('should skip if there are no assets to migrate, even without a default channel', async () => {
+        // Rename the default channel to simulate it not existing. If the
+        // function still queried the channel table for __default_channel__,
+        // it would throw.
+        await queryRunner.query(
+            `UPDATE ${esc('channel')} SET ${esc('code')} = '__tmp_renamed__' WHERE ${esc('code')} = '__default_channel__'`,
+        );
+        await queryRunner.query(`ALTER TABLE ${esc('asset')} ADD ${esc('name')} varchar(255) NULL`);
+        try {
+            const beforeRows: Array<{ c: string | number }> = await queryRunner.query(
+                `SELECT COUNT(*) AS ${esc('c')} FROM ${esc('asset_translation')}`,
+            );
+
+            // All asset.name values are NULL — nothing to migrate. Should not throw.
+            await expect(migrateAssetTranslationData(queryRunner)).resolves.not.toThrow();
+
+            // And no asset_translation rows should have been inserted.
+            const afterRows: Array<{ c: string | number }> = await queryRunner.query(
+                `SELECT COUNT(*) AS ${esc('c')} FROM ${esc('asset_translation')}`,
+            );
+            expect(Number(afterRows[0].c)).toBe(Number(beforeRows[0].c));
+        } finally {
+            if (await queryRunner.hasColumn('asset', 'name')) {
+                await queryRunner.query(`ALTER TABLE ${esc('asset')} DROP COLUMN ${esc('name')}`);
+            }
+            await queryRunner.query(
+                `UPDATE ${esc('channel')} SET ${esc('code')} = '__default_channel__' WHERE ${esc('code')} = '__tmp_renamed__'`,
+            );
+        }
+    });
+
     it('should populate asset_translation from name column', async () => {
         try {
             await simulatePreMigrationState();

--- a/packages/core/e2e/migrate-asset-translations.e2e-spec.ts
+++ b/packages/core/e2e/migrate-asset-translations.e2e-spec.ts
@@ -107,20 +107,21 @@ describe('migrateAssetTranslationData()', () => {
     // on a fresh install with no asset data and no default channel yet,
     // the migration should be a no-op rather than throwing.
     it('should skip if there are no assets to migrate, even without a default channel', async () => {
-        // Rename the default channel to simulate it not existing. If the
-        // function still queried the channel table for __default_channel__,
-        // it would throw.
-        await queryRunner.query(
-            `UPDATE ${esc('channel')} SET ${esc('code')} = '__tmp_renamed__' WHERE ${esc('code')} = '__default_channel__'`,
-        );
-        await queryRunner.query(`ALTER TABLE ${esc('asset')} ADD ${esc('name')} varchar(255) NULL`);
         try {
+            // Rename the default channel to simulate it not existing. If the
+            // function still queried the channel table for __default_channel__,
+            // it would throw.
+            await queryRunner.query(
+                `UPDATE ${esc('channel')} SET ${esc('code')} = '__tmp_renamed__' WHERE ${esc('code')} = '__default_channel__'`,
+            );
+            await queryRunner.query(`ALTER TABLE ${esc('asset')} ADD ${esc('name')} varchar(255) NULL`);
+
             const beforeRows: Array<{ c: string | number }> = await queryRunner.query(
                 `SELECT COUNT(*) AS ${esc('c')} FROM ${esc('asset_translation')}`,
             );
 
             // All asset.name values are NULL — nothing to migrate. Should not throw.
-            await expect(migrateAssetTranslationData(queryRunner)).resolves.not.toThrow();
+            await migrateAssetTranslationData(queryRunner);
 
             // And no asset_translation rows should have been inserted.
             const afterRows: Array<{ c: string | number }> = await queryRunner.query(

--- a/packages/core/src/migration-utils/v3_6_asset_translations.ts
+++ b/packages/core/src/migration-utils/v3_6_asset_translations.ts
@@ -49,7 +49,19 @@ export async function migrateAssetTranslationData(queryRunner: QueryRunner): Pro
 
     const esc = (name: string) => queryRunner.connection.driver.escape(name);
 
-    // 1. Get the default language code from the default channel
+    // 1. If there is no asset data to migrate, skip entirely. This covers the
+    // fresh-install case where migrations run against an empty database before
+    // the default channel has been populated.
+    const assetCounts: Array<{ count: string | number }> = await queryRunner.query(
+        `SELECT COUNT(*) AS ${esc('count')} FROM ${esc('asset')} WHERE ${esc('name')} IS NOT NULL`,
+    );
+    const assetCount = Number(assetCounts?.[0]?.count ?? 0);
+    if (assetCount === 0) {
+        console.log('No asset rows with a name to migrate. Skipping asset translation data migration.');
+        return;
+    }
+
+    // 2. Get the default language code from the default channel
     const rows: Array<{ defaultLanguageCode: string }> = await queryRunner.query(
         `SELECT ${esc('defaultLanguageCode')} FROM ${esc('channel')} WHERE ${esc('code')} = '__default_channel__'`,
     );
@@ -60,7 +72,7 @@ export async function migrateAssetTranslationData(queryRunner: QueryRunner): Pro
     }
     const defaultLanguageCode = rows[0].defaultLanguageCode;
 
-    // 2. Copy asset names into the asset_translation table
+    // 3. Copy asset names into the asset_translation table
     await queryRunner.query(
         `INSERT INTO ${esc('asset_translation')} (${esc('createdAt')}, ${esc('updatedAt')}, ${esc('languageCode')}, ${esc('name')}, ${esc('baseId')})
          SELECT a.${esc('createdAt')}, a.${esc('updatedAt')}, '${defaultLanguageCode}', a.${esc('name')}, a.${esc('id')}

--- a/packages/core/src/migration-utils/v3_6_asset_translations.ts
+++ b/packages/core/src/migration-utils/v3_6_asset_translations.ts
@@ -55,7 +55,7 @@ export async function migrateAssetTranslationData(queryRunner: QueryRunner): Pro
     const assetCounts: Array<{ count: string | number }> = await queryRunner.query(
         `SELECT COUNT(*) AS ${esc('count')} FROM ${esc('asset')} WHERE ${esc('name')} IS NOT NULL`,
     );
-    const assetCount = Number(assetCounts?.[0]?.count ?? 0);
+    const assetCount = Number(assetCounts[0].count);
     if (assetCount === 0) {
         console.log('No asset rows with a name to migrate. Skipping asset translation data migration.');
         return;


### PR DESCRIPTION
## Summary

`migrateAssetTranslationData()` unconditionally queried the `__default_channel__` row to obtain a default language code. On a fresh install, migrations run *before* the default channel is seeded, so an empty database threw:

> Could not find the default channel. The `__default_channel__` must exist before running this migration.

…even though there was no asset data to migrate.

This PR counts assets with a non-null `name` first. If there are none, the function logs and returns early without touching the channel table. The error still surfaces when real asset data exists but the default channel is missing — that's a legitimately broken state that should not be silently ignored.

Note: the sibling helper `migrateProductOptionGroupData()` also references `__default_channel__` but is accidentally safe — it joins through `product_option_group`, so an empty table makes the `INSERT … SELECT` a no-op rather than a throw. No parallel fix needed.

Fixes #4647

## Test plan

- [x] New e2e test in `migrate-asset-translations.e2e-spec.ts` reproduces the fresh-install scenario: renames the default channel so any channel lookup would fail, adds an empty `name` column to `asset`, and asserts the migration neither throws nor inserts any `asset_translation` rows
- [x] All 8 tests in `migrate-asset-translations.e2e-spec.ts` pass (sqljs)
- [x] Sibling `migrate-product-option-groups.e2e-spec.ts` still green (5/5)
- [x] `tsc --noEmit` clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4733"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->