### PR TITLE
fix(core): Load ProductVariant translations in OrderService.findOne

### DIFF
--- a/packages/core/e2e/order.e2e-spec.ts
+++ b/packages/core/e2e/order.e2e-spec.ts
@@ -12,6 +12,8 @@ import {
 import { omit } from '@vendure/common/lib/omit';
 import { pick } from '@vendure/common/lib/pick';
 import {
+    OrderService,
+    RequestContextService,
     defaultShippingCalculator,
     defaultShippingEligibilityChecker,
     manualFulfillmentHandler,
@@ -2405,6 +2407,51 @@ describe('Orders resolver', () => {
                 id: order.id,
             });
             expect(order2?.state).toBe('PartiallyShipped');
+        });
+
+        // https://github.com/vendurehq/vendure/issues/4566
+        // Before the fix, `findOne` translated each `line.productVariant` even when the
+        // caller's relations list did not include `lines.productVariant.translations`,
+        // causing `error.entity-has-no-translation-in-language` on subsequent
+        // `addItemToOrder` calls that internally reload the active order via
+        // `getOrderOrThrow`.
+        it('loads ProductVariant translations when findOne is called with explicit relations', async () => {
+            await shopClient.asAnonymousUser();
+            const { addItemToOrder: firstAdd } = await shopClient.query(addItemToOrderDocument, {
+                productVariantId: 'T_1',
+                quantity: 1,
+            });
+            shopOrderGuard.assertSuccess(firstAdd);
+            const internalOrderId = +firstAdd.id.replace('T_', '');
+
+            const ctx = await server.app.get(RequestContextService).create({ apiType: 'admin' });
+            const order = await server.app
+                .get(OrderService)
+                .findOne(ctx, internalOrderId, [
+                    'lines',
+                    'lines.productVariant',
+                    'lines.productVariant.productVariantPrices',
+                    'shippingLines',
+                    'surcharges',
+                    'customer',
+                ]);
+
+            expect(order).toBeDefined();
+            expect(order!.lines.length).toBe(1);
+            const variant = order!.lines[0].productVariant;
+            expect(variant.translations.length).toBe(1);
+            expect(variant.translations[0].languageCode).toBe(LanguageCode.en);
+            expect(variant.name).toBe('Laptop 13 inch 8GB');
+
+            // Re-add the same item: this exercises the original user-visible failure
+            // path (`addItemToOrder` -> `getOrderOrThrow` -> `findOne` -> translate).
+            // Pre-fix this would throw `error.entity-has-no-translation-in-language`.
+            const { addItemToOrder: secondAdd } = await shopClient.query(addItemToOrderDocument, {
+                productVariantId: 'T_1',
+                quantity: 1,
+            });
+            shopOrderGuard.assertSuccess(secondAdd);
+            expect(secondAdd.lines[0].quantity).toBe(2);
         });
     });
 

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -85,10 +85,10 @@ import { Channel } from '../../entity/channel/channel.entity';
 import { Customer } from '../../entity/customer/customer.entity';
 import { Fulfillment } from '../../entity/fulfillment/fulfillment.entity';
 import { HistoryEntry } from '../../entity/history-entry/history-entry.entity';
-import { Order } from '../../entity/order/order.entity';
-import { OrderLine } from '../../entity/order-line/order-line.entity';
 import { FulfillmentLine } from '../../entity/order-line-reference/fulfillment-line.entity';
+import { OrderLine } from '../../entity/order-line/order-line.entity';
 import { OrderModification } from '../../entity/order-modification/order-modification.entity';
+import { Order } from '../../entity/order/order.entity';
 import { Payment } from '../../entity/payment/payment.entity';
 import { ProductVariant } from '../../entity/product-variant/product-variant.entity';
 import { Promotion } from '../../entity/promotion/promotion.entity';
@@ -231,12 +231,22 @@ export class OrderService {
             'shippingLines',
             'surcharges',
         ];
-        if (
-            relations &&
-            effectiveRelations.includes('lines.productVariant') &&
-            !effectiveRelations.includes('lines.productVariant.taxCategory')
-        ) {
-            effectiveRelations.push('lines.productVariant.taxCategory');
+        // Any caller requesting `lines.productVariant` (directly or via a sub-relation
+        // path) implies the variant will be loaded into the split lines query and
+        // translated below. TypeORM doesn't honour transitive `eager: true` relations
+        // (like `ProductVariant.translations`) when an explicit `relations` array is
+        // passed to `setFindOptions`, so we inject `taxCategory` and `translations`
+        // ourselves to keep `applyChannelPriceAndTax` + `translator.translate` correct.
+        const wantsLineVariant = effectiveRelations.some(
+            r => r === 'lines.productVariant' || r.startsWith('lines.productVariant.'),
+        );
+        if (relations && wantsLineVariant) {
+            if (!effectiveRelations.includes('lines.productVariant.taxCategory')) {
+                effectiveRelations.push('lines.productVariant.taxCategory');
+            }
+            if (!effectiveRelations.includes('lines.productVariant.translations')) {
+                effectiveRelations.push('lines.productVariant.translations');
+            }
         }
 
         // Split relations into two groups for different loading strategies:
@@ -277,7 +287,7 @@ export class OrderService {
                 order.lines = lines;
             }
 
-            if (effectiveRelations.includes('lines.productVariant')) {
+            if (wantsLineVariant) {
                 for (const line of order.lines) {
                     line.productVariant = this.translator.translate(
                         await this.productVariantService.applyChannelPriceAndTax(


### PR DESCRIPTION
## Summary

`OrderService.findOne()` translates every `line.productVariant` via `translator.translate()` but did not guarantee `lines.productVariant.translations` was loaded when callers passed an explicit `relations` list. The auto-injection block only added `lines.productVariant.taxCategory`, leaving the variant without translations and causing `error.entity-has-no-translation-in-language` on common flows (notably `addItemToOrder` -> `getOrderOrThrow`).

## Root cause

In v3.3.6 line-loading was split into a separate query using `setFindOptions({ relations: lineRelations })`. TypeORM does not honour transitive `eager: true` relations (like `ProductVariant.translations`) when an explicit `relations` array is passed to `setFindOptions`, so the translations relation that was previously picked up via eager loading is no longer present. Meanwhile `findOne` unconditionally translates every loaded variant.

## Changes

- `packages/core/src/service/services/order.service.ts`
  - Extracted a `wantsLineVariant` predicate that matches both `lines.productVariant` and any `lines.productVariant.*` sub-relation, and used it for both the auto-inject block and the downstream translator block (previously two coupled literal-string checks).
  - When the caller passes `relations` containing the variant, auto-inject both `lines.productVariant.taxCategory` and `lines.productVariant.translations` when missing.
- `packages/core/e2e/order.e2e-spec.ts`
  - Added a regression test referencing #4566 inside the `issues` describe block. It calls `OrderService.findOne` directly with the exact buggy relations list from the report and asserts translations are loaded and `variant.name` is populated. A follow-up `addItemToOrder` step exercises the original user-visible failure path (`addItemToOrder` -> `getOrderOrThrow` -> `findOne` -> translate).

`getOrderOrThrow` defaults were intentionally not changed: they pass an explicit `relations` array to `findOne`, which then triggers the auto-inject — keeping a single source of truth.

## Follow-up

A separate `translator.translate(line.productVariant, ctx)` call exists in `OrderService.assertInsufficientStockOnHand()` (`order.service.ts:1843`). The variant there is loaded with `{ relations: ['productVariant'] }` only — the same root cause class. It is currently masked because that call uses a plain `repository.find()` rather than the split-load path, but worth tracking as a follow-up.

## Test plan

- [x] New test passes locally: `bun e2e -t "loads ProductVariant translations"` (7.5s)
- [x] No regressions in the other 92 order e2e tests
- [x] TypeScript build is clean

Fixes #4566

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->