### PR TITLE
fix(dashboard): normalize glob patterns to forward slashes on Windows

### DIFF
--- a/packages/dashboard/vite/vite-plugin-translations.ts
+++ b/packages/dashboard/vite/vite-plugin-translations.ts
@@ -146,7 +146,7 @@ async function getPluginTranslations(pluginInfo: PluginInfo[]): Promise<PluginTr
     const dashboardPaths = getDashboardPaths(pluginInfo);
     const pluginTranslations: PluginTranslation[] = [];
     for (const dashboardPath of dashboardPaths) {
-        const poPatterns = path.join(dashboardPath, '**/*.po');
+        const poPatterns = path.join(dashboardPath, '**/*.po').replace(/\\/g, '/');
         const translations = await glob(poPatterns, {
             ignore: [
                 // Skip nested node_modules (transitive deps) but not .pnpm or .bun directories.


### PR DESCRIPTION
# Description

`fast-glob` does not support Windows backslash path separators. On Windows, `path.join()` produces backslash-separated paths (e.g. `foo\bar\**\*.po`), which causes the glob in `getPluginTranslations()` to match nothing, silently skipping all plugin `.po` files.

The fix normalizes all glob patterns to forward slashes before passing them to `fast-glob`, following the same pattern already established in [plugin-discovery.ts#L450](https://github.com/vendurehq/vendure/blob/master/packages/dashboard/vite/utils/plugin-discovery.ts#L450).

# Breaking changes

No breaking changes

# Screenshots

Not applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4751"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->