### PR TITLE
fix(dashboard): Apply addCustomFields to profile page route loader

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_profile/profile.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_profile/profile.tsx
@@ -3,6 +3,8 @@ import { FormFieldWrapper } from '@/vdb/components/shared/form-field-wrapper.js'
 import { Badge } from '@/vdb/components/ui/badge.js';
 import { Button } from '@/vdb/components/ui/button.js';
 import { Input } from '@/vdb/components/ui/input.js';
+import { extendDetailFormQuery } from '@/vdb/framework/document-extension/extend-detail-form-query.js';
+import { addCustomFields } from '@/vdb/framework/document-introspection/add-custom-fields.js';
 import {    CustomFieldsPageBlock,
     DetailFormGrid,
     Page,
@@ -12,21 +14,26 @@ import {    CustomFieldsPageBlock,
     PageTitle,
 } from '@/vdb/framework/layout-engine/page-layout.js';
 import { ActionBarItem } from '@/vdb/framework/layout-engine/action-bar-item-wrapper.js';
-import { useDetailPage } from '@/vdb/framework/page/use-detail-page.js';
-import { api } from '@/vdb/graphql/api.js';
+import { getDetailQueryOptions, useDetailPage } from '@/vdb/framework/page/use-detail-page.js';
 import { useLocalFormat } from '@/vdb/hooks/use-local-format.js';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { createFileRoute } from '@tanstack/react-router';
 import { toast } from 'sonner';
 import { activeAdministratorDocument, updateAdministratorDocument } from './profile.graphql.js';
 
+const pageId = 'profile';
+
 export const Route = createFileRoute('/_authenticated/_profile/profile')({
     component: ProfilePage,
     loader: async ({ context }) => {
-        await context.queryClient.ensureQueryData({
-            queryFn: () => api.query(activeAdministratorDocument),
-            queryKey: ['DetailPage', 'profile'],
-        });
+        const { extendedQuery } = extendDetailFormQuery(
+            addCustomFields(activeAdministratorDocument),
+            pageId,
+        );
+        await context.queryClient.ensureQueryData(
+            getDetailQueryOptions(extendedQuery, { id: 'undefined' }),
+            {},
+        );
         return {
             breadcrumb: [{ path: '/profile', label: <Trans>Profile</Trans> }],
         };
@@ -42,6 +49,7 @@ function ProfilePage() {
         queryDocument: activeAdministratorDocument,
         entityField: 'activeAdministrator',
         updateDocument: updateAdministratorDocument,
+        pageId,
         setValuesForUpdate: entity => {
             return {
                 id: entity.id,
@@ -71,7 +79,7 @@ function ProfilePage() {
     });
 
     return (
-        <Page pageId="profile" form={form} submitHandler={submitHandler}>
+        <Page pageId={pageId} form={form} submitHandler={submitHandler}>
             <PageTitle>
                 <Trans>Profile</Trans>
             </PageTitle>


### PR DESCRIPTION
## Description

The `/profile` route loader queries `activeAdministratorDocument` directly without passing it through `addCustomFields()`, sending a bare `customFields` field. When custom fields are defined on the `Administrator` entity, the server rejects the query with:

> Field `customFields` of type `AdministratorCustomFields` must have a selection of subfields. Did you mean `customFields { ... }`?

The administrator detail page (`/administrators/:id`) doesn't hit this because it goes through `detailPageRouteLoader()`, which applies `addCustomFields()`.

## Fix

Wrap the document with `addCustomFields()` + `extendDetailFormQuery()` in the loader and use `getDetailQueryOptions()`. Thread `pageId` through `useDetailPage` and `<Page>` so extension hooks fire and the prefetch query key matches `useDetailPage`'s runtime key (previously they didn't, causing a redundant fetch).

Follows the `global-settings.tsx` pattern — the closest existing analog for a singleton-entity detail page.

## Verification

- Reproduced on master: `Administrator` custom field configured → `/dashboard/profile` shows the GraphQL error.
- With the fix applied: profile page loads, custom field renders, no GraphQL errors, no console errors.
- TypeScript check passes, all 349 dashboard unit tests pass.

## Note

This supersedes the stalled PR #4444 (which had been approved by @biggamesmallworld months ago but stuck on failing CI). The change incorporates the maintainer's review feedback (use the `pageId` constant in `<Page>` to keep loader and component aligned).

## Fixes

#4443

## Breaking changes

None.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4734"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->