### PR TITLE
perf(dashboard): reduce heavy relation query

### DIFF
--- a/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
@@ -240,9 +240,7 @@ const createEntityConfigs = (i18n: any) => ({
                         slug
                         isPrivate
                         position
-                        productVariants {
-                            totalItems
-                        }
+                        productVariantCount
                         featuredAsset {
                             id
                             preview
@@ -255,7 +253,7 @@ const createEntityConfigs = (i18n: any) => ({
         label: (item: any) => (
             <EntityLabel
                 title={item.name}
-                subtitle={`${item.slug} • ${item.productVariants?.totalItems || 0} products`}
+                subtitle={`${item.slug} • ${item.productVariantCount || 0} products`}
                 imageUrl={item.featuredAsset?.preview}
                 placeholderLetter="C"
                 statusIndicator={<StatusBadge condition={item.isPrivate} text="Private" />}


### PR DESCRIPTION
# Description

This PR improves Dashboard relation selector performance by replacing the expensive nested collection variant count query with the lightweight aggregate count field.

Summary of changes:
- Switched collection selector query field from `productVariants { totalItems }` to `productVariantCount`.
- Updated the displayed count in the selector label to use `productVariantCount`.
Related issue:
- Closes #4742

# Breaking changes

No breaking changes.

# Screenshots

N/A (performance/query optimization only, no visual behavior change beyond count source)

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->