### PR TITLE
fix(dashboard): Apply column filters on list pages using OR filter operator

### DIFF
--- a/packages/dashboard/e2e/tests/regression/issue-4730-list-page-filter-with-empty-search.spec.ts
+++ b/packages/dashboard/e2e/tests/regression/issue-4730-list-page-filter-with-empty-search.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from '@playwright/test';
+
+import { BaseListPage } from '../../page-objects/list-page.base.js';
+
+test.describe('Issue 4730 — list-page column filter with empty search', () => {
+    // #4730 — list pages that combine `filterOperator: 'OR'` (set via
+    // `transformVariables`) with an unguarded `onSearchTermChange` returning
+    // `{ field: { contains: searchTerm } }` silently neutralised column filters.
+    // With an empty search the `contains: ''` clauses match every row and the
+    // OR operator makes the whole filter trivially true regardless of column
+    // filters. Customers, countries and promotions were affected; the fix adds
+    // a `searchTerm ?` guard on each page plus a framework safety net in
+    // `PaginatedListDataTable` that discards the search-term filter when the
+    // term is empty.
+    test('should apply a column filter on customers list when the search box is empty', async ({ page }) => {
+        const lp = new BaseListPage(page, {
+            path: '/customers',
+            title: 'Customers',
+            newButtonLabel: 'New Customer',
+        });
+        await lp.goto();
+        await lp.expectLoaded();
+
+        const initialCount = await lp.getRows().count();
+        expect(initialCount).toBeGreaterThan(0);
+
+        // Open the column filter menu and pick the "Email address" column
+        await lp.openAddFilterMenu();
+        const dropdown = page.locator('[data-slot="dropdown-menu-content"]');
+        await expect(dropdown).toBeVisible();
+        await dropdown.getByRole('menuitem', { name: /email address/i }).click();
+
+        // Filter dialog opens. The default operator is "contains" — enter a
+        // value that no customer in the e2e seed (5 randomly-generated
+        // customers) should match.
+        const dialog = page.locator('[role="dialog"]');
+        await expect(dialog).toBeVisible();
+        await dialog.getByPlaceholder('Enter filter value...').fill('OSS-536-NOMATCH-TOKEN');
+        await dialog.getByRole('button', { name: 'Apply filter' }).click();
+
+        // Wait for the refetch
+        await page.waitForResponse(resp => resp.url().includes('/admin-api') && resp.status() === 200);
+
+        // Before the fix this would still show `initialCount` rows because the
+        // empty-search `contains: ''` clauses (OR'd in via filterOperator)
+        // matched every row, ignoring the column filter entirely. After the
+        // fix the only row left is the "No results" empty-state row.
+        const filteredCount = await lp.getRows().count();
+        expect(filteredCount).toBeLessThan(initialCount);
+        await expect(page.getByText('No results', { exact: true })).toBeVisible();
+    });
+});

--- a/packages/dashboard/src/app/routes/_authenticated/_countries/countries.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_countries/countries.tsx
@@ -26,14 +26,12 @@ function CountryListPage() {
                 enabled: true,
             }}
             onSearchTermChange={searchTerm => {
-                return {
-                    name: {
-                        contains: searchTerm,
-                    },
-                    code: {
-                        contains: searchTerm,
-                    },
-                };
+                return searchTerm
+                    ? {
+                          name: { contains: searchTerm },
+                          code: { contains: searchTerm },
+                      }
+                    : {};
             }}
             transformVariables={variables => {
                 return {

--- a/packages/dashboard/src/app/routes/_authenticated/_customers/customers.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customers/customers.tsx
@@ -22,17 +22,13 @@ function CustomerListPage() {
             pageId="customer-list"
             listQuery={customerListDocument}
             onSearchTermChange={searchTerm => {
-                return {
-                    lastName: {
-                        contains: searchTerm,
-                    },
-                    emailAddress: {
-                        contains: searchTerm,
-                    },
-                    phoneNumber: {
-                        contains: searchTerm,
-                    },
-                };
+                return searchTerm
+                    ? {
+                          lastName: { contains: searchTerm },
+                          emailAddress: { contains: searchTerm },
+                          phoneNumber: { contains: searchTerm },
+                      }
+                    : {};
             }}
             transformVariables={variables => {
                 return {

--- a/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_promotions/promotions.tsx
@@ -36,10 +36,12 @@ function PromotionListPage() {
                 endsAt: true,
             }}
             onSearchTermChange={searchTerm => {
-                return {
-                    name: { contains: searchTerm },
-                    couponCode: { contains: searchTerm },
-                };
+                return searchTerm
+                    ? {
+                          name: { contains: searchTerm },
+                          couponCode: { contains: searchTerm },
+                      }
+                    : {};
             }}
             transformVariables={variables => {
                 return {

--- a/packages/dashboard/src/lib/components/shared/paginated-list-data-table.tsx
+++ b/packages/dashboard/src/lib/components/shared/paginated-list-data-table.tsx
@@ -187,6 +187,16 @@ export interface PaginatedListDataTableProps<
     additionalColumns?: AC;
     defaultColumnOrder?: (keyof ListQueryFields<T> | keyof AC | CustomFieldKeysOfItem<ListQueryFields<T>>)[];
     defaultVisibility?: Partial<Record<AllItemFieldKeys<T>, boolean>>;
+    /**
+     * @description
+     * Called whenever the debounced search term changes (including when it
+     * becomes empty). Return a partial filter to merge with the column /
+     * faceted filters. The returned filter is only applied when the term is
+     * non-empty — when the term is `''`, the returned value is discarded so
+     * that callers can write `{ field: { contains: searchTerm } }` without
+     * producing tautological `contains: ''` clauses. The callback itself is
+     * still invoked on every change so pages can use it as a state-sync hook.
+     */
     onSearchTermChange?: (searchTerm: string) => NonNullable<V['options']>['filter'];
     page: number;
     itemsPerPage: number;
@@ -452,7 +462,15 @@ export function PaginatedListDataTable<
 
     const { data, isFetching } = useQuery({
         queryFn: () => {
-            const searchFilter = onSearchTermChange ? onSearchTermChange(debouncedSearchTerm) : {};
+            // Always invoke onSearchTermChange so callers can use it as a
+            // state-sync hook (e.g. collections.tsx gates drag-and-drop on the
+            // current search term). Discard its filter contribution when the
+            // term is empty — otherwise pages built around
+            // `contains: searchTerm` produce `contains: ''` clauses that match
+            // everything, and combined with `filterOperator: 'OR'` they
+            // silently disable all column filters.
+            const rawSearchFilter = onSearchTermChange ? onSearchTermChange(debouncedSearchTerm) : {};
+            const searchFilter = debouncedSearchTerm ? rawSearchFilter : {};
             const mergedFilter = { ...filter, ...searchFilter };
             const variables = {
                 options: {


### PR DESCRIPTION
## Summary

Reported as customers-only but the same bug pattern silently disables column filters on three list pages: **customers**, **countries** and **promotions**.

### Root cause

Six list pages (administrators, countries, customers, product-variants, products, promotions) override `filterOperator: 'OR'` via `transformVariables` so that the search term can OR across multiple fields (e.g. `lastName`, `emailAddress`, `phoneNumber` for customers). The three "broken" pages above return `{ field: { contains: searchTerm } }` unconditionally from `onSearchTermChange`. When the search box is empty:

1. `debouncedSearchTerm` is `''`
2. `onSearchTermChange('')` returns `{ lastName: { contains: '' }, emailAddress: { contains: '' }, phoneNumber: { contains: '' } }`
3. `{ contains: '' }` matches every row
4. `filterOperator: 'OR'` makes the entire filter trivially true regardless of column filters
5. → applying a column filter on `id` (or any custom field) appears to do nothing

The three other multi-field-search pages (products, administrators, product-variants) already guard `onSearchTermChange` with `searchTerm ? { ... } : {}`.

### Fix

- **Page-level**: add the `searchTerm ?` guard on customers, countries, promotions, matching the existing pattern.
- **Framework-level**: `PaginatedListDataTable` now discards the `onSearchTermChange` filter contribution when the debounced term is empty, while still invoking the callback so pages that rely on it as a state-sync hook (notably `collections.tsx`, which gates drag-and-drop on the current search term) keep working. JSDoc on the prop documents the new contract.

### Follow-up worth filing

Migrate multi-field search pages from `filterOperator: 'OR'` to an explicit `_or: [...]` shape inside the filter — the way `orders.tsx` already does it:

```ts
onSearchTermChange={t => ({
    _or: [
        { code: { contains: t } },
        { customerLastName: { contains: t } },
        ...
    ],
})}
```

That removes the global OR override (which also OR's column / faceted filters with the search clauses — a subtle precision bug that survives this PR) and removes the need for the framework guard entirely.

## Test plan

- [x] `bunx tsc --noEmit` on `packages/dashboard` — no new errors introduced
- [x] `bunx prettier --check` on all four files — clean
- [x] Pre-commit hooks (lint, `check-lib-imports.js`, format) pass
- [x] Reviewed by Nigel + vendurebot before commit; addressed BLOCKER on `collections.tsx` drag-and-drop state-sync (framework guard now preserves the callback invocation, only discards the filter contribution)
- [ ] Manual smoke test: apply a column filter on `/customers`, `/countries`, `/promotions` with an empty search box — list should now respect the filter
- [ ] Manual regression smoke test: `/collections` drag-and-drop still toggles correctly when typing into and then clearing the search box

Fixes #4730

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4746"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->