### PR TITLE
# fix(dashboard): stop keydown propagation in facet values dialog to prevent DropdownMenu focus steal

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx
@@ -150,7 +150,10 @@ export function AssignFacetValuesDialog({
 
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
-            <DialogContent className="sm:max-w-[800px] max-h-[80vh] overflow-hidden flex flex-col">
+            <DialogContent
+                className="sm:max-w-[800px] max-h-[80vh] overflow-hidden flex flex-col"
+                onKeyDown={event => event.stopPropagation()}
+            >
                 <DialogHeader>
                     <DialogTitle>
                         <Trans>Edit facet values</Trans>


### PR DESCRIPTION

# Description

Fixes #4749

The search input in the "Edit facet values" bulk action dialog could not receive keyboard input. Clicking the input showed a cursor momentarily, but it was immediately stolen away — making it impossible to type. The "Browse facets" button (click-based) worked fine.

**Root cause:** The `AssignFacetValuesDialog` component is rendered inside `DropdownMenuContent` (via `action.component` in `data-table-bulk-actions.tsx`). The DropdownMenu uses Base UI's `Menu`, which wraps its popup in a `FloatingFocusManager` with `restoreFocus: true`. When the user types in the dialog's search input, `keydown` events bubble up from the input through the Dialog to the DropdownMenu. The menu's focus manager intercepts these events and pulls focus back to the menu, making the input unusable.

**Fix:** Added `onKeyDown={event => event.stopPropagation()}` on `DialogContent` to prevent keyboard events from bubbling out of the dialog to the parent DropdownMenu. The dialog's own keyboard handling (Escape, Tab) still works since Base UI handles those via listeners attached directly to the dialog element.

**What I tried that didn't work:**
- `modal={false}` on the Dialog — Dialog's focus trap wasn't the issue
- `modal={false}` on the DropdownMenu — Menu's `FloatingFocusManager` uses `restoreFocus: true` regardless of `modal`
- Removing `FacetValueSelector` and using a raw `<Command>` + `<CommandInput>` — still can't type ( was just to debug)
- Using a plain `<input type="text">` in the dialog — still can't type (proved cmdk/FacetValueSelector were not the issue) ( added just to debug)
- Making `CommandInput` uncontrolled (removing `value` prop) — didn't help
- `inline` prop to skip Popover wrapper — didn't help


`stopPropagation` on the DialogContent is the most surgical fix ig — one line, zero blast radius, doesn't touch any shared components.

# Breaking changes

None.

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4750"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->