### PR TITLE
fix(dashboard): Stop logging "Uncompiled message detected" warnings

### DIFF
--- a/packages/dashboard/src/lib/components/layout/generated-breadcrumbs.tsx
+++ b/packages/dashboard/src/lib/components/layout/generated-breadcrumbs.tsx
@@ -69,6 +69,12 @@ export function GeneratedBreadcrumbs() {
         return p === u || p.startsWith(`${u}/`);
     };
 
+    // Nav-menu section titles are static translation keys (same convention as
+    // nav-main.tsx); page-level breadcrumbs from loaders may be dynamic entity
+    // names (product/collection/facet names) and must NOT be passed through
+    // i18n.t() — the BreadcrumbLink render below renders `label` as-is.
+    const translateSectionTitle = (title: string) => (title in i18n.messages ? i18n.t(title) : title);
+
     const checkSectionItems = (
         section: NavMenuSection | NavMenuItem,
         cleanPath: string,
@@ -80,7 +86,7 @@ export function GeneratedBreadcrumbs() {
         for (const item of section.items) {
             if (!item?.url) continue;
             if (pathMatches(cleanPath, item.url)) {
-                return { label: section.title, path: item.url };
+                return { label: translateSectionTitle(section.title), path: item.url };
             }
         }
         return undefined;
@@ -91,7 +97,7 @@ export function GeneratedBreadcrumbs() {
         cleanPath: string,
     ): BreadcrumbPair | undefined => {
         if ('url' in section && section.url && pathMatches(cleanPath, section.url)) {
-            return { label: section.title, path: section.url };
+            return { label: translateSectionTitle(section.title), path: section.url };
         }
         return undefined;
     };
@@ -123,7 +129,7 @@ export function GeneratedBreadcrumbs() {
                 {breadcrumbs.map(({ label, path }, index, arr) => (
                     <Fragment key={`${path}-${index}`}>
                         <BreadcrumbItem className="hidden md:block">
-                            <BreadcrumbLink render={<Link to={path} />}>{typeof label === 'string' ? i18n.t(label) : label}</BreadcrumbLink>
+                            <BreadcrumbLink render={<Link to={path} />}>{label}</BreadcrumbLink>
                         </BreadcrumbItem>
                         {index < arr.length - 1 && <BreadcrumbSeparator className="hidden md:block" />}
                     </Fragment>

--- a/packages/dashboard/src/lib/hooks/use-dynamic-translations.ts
+++ b/packages/dashboard/src/lib/hooks/use-dynamic-translations.ts
@@ -4,43 +4,30 @@ import { useLingui } from '@lingui/react';
 export function useDynamicTranslations() {
     const { i18n } = useLingui();
 
-    const getTranslatedFieldName = (fieldId: string) => {
-        const fieldNameTranslationId = `fieldName.${fieldId}`;
-        const translatedDisplay = i18n.t(fieldNameTranslationId);
-        return translatedDisplay !== fieldNameTranslationId
-            ? translatedDisplay
-            : camelCaseToTitleCase(fieldId);
-    };
+    // Calling i18n.t() for an id missing from the catalog logs a
+    // "Uncompiled message detected!" warning in production builds. The catalog
+    // does not include every possible custom-field name or state name, so guard
+    // the lookup instead of relying on i18n.t() returning the raw id.
+    const translateOrFallback = (id: string, fallback: () => string) =>
+        id in i18n.messages ? i18n.t(id) : fallback();
 
-    const getTranslatedOrderState = (state: string) => {
-        const stateTranslationId = `orderState.${state}`;
-        const translatedDisplay = i18n.t(stateTranslationId);
-        return translatedDisplay !== stateTranslationId ? translatedDisplay : camelCaseToTitleCase(state);
-    };
+    const getTranslatedFieldName = (fieldId: string) =>
+        translateOrFallback(`fieldName.${fieldId}`, () => camelCaseToTitleCase(fieldId));
 
-    const getTranslatedFulfillmentState = (state: string) => {
-        const stateTranslationId = `fulfillmentState.${state}`;
-        const translatedDisplay = i18n.t(stateTranslationId);
-        return translatedDisplay !== stateTranslationId ? translatedDisplay : camelCaseToTitleCase(state);
-    };
+    const getTranslatedOrderState = (state: string) =>
+        translateOrFallback(`orderState.${state}`, () => camelCaseToTitleCase(state));
 
-    const getTranslatedPaymentState = (state: string) => {
-        const stateTranslationId = `paymentState.${state}`;
-        const translatedDisplay = i18n.t(stateTranslationId);
-        return translatedDisplay !== stateTranslationId ? translatedDisplay : camelCaseToTitleCase(state);
-    };
+    const getTranslatedFulfillmentState = (state: string) =>
+        translateOrFallback(`fulfillmentState.${state}`, () => camelCaseToTitleCase(state));
 
-    const getTranslatedRefundState = (state: string) => {
-        const stateTranslationId = `refundState.${state}`;
-        const translatedDisplay = i18n.t(stateTranslationId);
-        return translatedDisplay !== stateTranslationId ? translatedDisplay : camelCaseToTitleCase(state);
-    };
+    const getTranslatedPaymentState = (state: string) =>
+        translateOrFallback(`paymentState.${state}`, () => camelCaseToTitleCase(state));
 
-    const getTranslatedRefundReason = (reason: string) => {
-        const reasonTranslationId = `refundReason.${reason}`;
-        const translatedDisplay = i18n.t(reasonTranslationId);
-        return translatedDisplay === reasonTranslationId ? camelCaseToTitleCase(reason) : translatedDisplay;
-    };
+    const getTranslatedRefundState = (state: string) =>
+        translateOrFallback(`refundState.${state}`, () => camelCaseToTitleCase(state));
+
+    const getTranslatedRefundReason = (reason: string) =>
+        translateOrFallback(`refundReason.${reason}`, () => camelCaseToTitleCase(reason));
 
     return {
         getTranslatedFieldName,


### PR DESCRIPTION
## Summary

In production builds `@lingui/core` does not install the runtime message compiler — `i18n.t(id)` for an id missing from the catalog falls back to returning the raw id **and** logs `console.warn("Uncompiled message detected! …")`. The dashboard hit this in two places, flooding the console linearly with the number of custom fields on a page.

### Root cause

1. **`packages/dashboard/src/lib/hooks/use-dynamic-translations.ts`** — six helpers (`getTranslatedFieldName`, `getTranslatedOrderState`, `getTranslatedFulfillmentState`, `getTranslatedPaymentState`, `getTranslatedRefundState`, `getTranslatedRefundReason`) used the anti-pattern of calling `i18n.t(id)` and comparing the returned value to the input to decide whether a translation existed. Every custom field name and every state without a catalog entry produced a warning.
2. **`packages/dashboard/src/lib/components/layout/generated-breadcrumbs.tsx`** — the render line passed raw entity names from the database (e.g. `"Solarkabel in SET(Schwarz-Rot) PV Kabel 6mm² 1m"`) through `i18n.t()`. Beyond the console noise, this is a latent bug: if such a string ever contains ICU-like characters (`{`, `}`, `#`) and a runtime compiler is later installed, it would be parsed as a message-format template.

### Fix

- `use-dynamic-translations.ts` — extract a `translateOrFallback(id, fallback)` helper that guards on `id in i18n.messages` before calling `i18n.t()`. All six helpers now use it, eliminating both the warning and the duplicated three-line pattern.
- `generated-breadcrumbs.tsx` — pre-translate the nav-menu `section.title` (which is a static translation key, same convention as `nav-main.tsx`) when the `BreadcrumbPair` is constructed, behind the same `title in i18n.messages` guard so extension-registered nav titles without a catalog entry don't trigger the warning either. Drop `i18n.t(label)` from the render so dynamic page-crumb labels (entity names from loaders) are rendered as-is.

### Behaviour preserved

- The existing e2e regression test `packages/dashboard/e2e/tests/regression/breadcrumb-stale-after-mutation.spec.ts` asserts the product name appears in the breadcrumb before and after rename. Before the fix `i18n.t("Breadcrumb Original Name")` returned the raw string (with a warning); after the fix it renders the raw string directly — same visible output.
- Built-in nav-menu titles (`"Catalog"`, `"Customers"`, ...) are in the catalog so the guarded `translateSectionTitle` returns the translated value as before.

### Follow-up (not in this PR)

`packages/dashboard/src/lib/components/layout/nav-main.tsx` uses the same unguarded `i18n.t(item.title)` pattern in six places. Built-in nav items are catalogued so it's fine today, but extension-registered custom nav items would reintroduce the warning. Worth a dedicated PR with a small shared helper once a third caller appears.

## Test plan

- [x] `bunx tsc --noEmit` on `packages/dashboard` — no new errors introduced by the diff
- [x] `bunx prettier --check` on both files — clean
- [x] Pre-commit hooks (lint, `check-lib-imports.js`, format) pass
- [x] Existing breadcrumb e2e regression test logic preserved (visible-label semantics unchanged)
- [ ] Manual production build smoke test — verify `Uncompiled message detected` no longer appears in browser console after `vite build`

Fixes #4736

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4745"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->