### PR TITLE
feat(dashboard): allow NavTitleDescriptor for nav section and item titles

### DIFF
--- a/packages/dashboard/src/lib/framework/extension-api/define-dashboard-extension.spec.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/define-dashboard-extension.spec.ts
@@ -171,6 +171,41 @@ describe('defineDashboardExtension - navSections', () => {
         warnSpy.mockRestore();
     });
 
+    it('normalizes NavTitleDescriptor to its id for navSection title', () => {
+        defineDashboardExtension({
+            navSections: [{ id: 'my-section', title: { id: 'my-section-title', message: 'My Section' } }],
+        });
+
+        executeDashboardExtensionCallbacks();
+
+        const result = getNavMenuConfig();
+        const section = result.sections.find(s => s.id === 'my-section');
+        expect(section?.title).toBe('my-section-title');
+    });
+
+    it('normalizes NavTitleDescriptor to its id for navMenuItem title', () => {
+        defineDashboardExtension({
+            navSections: [{ id: 'catalog', title: 'Catalog' }],
+            routes: [
+                {
+                    path: '/my-page',
+                    component: () => null,
+                    navMenuItem: {
+                        sectionId: 'catalog',
+                        title: { id: 'my-page-title', message: 'My Page' },
+                    },
+                },
+            ],
+        });
+
+        executeDashboardExtensionCallbacks();
+
+        const result = getNavMenuConfig();
+        const section = result.sections.find(s => s.id === 'catalog');
+        const item = section && 'items' in section ? section.items?.find(i => i.url === '/my-page') : undefined;
+        expect(item?.title).toBe('my-page-title');
+    });
+
     it('can move items between sections', () => {
         addNavMenuSection({
             id: 'settings',

--- a/packages/dashboard/src/lib/framework/extension-api/logic/navigation.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/logic/navigation.ts
@@ -28,6 +28,7 @@ function registerNavSections(
     for (const section of navSections) {
         addNavMenuSection({
             ...section,
+            title: typeof section.title === 'string' ? section.title : section.title.id,
             placement: section.placement ?? 'top',
             order: section.order ?? 999,
             items: [],
@@ -41,10 +42,11 @@ function registerRoutes(routes?: DashboardRouteDefinition[]) {
     }
     for (const route of routes) {
         if (route.navMenuItem) {
+            const rawTitle = route.navMenuItem.title ?? route.path;
             const item: NavMenuItem = {
                 url: route.navMenuItem.url ?? route.path,
                 id: route.navMenuItem.id ?? route.path,
-                title: route.navMenuItem.title ?? route.path,
+                title: typeof rawTitle === 'string' ? rawTitle : rawTitle.id,
                 order: route.navMenuItem.order,
                 requiresPermission: route.navMenuItem.requiresPermission,
                 icon: route.navMenuItem.icon,

--- a/packages/dashboard/src/lib/framework/extension-api/types/navigation.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/types/navigation.ts
@@ -2,7 +2,7 @@ import { AnyRoute, RouteOptions } from '@tanstack/react-router';
 import { LucideIcon } from 'lucide-react';
 import type React from 'react';
 
-import { NavMenuItem } from '../../nav-menu/nav-menu-extensions.js';
+import { NavMenuItem, NavTitleDescriptor } from '../../nav-menu/nav-menu-extensions.js';
 
 /**
  * @description
@@ -32,7 +32,7 @@ export interface DashboardRouteDefinition {
      * this item should appear in. It can also point to custom nav menu sections that
      * have been defined using the `navSections` extension property.
      */
-    navMenuItem?: Partial<NavMenuItem> & { sectionId: string };
+    navMenuItem?: Omit<Partial<NavMenuItem>, 'title'> & { title?: string | NavTitleDescriptor; sectionId: string };
     /**
      * @description
      * Optional loader function to fetch data before the route renders.
@@ -80,7 +80,7 @@ export interface DashboardNavSectionDefinition {
      * @description
      * The display title for the navigation section.
      */
-    title: string;
+    title: string | NavTitleDescriptor;
     /**
      * @description
      * Optional icon to display next to the section title. The icons should

--- a/packages/dashboard/src/lib/framework/nav-menu/nav-menu-extensions.ts
+++ b/packages/dashboard/src/lib/framework/nav-menu/nav-menu-extensions.ts
@@ -5,6 +5,14 @@ import { globalRegistry } from '../registry/global-registry.js';
 // Define the placement options for navigation sections
 export type NavMenuSectionPlacement = 'top' | 'bottom';
 
+// Minimal subset of Lingui's MessageDescriptor
+export interface NavTitleDescriptor {
+    id: string;
+    comment?: string;
+    message?: string;
+    values?: Record<string, unknown>;
+}
+
 /**
  * @description
  * Defines an items in the navigation menu.


### PR DESCRIPTION
# Description

Currently, `DashboardNavSectionDefinition.title` and `navMenuItem.title` only accept a plain `string`. This makes it impossible to use lazy i18n message descriptors (such as those produced by Lingui's `msg` macro) as nav menu titles, since these are not evaluated at definition time.

This PR extends both fields to accept `string | NavTitleDescriptor`, where `NavTitleDescriptor` is a minimal interface compatible with Lingui's `MessageDescriptor`. The normalization to `string` happens at registration time in [logic/navigation.ts](packages/dashboard/src/lib/framework/extension-api/logic/navigation.ts), so the internal `NavMenuItem.title` type remains unchanged.

**Usage example:**
```typescript
import { msg } from '@lingui/core/macro';

defineDashboardExtension({
    navSections: [{ id: 'my-section', title: msg`My Section` }],
    routes: [{
        path: '/my-page',
        component: MyPage,
        navMenuItem: { sectionId: 'my-section', title: msg`My Page` },
    }],
});
```

# Breaking changes

No breaking changes.

# Screenshots

 Not applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4744"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->