### PR TITLE
fix(admin-ui): Seed channel token before config fetch

### DIFF
--- a/packages/admin-ui/src/lib/core/src/data/server-config.spec.ts
+++ b/packages/admin-ui/src/lib/core/src/data/server-config.spec.ts
@@ -1,0 +1,96 @@
+import { Injector } from '@angular/core';
+import { DEFAULT_CHANNEL_CODE } from '@vendure/common/lib/shared-constants';
+import { of, throwError } from 'rxjs';
+
+import { LocalStorageService } from '../providers/local-storage/local-storage.service';
+
+import { GET_CURRENT_USER } from './definitions/auth-definitions';
+import { GET_SERVER_CONFIG } from './definitions/settings-definitions';
+import { BaseDataService } from './providers/base-data.service';
+import { ServerConfigService } from './server-config';
+
+describe('ServerConfigService', () => {
+    const serverConfigResult = {
+        globalSettings: {
+            serverConfig: {
+                entityCustomFields: [],
+            },
+        },
+    };
+
+    function createService(
+        query: jasmine.Spy,
+        storedValues: Record<string, any> = {},
+    ): {
+        service: ServerConfigService;
+        localStorageService: jasmine.SpyObj<LocalStorageService>;
+    } {
+        const localStorageService = jasmine.createSpyObj<LocalStorageService>('LocalStorageService', [
+            'get',
+            'set',
+        ]);
+        localStorageService.get.and.callFake((key: string) => storedValues[key] ?? null);
+        localStorageService.set.and.callFake((key: string, value: any) => {
+            storedValues[key] = value;
+        });
+
+        const injector = jasmine.createSpyObj<Injector>('Injector', ['get']);
+        injector.get.withArgs(BaseDataService).and.returnValue({ query });
+
+        return {
+            service: new ServerConfigService(injector, localStorageService),
+            localStorageService,
+        };
+    }
+
+    it('sets the active channel token before fetching the server config', async () => {
+        const query = jasmine.createSpy('query').and.callFake(document => {
+            if (document === GET_CURRENT_USER) {
+                return {
+                    single$: of({
+                        me: {
+                            channels: [
+                                { code: 'secondary', token: 'secondary-token' },
+                                { code: DEFAULT_CHANNEL_CODE, token: 'default-token' },
+                            ],
+                        },
+                    }),
+                };
+            }
+            if (document === GET_SERVER_CONFIG) {
+                return { single$: of(serverConfigResult) };
+            }
+        });
+        const { service, localStorageService } = createService(query);
+
+        await service.getServerConfig();
+
+        expect(query.calls.allArgs().map(args => args[0])).toEqual([GET_CURRENT_USER, GET_SERVER_CONFIG]);
+        expect(localStorageService.set).toHaveBeenCalledWith('activeChannelToken', 'default-token');
+    });
+
+    it('does not fetch the current user when an active channel token already exists', async () => {
+        const query = jasmine.createSpy('query').and.returnValue({ single$: of(serverConfigResult) });
+        const { service } = createService(query, { activeChannelToken: 'stored-token' });
+
+        await service.getServerConfig();
+
+        expect(query.calls.allArgs().map(args => args[0])).toEqual([GET_SERVER_CONFIG]);
+    });
+
+    it('still fetches the server config when current user lookup fails', async () => {
+        const query = jasmine.createSpy('query').and.callFake(document => {
+            if (document === GET_CURRENT_USER) {
+                return { single$: throwError(() => new Error('Not authenticated')) };
+            }
+            if (document === GET_SERVER_CONFIG) {
+                return { single$: of(serverConfigResult) };
+            }
+        });
+        const { service } = createService(query);
+
+        await service.getServerConfig();
+
+        expect(query.calls.allArgs().map(args => args[0])).toEqual([GET_CURRENT_USER, GET_SERVER_CONFIG]);
+    });
+});

--- a/packages/admin-ui/src/lib/core/src/data/server-config.ts
+++ b/packages/admin-ui/src/lib/core/src/data/server-config.ts
@@ -1,15 +1,20 @@
 import { Injectable, Injector } from '@angular/core';
+import { DEFAULT_CHANNEL_CODE } from '@vendure/common/lib/shared-constants';
 import { lastValueFrom } from 'rxjs';
 
 import {
+    CurrentUserFragment,
     CustomFieldConfig,
     CustomFields,
+    GetCurrentUserQuery,
     GetGlobalSettingsQuery,
     GetServerConfigQuery,
     OrderProcessState,
     PermissionDefinition,
 } from '../common/generated-types';
+import { LocalStorageService } from '../providers/local-storage/local-storage.service';
 
+import { GET_CURRENT_USER } from './definitions/auth-definitions';
 import { GET_GLOBAL_SETTINGS, GET_SERVER_CONFIG } from './definitions/settings-definitions';
 import { BaseDataService } from './providers/base-data.service';
 
@@ -29,7 +34,10 @@ export class ServerConfigService {
         return this.injector.get<BaseDataService>(BaseDataService);
     }
 
-    constructor(private injector: Injector) {}
+    constructor(
+        private injector: Injector,
+        private localStorageService: LocalStorageService,
+    ) {}
 
     /**
      * Fetches the ServerConfig. Should be run as part of the app bootstrap process by attaching
@@ -43,19 +51,53 @@ export class ServerConfigService {
      * Fetch the ServerConfig. Should be run on app init (in case user is already logged in) and on successful login.
      */
     getServerConfig() {
-        return lastValueFrom(
-            this.baseDataService.query<GetServerConfigQuery>(GET_SERVER_CONFIG).single$,
-        ).then(
-            result => {
-                this._serverConfig = result.globalSettings.serverConfig;
-                for (const entityCustomFields of this._serverConfig.entityCustomFields) {
-                    this.customFieldsMap.set(entityCustomFields.entityName, entityCustomFields.customFields);
+        return this.ensureActiveChannelToken().then(() =>
+            lastValueFrom(this.baseDataService.query<GetServerConfigQuery>(GET_SERVER_CONFIG).single$).then(
+                result => {
+                    this._serverConfig = result.globalSettings.serverConfig;
+                    for (const entityCustomFields of this._serverConfig.entityCustomFields) {
+                        this.customFieldsMap.set(
+                            entityCustomFields.entityName,
+                            entityCustomFields.customFields,
+                        );
+                    }
+                },
+                err => {
+                    // Let the error fall through to be caught by the http interceptor.
+                },
+            ),
+        );
+    }
+
+    private ensureActiveChannelToken(): Promise<void> {
+        if (this.localStorageService.get('activeChannelToken')) {
+            return Promise.resolve();
+        }
+        return lastValueFrom(this.baseDataService.query<GetCurrentUserQuery>(GET_CURRENT_USER).single$).then(
+            ({ me }) => {
+                if (me?.channels.length) {
+                    this.localStorageService.set(
+                        'activeChannelToken',
+                        this.getActiveChannel(me.channels).token,
+                    );
                 }
             },
-            err => {
-                // Let the error fall through to be caught by the http interceptor.
+            () => {
+                // Ignore unauthenticated app initialization; the main server config request handles errors.
             },
         );
+    }
+
+    private getActiveChannel(userChannels: CurrentUserFragment['channels']) {
+        const lastActiveChannelToken = this.localStorageService.get('activeChannelToken');
+        if (lastActiveChannelToken) {
+            const lastActiveChannel = userChannels.find(c => c.token === lastActiveChannelToken);
+            if (lastActiveChannel) {
+                return lastActiveChannel;
+            }
+        }
+        const defaultChannel = userChannels.find(c => c.code === DEFAULT_CHANNEL_CODE);
+        return defaultChannel || userChannels[0];
     }
 
     getAvailableLanguages() {


### PR DESCRIPTION
/claim #2363

## Summary

- seed the Admin UI active channel token from the current user before the server config request when it is missing
- preserve the existing active-channel choice behavior by preferring the stored token, then the default channel, then the first channel
- add focused ServerConfigService coverage for token seeding, existing-token behavior, and unauthenticated bootstrap fallback

## Why

External authentication can leave the Admin UI authenticated but without an `activeChannelToken` in local storage. Since the app waits for `ServerConfigService` during bootstrap, setting the channel token there ensures the initial Admin API requests include the channel token instead of requiring a page reload.

## Testing

- `npm run build` in `packages/common`
- `PUPPETEER_EXECUTABLE_PATH="/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" npm run test -- --include src/lib/core/src/data/server-config.spec.ts`

Fixes #2363

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4760"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781940062&installation_id=128408429&pr_number=4760&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4760&signature=87e6eaf81b5880aeeb03268b1d598e7337ba579e6f1a6fa4bc019ee1c1c20e54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->