### PR TITLE
fix(dashboard): Resolve logout stuck in verifying state on failure

### DIFF
--- a/packages/dashboard/src/lib/providers/auth.tsx
+++ b/packages/dashboard/src/lib/providers/auth.tsx
@@ -135,6 +135,9 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
         }
     }, [settings.activeChannelId, currentUserData?.me?.channels]);
 
+    // Determine isAuthenticated from currentUserData
+    const isAuthenticated = !!currentUserData?.me?.id;
+
     // Auth actions
     const login = React.useCallback(
         (username: string, password: string, onLoginSuccess?: () => void) => {
@@ -189,23 +192,33 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
         async (onLogoutSuccess?: () => void) => {
             setIsLoginLogoutInProgress(true);
             setStatus('verifying');
-            api.mutate(LogOutMutation)({}).then(async data => {
-                if (data?.logout.success) {
-                    // Clear all cached queries to prevent stale data
-                    queryClient.clear();
-                    // Clear selected channel from localStorage
-                    localStorage.removeItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
-                    setStatus('unauthenticated');
+            api.mutate(LogOutMutation)({})
+                .then(async data => {
+                    if (data?.logout.success) {
+                        // Clear all cached queries to prevent stale data
+                        queryClient.clear();
+                        // Clear selected channel from localStorage
+                        localStorage.removeItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
+                        setStatus('unauthenticated');
+                        setIsLoginLogoutInProgress(false);
+                        onLogoutSuccess?.();
+                    } else {
+                        // Server responded but reported success=false. Restore the
+                        // pre-logout authenticated status so the UI is interactive again.
+                        setStatus(isAuthenticated ? 'authenticated' : 'unauthenticated');
+                        setIsLoginLogoutInProgress(false);
+                    }
+                })
+                .catch(error => {
+                    // Network/server failure. Match login()'s rejection handler:
+                    // surface the message and unblock the UI so the user can retry.
+                    setAuthenticationError(error?.message);
+                    setStatus(isAuthenticated ? 'authenticated' : 'unauthenticated');
                     setIsLoginLogoutInProgress(false);
-                    onLogoutSuccess?.();
-                }
-            });
+                });
         },
-        [queryClient],
+        [queryClient, isAuthenticated],
     );
-
-    // Determine isAuthenticated from currentUserData
-    const isAuthenticated = !!currentUserData?.me?.id;
 
     // Handle status transitions based on query state
     React.useEffect(() => {

--- a/packages/dashboard/src/lib/providers/auth.tsx
+++ b/packages/dashboard/src/lib/providers/auth.tsx
@@ -190,6 +190,11 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
 
     const logout = React.useCallback(
         async (onLogoutSuccess?: () => void) => {
+            // Clear any stale error from a previous logout attempt. Matches the
+            // login() pattern (line 149 below clears it on the success path)
+            // and ensures UI doesn't keep rendering a previous failure's
+            // message during a retry.
+            setAuthenticationError(undefined);
             setIsLoginLogoutInProgress(true);
             setStatus('verifying');
             // Try block scoped to the mutation call only. Exceptions thrown

--- a/packages/dashboard/src/lib/providers/auth.tsx
+++ b/packages/dashboard/src/lib/providers/auth.tsx
@@ -219,8 +219,15 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
             if (data?.logout.success) {
                 // Clear all cached queries to prevent stale data
                 queryClient.clear();
-                // Clear selected channel from localStorage
-                localStorage.removeItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
+                try {
+                    // localStorage can throw (quota exceeded, Safari private
+                    // mode, security errors, storage disabled). The server-side
+                    // logout already succeeded — don't let storage cleanup
+                    // failure block the UI state transition below.
+                    localStorage.removeItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
+                } catch {
+                    // intentionally swallowed — see comment above
+                }
                 setStatus('unauthenticated');
                 setIsLoginLogoutInProgress(false);
                 onLogoutSuccess?.();

--- a/packages/dashboard/src/lib/providers/auth.tsx
+++ b/packages/dashboard/src/lib/providers/auth.tsx
@@ -192,22 +192,13 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
         async (onLogoutSuccess?: () => void) => {
             setIsLoginLogoutInProgress(true);
             setStatus('verifying');
+            // Try block scoped to the mutation call only. Exceptions thrown
+            // by the success-branch side-effects below (queryClient.clear,
+            // localStorage.removeItem, onLogoutSuccess) propagate naturally
+            // rather than being misclassified as transport failures.
+            let data;
             try {
-                const data = await api.mutate(LogOutMutation)({});
-                if (data?.logout.success) {
-                    // Clear all cached queries to prevent stale data
-                    queryClient.clear();
-                    // Clear selected channel from localStorage
-                    localStorage.removeItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
-                    setStatus('unauthenticated');
-                    setIsLoginLogoutInProgress(false);
-                    onLogoutSuccess?.();
-                } else {
-                    // Server responded but reported success=false. Restore the
-                    // pre-logout authenticated status so the UI is interactive again.
-                    setStatus(isAuthenticated ? 'authenticated' : 'unauthenticated');
-                    setIsLoginLogoutInProgress(false);
-                }
+                data = await api.mutate(LogOutMutation)({});
             } catch (error) {
                 // Network/server failure. Transport failure doesn't tell us
                 // whether the server applied the logout, so refetch the
@@ -221,6 +212,22 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
                 } else {
                     setStatus('authenticated');
                 }
+                setIsLoginLogoutInProgress(false);
+                return;
+            }
+
+            if (data?.logout.success) {
+                // Clear all cached queries to prevent stale data
+                queryClient.clear();
+                // Clear selected channel from localStorage
+                localStorage.removeItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
+                setStatus('unauthenticated');
+                setIsLoginLogoutInProgress(false);
+                onLogoutSuccess?.();
+            } else {
+                // Server responded but reported success=false. Restore the
+                // pre-logout authenticated status so the UI is interactive again.
+                setStatus(isAuthenticated ? 'authenticated' : 'unauthenticated');
                 setIsLoginLogoutInProgress(false);
             }
         },

--- a/packages/dashboard/src/lib/providers/auth.tsx
+++ b/packages/dashboard/src/lib/providers/auth.tsx
@@ -192,39 +192,37 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
         async (onLogoutSuccess?: () => void) => {
             setIsLoginLogoutInProgress(true);
             setStatus('verifying');
-            await api.mutate(LogOutMutation)({})
-                .then(async data => {
-                    if (data?.logout.success) {
-                        // Clear all cached queries to prevent stale data
-                        queryClient.clear();
-                        // Clear selected channel from localStorage
-                        localStorage.removeItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
-                        setStatus('unauthenticated');
-                        setIsLoginLogoutInProgress(false);
-                        onLogoutSuccess?.();
-                    } else {
-                        // Server responded but reported success=false. Restore the
-                        // pre-logout authenticated status so the UI is interactive again.
-                        setStatus(isAuthenticated ? 'authenticated' : 'unauthenticated');
-                        setIsLoginLogoutInProgress(false);
-                    }
-                })
-                .catch(async error => {
-                    // Network/server failure. Transport failure doesn't tell us
-                    // whether the server applied the logout, so refetch the
-                    // current user to determine actual state rather than trusting
-                    // the cached isAuthenticated snapshot (staleTime: Infinity
-                    // means react-query won't auto-refetch this query).
-                    setAuthenticationError(error?.message);
-                    const { data: refreshedData, error: refreshedError } =
-                        await refetchCurrentUser();
-                    if (refreshedError || !refreshedData?.me?.id) {
-                        setStatus('unauthenticated');
-                    } else {
-                        setStatus('authenticated');
-                    }
+            try {
+                const data = await api.mutate(LogOutMutation)({});
+                if (data?.logout.success) {
+                    // Clear all cached queries to prevent stale data
+                    queryClient.clear();
+                    // Clear selected channel from localStorage
+                    localStorage.removeItem(LS_KEY_SELECTED_CHANNEL_TOKEN);
+                    setStatus('unauthenticated');
                     setIsLoginLogoutInProgress(false);
-                });
+                    onLogoutSuccess?.();
+                } else {
+                    // Server responded but reported success=false. Restore the
+                    // pre-logout authenticated status so the UI is interactive again.
+                    setStatus(isAuthenticated ? 'authenticated' : 'unauthenticated');
+                    setIsLoginLogoutInProgress(false);
+                }
+            } catch (error) {
+                // Network/server failure. Transport failure doesn't tell us
+                // whether the server applied the logout, so refetch the
+                // current user to determine actual state rather than trusting
+                // the cached isAuthenticated snapshot (staleTime: Infinity
+                // means react-query won't auto-refetch this query).
+                setAuthenticationError(error instanceof Error ? error.message : String(error));
+                const { data: refreshedData, error: refreshedError } = await refetchCurrentUser();
+                if (refreshedError || !refreshedData?.me?.id) {
+                    setStatus('unauthenticated');
+                } else {
+                    setStatus('authenticated');
+                }
+                setIsLoginLogoutInProgress(false);
+            }
         },
         [queryClient, isAuthenticated, refetchCurrentUser],
     );

--- a/packages/dashboard/src/lib/providers/auth.tsx
+++ b/packages/dashboard/src/lib/providers/auth.tsx
@@ -192,7 +192,7 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
         async (onLogoutSuccess?: () => void) => {
             setIsLoginLogoutInProgress(true);
             setStatus('verifying');
-            api.mutate(LogOutMutation)({})
+            await api.mutate(LogOutMutation)({})
                 .then(async data => {
                     if (data?.logout.success) {
                         // Clear all cached queries to prevent stale data
@@ -209,15 +209,24 @@ export function AuthProvider({ children }: Readonly<{ children: React.ReactNode 
                         setIsLoginLogoutInProgress(false);
                     }
                 })
-                .catch(error => {
-                    // Network/server failure. Match login()'s rejection handler:
-                    // surface the message and unblock the UI so the user can retry.
+                .catch(async error => {
+                    // Network/server failure. Transport failure doesn't tell us
+                    // whether the server applied the logout, so refetch the
+                    // current user to determine actual state rather than trusting
+                    // the cached isAuthenticated snapshot (staleTime: Infinity
+                    // means react-query won't auto-refetch this query).
                     setAuthenticationError(error?.message);
-                    setStatus(isAuthenticated ? 'authenticated' : 'unauthenticated');
+                    const { data: refreshedData, error: refreshedError } =
+                        await refetchCurrentUser();
+                    if (refreshedError || !refreshedData?.me?.id) {
+                        setStatus('unauthenticated');
+                    } else {
+                        setStatus('authenticated');
+                    }
                     setIsLoginLogoutInProgress(false);
                 });
         },
-        [queryClient, isAuthenticated],
+        [queryClient, isAuthenticated, refetchCurrentUser],
     );
 
     // Handle status transitions based on query state


### PR DESCRIPTION
# Description

Fixes #4735.

`AuthProvider.logout` in `packages/dashboard/src/lib/providers/auth.tsx` previously called `api.mutate(LogOutMutation)({}).then(...)` with no `.catch()` and no `else` branch for `data.logout.success === false`. On any failure path, `isLoginLogoutInProgress` stayed `true` and `status` stayed `'verifying'` forever — the status-transition `useEffect` early-returns while `isLoginLogoutInProgress` is true, so the UI cannot self-recover. The user sees a permanent verifying spinner; only a hard reload restores a usable state.

The fix mirrors the existing `login` callback's three-path handling in the same file (success → terminal status, server-reported failure → terminal status, promise rejection → terminal status with `authenticationError` set). Adds a `.catch()`, an `else` branch, and hoists the `isAuthenticated` declaration above the auth callbacks so it can be added to the `useCallback` dependency array — used to choose between `'authenticated'` and `'unauthenticated'` as the terminal fallback so we never demote a still-valid session if the logout request itself failed at the network layer.

### Reproduction (manual)

1. Log in to the admin dashboard.
2. Open DevTools → Network → set the request filter to block POST to `/admin-api` (or stop the Vendure server).
3. Click "Logout" from the user menu.
4. Observe: the UI shows the "verifying" state indefinitely. Logging in does nothing. Only `Cmd-R` recovers.

After this fix, step 4 surfaces the network error via `authenticationError` and the UI returns to an interactive state.

### Why no automated test in this PR

`packages/dashboard` does not currently have hook-test infrastructure — `@testing-library/react` is not in `devDependencies`, the only existing tests are pure-function unit tests (`use-page-title.test.ts`) and SSR-string assertions (`page-layout.spec.tsx`). Per the discussion on #4735, adding `@testing-library/react` infra for a single fix would be scope creep; happy to follow up with a separate PR that adds the hook-test setup, as suggested in the triage reply. The fix itself is structurally a mirror of the `login` callback's already-exercised three-path handling.

# Breaking changes

No. Public API of `useAuth` is unchanged. The terminal-state behavior on failure is strictly additive — previously the UI got stuck, now it transitions cleanly. No consumer relies on the stuck state.

# Screenshots

N/A — internal behavior fix; no visual change on the happy path. The failure-path behavior (DevTools-throttled-to-offline reproduction) is in the Description above.

# Checklist

Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

Most of the time:
- [ ] I have added or updated test cases — see "Why no automated test in this PR" above; agreed with @grolmus on #4735 that this is scope-appropriate.
- [x] I have updated the README if needed (no README change needed — internal behavior fix)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4757"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->