### PR TITLE
fix(dashboard): Make AlertsProvider react to extensions registered after mount

### DIFF
--- a/packages/dashboard/e2e/fixtures/alert-test-dashboard/index.tsx
+++ b/packages/dashboard/e2e/fixtures/alert-test-dashboard/index.tsx
@@ -1,0 +1,23 @@
+import { defineDashboardExtension } from '@vendure/dashboard';
+
+// #4729 — separate plugin registering ONLY alerts.
+//
+// Reproducing the original bug requires two plugins each calling
+// `defineDashboardExtension` independently — when alerts live in their own
+// plugin and another plugin (`FormInputsTestPlugin`) also registers
+// extensions, the original `AlertsProvider` would snapshot an empty registry
+// and never poll. See vendurehq/vendure#4729.
+defineDashboardExtension({
+    alerts: [
+        {
+            id: 'oss-535-test-alert',
+            title: 'OSS-535 regression alert',
+            severity: 'info',
+            check: () => 1,
+            // `shouldShow` is invoked with `undefined` on the initial render
+            // before `check()` resolves, so guard the access — matches the
+            // shape used by the built-in `searchIndexBufferAlert`.
+            shouldShow: data => (data ?? 0) > 0,
+        },
+    ],
+});

--- a/packages/dashboard/e2e/fixtures/alert-test-plugin.ts
+++ b/packages/dashboard/e2e/fixtures/alert-test-plugin.ts
@@ -1,0 +1,14 @@
+import { VendurePlugin } from '@vendure/core';
+
+/**
+ * E2E-only plugin that registers a dashboard alert through a SEPARATE
+ * `defineDashboardExtension` call from {@link FormInputsTestPlugin}. The
+ * combination of two plugins each contributing extensions is the trigger for
+ * #4729 — see `alert-test-dashboard/index.tsx` for the alert definition and
+ * `tests/regression/issue-4729-alerts-do-not-poll-multi-plugin.spec.ts` for
+ * the regression test.
+ */
+@VendurePlugin({
+    dashboard: './alert-test-dashboard/index.tsx',
+})
+export class AlertTestPlugin {}

--- a/packages/dashboard/e2e/fixtures/e2e-vendure-config.ts
+++ b/packages/dashboard/e2e/fixtures/e2e-vendure-config.ts
@@ -1,5 +1,6 @@
 import { VendureConfig } from '@vendure/core';
 
+import { AlertTestPlugin } from './alert-test-plugin';
 import { FormInputsTestPlugin } from './form-inputs-test-plugin';
 
 /**
@@ -29,5 +30,5 @@ export const config: VendureConfig = {
     paymentOptions: {
         paymentMethodHandlers: [],
     },
-    plugins: [FormInputsTestPlugin],
+    plugins: [FormInputsTestPlugin, AlertTestPlugin],
 };

--- a/packages/dashboard/e2e/tests/regression/issue-4729-alerts-do-not-poll-multi-plugin.spec.ts
+++ b/packages/dashboard/e2e/tests/regression/issue-4729-alerts-do-not-poll-multi-plugin.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from '@playwright/test';
+
+// #4729 — When two or more plugins each call `defineDashboardExtension`, the
+// alert polling never started. Root cause was `AlertsProvider` snapshotting
+// `getAlertRegistry()` in its mount effect — but React fires child effects
+// before parent effects, and the extension registration callbacks are queued
+// during render and only executed inside `App`'s post-mount effect. The
+// snapshot was therefore always empty, `alertDefs` stayed `[]` forever, and
+// `useQueries` never built any observers.
+//
+// The fixtures wire two separate plugins through the Vite config:
+//   - FormInputsTestPlugin     — contributes routes
+//   - AlertTestPlugin          — contributes a single always-on alert
+//
+// If the bug regresses, the alert bell button never renders (the `Alerts`
+// component short-circuits to `null` when `alerts.length === 0`).
+test.describe('Issue 4729 — dashboard alerts with multiple extension plugins', () => {
+    test('should render the alert bell with an active count when alerts come from a separate plugin', async ({
+        page,
+    }) => {
+        // initialDelayMs in alerts-provider.tsx is 5_000 — give the alert
+        // enough time to poll once and become active.
+        test.setTimeout(30_000);
+
+        await page.goto('/');
+
+        // The alert bell only renders if `useAlerts` returned a non-empty
+        // `alerts` array, i.e. the registry was actually picked up. Locate it
+        // by the BellIcon's lucide class name (the button itself has no
+        // accessible name).
+        const bellIcon = page.locator('button:has(svg.lucide-bell)');
+        await expect(bellIcon).toBeVisible({ timeout: 15_000 });
+
+        // The active-count badge appears once the alert's `check()` has
+        // resolved and `shouldShow(data)` returned true (`{ active: true }`
+        // in the fixture).
+        await expect(bellIcon.locator('text=1')).toBeVisible({ timeout: 15_000 });
+    });
+});

--- a/packages/dashboard/src/lib/providers/alerts-provider.tsx
+++ b/packages/dashboard/src/lib/providers/alerts-provider.tsx
@@ -1,4 +1,5 @@
 import { getAlertRegistry } from '@/vdb/framework/alert/alert-extensions.js';
+import { onExtensionSourceChange } from '@/vdb/framework/extension-api/define-dashboard-extension.js';
 import { DashboardAlertDefinition } from '@/vdb/framework/extension-api/types/alerts.js';
 import { useQueries, UseQueryOptions } from '@tanstack/react-query';
 import { createContext, ReactNode, useEffect, useState } from 'react';
@@ -15,12 +16,17 @@ export const AlertsContext = createContext<AlertsContextValue | undefined>(undef
 
 export function AlertsProvider({ children }: { children: ReactNode }) {
     const initialDelayMs = 5_000;
-    const [alertDefs, setAlertDefs] = useState<DashboardAlertDefinition[]>([]);
+    // Seed from the registry synchronously and resubscribe — extensions register
+    // their alerts during `App`'s post-mount effect (after this provider's own
+    // mount effect runs), so we'd otherwise snapshot an empty registry.
+    const [alertDefs, setAlertDefs] = useState<DashboardAlertDefinition[]>(() =>
+        Array.from(getAlertRegistry().values()),
+    );
     const [enabledQueries, setEnabledQueries] = useState(false);
     const [dismissedAlerts, setDismissedAlerts] = useState<Map<string, number>>(new Map());
 
     useEffect(() => {
-        setAlertDefs(Array.from(getAlertRegistry().values()));
+        onExtensionSourceChange(() => setAlertDefs(Array.from(getAlertRegistry().values())));
     }, []);
 
     useEffect(() => {


### PR DESCRIPTION
## Summary

When two or more plugins each call `defineDashboardExtension`, alerts defined in one plugin never started polling — `check` and `shouldShow` were silently skipped. Workaround was to consolidate every extension into a single \"hub\" plugin, which defeats the point of the extension system.

## Root cause

The boot sequence has a tight effect-ordering race:

1. `App` (`packages/dashboard/src/app/main.tsx:98`) uses `useDashboardExtensions()` which awaits every plugin's extension entry module. Each module's `defineDashboardExtension(...)` call **queues** a callback into the global `registerDashboardExtensionCallbacks` set — it does not register the alerts immediately.
2. When the dynamic imports resolve, `extensionsLoaded` flips true and `<AppProviders>` mounts, including `<AlertsProvider>`.
3. React fires child effects before parent effects, so `AlertsProvider`'s mount effect ran `setAlertDefs(Array.from(getAlertRegistry().values()))` **before** `App`'s `useEffect([extensionsLoaded])` had a chance to call `executeDashboardExtensionCallbacks()`. The alert registry was still empty at that point, so `alertDefs` state stayed permanently `[]` and `useQueries` never built any observers.

The bug only manifests when 2+ plugins each call `defineDashboardExtension` because in the single-plugin case React StrictMode's double-invocation of `useEffect` in dev (or natural re-renders triggered by `useDashboardExtensions`'s own `setReloadCount`) gave the snapshot a second chance — but it's never been guaranteed correct.

## Fix

Mirror the existing pattern in `useLoginExtensions` (`packages/dashboard/src/lib/framework/extension-api/use-login-extensions.ts`):

- Seed the state synchronously from the registry via a lazy `useState` initializer (covers the case where extensions were registered before this provider mounted).
- Subscribe to `onExtensionSourceChange` so later registrations propagate into state.

`useQueries` rebuilds its observer list when `alertDefs` changes, so polling starts as soon as the alert is registered.

## Scope check

Only `AlertsProvider` was affected. Every other extension consumer either:
- Reads the registry lazily at render time (`ToolbarItems` in `app-layout.tsx:81`, `GeneratedBreadcrumbs`, `nav-main`, form components, ...) and naturally picks up changes via re-renders triggered by `useDashboardExtensions`'s `setReloadCount`.
- Is gated behind `extensionsLoaded` upstream of the registration phase (the dashboard widgets route at `_authenticated/index.tsx`).

## Follow-ups (out of scope)

- `onExtensionSourceChange` has no unregister API; the callback set grows monotonically. All three subscribers (`AlertsProvider`, `useLoginExtensions`, `useDashboardExtensions`) leak under StrictMode and HMR. Worth a small refactor that returns an unsubscribe fn and updates all call sites.
- The registration-vs-mount ordering is an undocumented invariant that has now bitten the extension system twice (`useLoginExtensions` solved it, now `AlertsProvider`). Worth a short JSDoc paragraph on `onExtensionSourceChange` documenting it.

## Test plan

- [x] `bunx tsc --noEmit` on `packages/dashboard` — no new errors
- [x] `bunx prettier --check` — clean
- [x] Pre-commit hooks (lint, `check-lib-imports.js`, format) pass
- [x] Reviewed by Nigel + vendurebot before commit
- [ ] Manual smoke: build two plugins, one with `alerts: [...]`, one with `customFormComponents: {...}`, confirm the alert polls and renders

Fixes #4729

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4747"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->