### PR TITLE
fix(dashboard): Preserve column visibility and fix Dialog title context

### DIFF
--- a/packages/dashboard/e2e/tests/system/scheduled-tasks.spec.ts
+++ b/packages/dashboard/e2e/tests/system/scheduled-tasks.spec.ts
@@ -14,4 +14,37 @@ test.describe('Scheduled Tasks', () => {
         await expect(page.getByTestId('page-heading')).toBeVisible();
         await expect(page.getByRole('table')).toBeVisible();
     });
+
+    // OSS-470 — column visibility must survive a refresh.
+    //
+    // Original bug: the parent's inline `defaultColumnVisibility` got a new
+    // reference each render, and the DataTable effect compared that against
+    // the user-modified state and reset it. The user-visible trigger was the
+    // disable/enable mutation's onSuccess → queryClient.invalidateQueries →
+    // parent re-render. This e2e Vendure config registers no scheduled tasks,
+    // so refetches return the same empty data and TanStack Query's tracked
+    // properties skip the parent re-render — meaning this test does not fail
+    // against the unfixed code. It is kept as a smoke test for the wider class
+    // of "resets-on-refresh" regressions; the actual fix was verified manually
+    // on a dev server with real scheduled tasks.
+    test('should preserve column visibility after a refresh', async ({ page }) => {
+        await page.goto('/scheduled-tasks');
+        await expect(page.getByRole('table')).toBeVisible();
+
+        const dataTable = page.getByRole('table');
+        const descriptionHeader = dataTable.locator('thead th').filter({ hasText: 'Description' });
+
+        // "Description" column is visible by default — hide it via column settings.
+        await expect(descriptionHeader).toBeVisible();
+        await page.getByTestId('dt-column-settings-trigger').click();
+        await page.getByRole('menuitemcheckbox', { name: 'Description', exact: true }).click();
+        await page.keyboard.press('Escape');
+        await expect(descriptionHeader).toBeHidden();
+
+        // Refresh — same code path the disable/enable mutation onSuccess takes.
+        await page.getByTestId('dt-refresh-button').click();
+
+        // Column visibility must persist across the refetch.
+        await expect(descriptionHeader).toBeHidden();
+    });
 });

--- a/packages/dashboard/src/lib/components/data-table/data-table.tsx
+++ b/packages/dashboard/src/lib/components/data-table/data-table.tsx
@@ -229,16 +229,18 @@ export function DataTable<TData>({
         },
     });
 
+    // Track the last-applied `defaultColumnVisibility` content so we only reset state
+    // when the prop's actual content changes (e.g. the user reset the table settings),
+    // not on every re-render where the parent passes a new reference to the same value.
+    const lastAppliedDefaultRef = useRef<string | undefined>(
+        defaultColumnVisibility ? JSON.stringify(defaultColumnVisibility) : undefined,
+    );
     useEffect(() => {
-        // If the defaultColumnVisibility changes externally (e.g. the user reset the table settings),
-        // we want to reset the column visibility to the default.
-        if (
-            defaultColumnVisibility &&
-            JSON.stringify(defaultColumnVisibility) !== JSON.stringify(columnVisibility)
-        ) {
-            setColumnVisibility(defaultColumnVisibility);
-        }
-        // We intentionally do not include `columnVisibility` in the dependency array
+        if (!defaultColumnVisibility) return;
+        const serialized = JSON.stringify(defaultColumnVisibility);
+        if (lastAppliedDefaultRef.current === serialized) return;
+        lastAppliedDefaultRef.current = serialized;
+        setColumnVisibility(defaultColumnVisibility);
     }, [defaultColumnVisibility]);
 
     // Add drag handle column if drag and drop is enabled

--- a/packages/dashboard/src/lib/components/data-table/refresh-button.tsx
+++ b/packages/dashboard/src/lib/components/data-table/refresh-button.tsx
@@ -36,7 +36,7 @@ export function RefreshButton({
 
     return (
         <Tooltip>
-            <TooltipTrigger render={<Button variant="outline" size="icon-sm" onClick={handleClick} disabled={delayedLoading} />}>
+            <TooltipTrigger render={<Button variant="outline" size="icon-sm" onClick={handleClick} disabled={delayedLoading} data-testid="dt-refresh-button" />}>
                     <RefreshCw className={delayedLoading ? 'animate-rotate' : ''} />
             </TooltipTrigger>
             <TooltipContent>

--- a/packages/dashboard/src/lib/components/ui/alert-dialog.tsx
+++ b/packages/dashboard/src/lib/components/ui/alert-dialog.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/vdb/lib/utils.js';
-import { AlertDialogPrimitive } from '@vendure-io/ui/lib/base-ui';
+import { AlertDialogTitle as AlertDialogTitleBase } from '@vendure-io/ui/components/ui/alert-dialog';
 
 export {
     AlertDialog,
@@ -15,19 +15,11 @@ export {
     AlertDialogTrigger,
 } from '@vendure-io/ui/components/ui/alert-dialog';
 
-// Override AlertDialogTitle to use the heading font (Public Sans)
+// Override AlertDialogTitle to use the heading font (Public Sans). Wrap the
+// base wrapper rather than the primitive — see dialog.tsx for the rationale.
 export function AlertDialogTitle({
     className,
     ...props
-}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
-    return (
-        <AlertDialogPrimitive.Title
-            data-slot="alert-dialog-title"
-            className={cn(
-                'text-lg font-medium font-heading sm:group-data-[size=default]/alert-dialog-content:group-has-data-[slot=alert-dialog-media]/alert-dialog-content:col-start-2',
-                className,
-            )}
-            {...props}
-        />
-    );
+}: React.ComponentProps<typeof AlertDialogTitleBase>) {
+    return <AlertDialogTitleBase className={cn('font-heading', className)} {...props} />;
 }

--- a/packages/dashboard/src/lib/components/ui/dialog.tsx
+++ b/packages/dashboard/src/lib/components/ui/dialog.tsx
@@ -1,5 +1,5 @@
 import { cn } from '@/vdb/lib/utils.js';
-import { DialogPrimitive } from '@vendure-io/ui/lib/base-ui';
+import { DialogTitle as DialogTitleBase } from '@vendure-io/ui/components/ui/dialog';
 
 export {
     Dialog,
@@ -13,13 +13,14 @@ export {
     DialogTrigger,
 } from '@vendure-io/ui/components/ui/dialog';
 
-// Override DialogTitle to use the heading font (Public Sans)
-export function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
-    return (
-        <DialogPrimitive.Title
-            data-slot="dialog-title"
-            className={cn('leading-none font-medium font-heading', className)}
-            {...props}
-        />
-    );
+// Override DialogTitle to use the heading font (Public Sans). Wrap the base
+// wrapper rather than the primitive — going through the primitive directly
+// can resolve to a different module instance, leaving the title outside the
+// Dialog root context ("Cannot destructure property 'store' of
+// useDialogRootContext(...)").
+export function DialogTitle({
+    className,
+    ...props
+}: React.ComponentProps<typeof DialogTitleBase>) {
+    return <DialogTitleBase className={cn('font-heading', className)} {...props} />;
 }


### PR DESCRIPTION
## Summary

Two related dashboard fixes uncovered while triaging the column-visibility regression on the Scheduled Tasks page.

### 1. Column visibility reset after a mutation refetch

`DataTable`'s effect that synced `defaultColumnVisibility` into state compared the prop against the user's *current* state and reset whenever they differed. With inline literals like `<DataTable defaultColumnVisibility={{ schedule: false }} />` (used on Scheduled Tasks), every parent re-render produced a fresh reference, so any mutation that invalidated the query — including `disable` / `enable` — silently reverted the user's column visibility.

The effect now tracks the last-applied default content via a ref and only resets when that content actually changes (e.g. the user clicks "Reset" in the column settings menu). User-modified state is preserved across incidental re-renders.

Fix is in `DataTable` rather than at the caller because `paginated-list-data-table.tsx` and `order-table.tsx` have the same shape (`defaultColumnVisibility={computeEveryRender(...)}`) and would be vulnerable to the same regression on any future mutation cycle.

### 2. `DialogTitle` / `AlertDialogTitle` primitive context error

While verifying the column fix on the dev server I hit:

```
TypeError: Cannot destructure property 'store' of 'useDialogRootContext(...)' as it is undefined.
The above error occurred in the <DialogTitle> component.
```

…on every dialog with a title (Scheduled Tasks > View result, and any other consumer of the dashboard's `DialogTitle` / `AlertDialogTitle`).

Root cause: the dashboard's overrides rendered the `@base-ui/react` primitive (`DialogPrimitive.Title` / `AlertDialogPrimitive.Title`) directly while the surrounding `<Dialog>` / `<AlertDialog>` came from the `@vendure-io/ui` wrappers. Vite can resolve those two paths (`@vendure-io/ui/lib/base-ui` vs `@vendure-io/ui/components/ui/dialog` → `@base-ui/react/dialog`) to separate module instances, so the title rendered with no Dialog root context.

Fix: wrap `@vendure-io/ui`'s `DialogTitle` / `AlertDialogTitle` rather than the underlying primitive, and apply `font-heading` via `className`. The merge keeps the original utility classes and there is now a single primitive instance for the whole Dialog subtree.

## Test plan

- [x] Manually verified on dev server (which has real scheduled tasks): hidden Schedule Pattern via column settings shows up, disable a task → column stays visible. Re-enable cleans up.
- [x] Manually verified View result dialog opens without console errors and renders payload.
- [x] Added regression smoke test in `e2e/tests/system/scheduled-tasks.spec.ts` (refresh button instead of disable, since the e2e config registers no scheduled tasks — comment in the test explains).
- [x] All 4 scheduled-tasks playwright tests pass locally.
- [x] TypeScript build clean.

## Notes

- The e2e regression test does not fail without the column-visibility fix in this test environment: with no scheduled tasks in the e2e Vendure config, refetches return the same empty data and TanStack Query's tracked properties skip the parent re-render that triggers the bug. The test still guards against the broader "resets-on-refresh" class of regressions; the underlying fix was verified manually on a dev server with real tasks.
- The `data-testid="dt-refresh-button"` added to the `RefreshButton` is reused for the new test and is generally useful for future e2e coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4739"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved column visibility persistence in data tables to prevent resetting when page refreshes
  
* **Tests**
  * Added end-to-end test verifying column visibility settings persist after page refresh

* **Style**
  * Updated dialog and alert dialog components for improved UI consistency

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/vendurehq/vendure/pull/4739)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->