### PR TITLE
feat(email-plugin): Move mjml to optional peer dependency

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -58,7 +58,7 @@
     },
     "packages/admin-ui": {
       "name": "@vendure/admin-ui",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "@angular/animations": "^19.2.4",
         "@angular/cdk": "^19.2.7",
@@ -148,7 +148,7 @@
     },
     "packages/admin-ui-plugin": {
       "name": "@vendure/admin-ui-plugin",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "date-fns": "^4.0.0",
         "express-rate-limit": "^7.5.0",
@@ -167,7 +167,7 @@
     },
     "packages/asset-server-plugin": {
       "name": "@vendure/asset-server-plugin",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "file-type": "^19.0.0",
         "fs-extra": "^11.2.0",
@@ -189,7 +189,7 @@
     },
     "packages/cli": {
       "name": "@vendure/cli",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "bin": {
         "vendure": "dist/cli.js",
       },
@@ -215,7 +215,7 @@
     },
     "packages/common": {
       "name": "@vendure/common",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "devDependencies": {
         "rimraf": "^5.0.5",
         "typescript": "5.8.2",
@@ -223,7 +223,7 @@
     },
     "packages/core": {
       "name": "@vendure/core",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "@apollo/server": "^4.12.2",
         "@graphql-tools/stitch": "^10.1.16",
@@ -234,7 +234,7 @@
         "@nestjs/platform-express": "^11.0.12",
         "@nestjs/terminus": "^11.0.0",
         "@nestjs/typeorm": "^11.0.0",
-        "@vendure/common": "3.6.2",
+        "@vendure/common": "3.6.3",
         "bcrypt": "^6.0.0",
         "body-parser": "^1.20.2",
         "cookie-session": "^2.1.0",
@@ -300,7 +300,7 @@
     },
     "packages/create": {
       "name": "@vendure/create",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "bin": {
         "create": "./index.js",
       },
@@ -330,7 +330,7 @@
     },
     "packages/dashboard": {
       "name": "@vendure/dashboard",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "@babel/core": "^7.29.0",
         "@babel/preset-react": "^7.28.5",
@@ -429,7 +429,7 @@
     },
     "packages/dev-server": {
       "name": "dev-server",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "@nestjs/axios": "^4.0.0",
         "@vendure/admin-ui-plugin": "3.6.2",
@@ -453,14 +453,13 @@
     },
     "packages/email-plugin": {
       "name": "@vendure/email-plugin",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "@types/nodemailer": "^6.4.9",
         "dateformat": "^3.0.3",
         "express": "^5.1.0",
         "fs-extra": "^11.2.0",
         "handlebars": "^4.7.8",
-        "mjml": "^4.14.1",
         "nodemailer": "^6.9.4",
       },
       "devDependencies": {
@@ -468,15 +467,22 @@
         "@types/express": "^5.0.1",
         "@types/fs-extra": "^11.0.4",
         "@types/mjml": "^4.7.4",
-        "@vendure/common": "3.6.2",
-        "@vendure/core": "3.6.2",
+        "@vendure/common": "3.6.3",
+        "@vendure/core": "3.6.3",
+        "mjml": "^4.14.1",
         "rimraf": "^5.0.5",
         "typescript": "5.8.2",
       },
+      "peerDependencies": {
+        "mjml": "^4.14.1",
+      },
+      "optionalPeers": [
+        "mjml",
+      ],
     },
     "packages/graphiql-plugin": {
       "name": "@vendure/graphiql-plugin",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "express": "^5.1.0",
       },
@@ -498,7 +504,7 @@
     },
     "packages/harden-plugin": {
       "name": "@vendure/harden-plugin",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "graphql-query-complexity": "^0.12.0",
       },
@@ -512,7 +518,7 @@
     },
     "packages/job-queue-plugin": {
       "name": "@vendure/job-queue-plugin",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "devDependencies": {
         "@vendure/common": "3.6.2",
         "@vendure/core": "3.6.2",
@@ -532,7 +538,7 @@
     },
     "packages/telemetry-plugin": {
       "name": "@vendure/telemetry-plugin",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "@opentelemetry/api": "^1.9.0",
         "@opentelemetry/auto-instrumentations-node": "^0.58.0",
@@ -552,7 +558,7 @@
     },
     "packages/testing": {
       "name": "@vendure/testing",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
         "@vendure/common": "3.6.2",
@@ -577,7 +583,7 @@
     },
     "packages/ui-devkit": {
       "name": "@vendure/ui-devkit",
-      "version": "3.6.2",
+      "version": "3.6.3",
       "dependencies": {
         "@angular-devkit/build-angular": "^19.2.5",
         "@angular/cli": "^19.2.5",

--- a/docs/docs/reference/core-plugins/email-plugin/email-generator.mdx
+++ b/docs/docs/reference/core-plugins/email-plugin/email-generator.mdx
@@ -41,10 +41,20 @@ interpolated email text.
 </div>
 ## HandlebarsMjmlGenerator
 
-<GenerationInfo sourceFile="packages/email-plugin/src/generator/handlebars-mjml-generator.ts" sourceLine="17" packageName="@vendure/email-plugin" />
+<GenerationInfo sourceFile="packages/email-plugin/src/generator/handlebars-mjml-generator.ts" sourceLine="26" packageName="@vendure/email-plugin" />
 
 Uses Handlebars (https://handlebarsjs.com/) to output MJML (https://mjml.io) which is then
 compiled down to responsive email HTML.
+
+Since v3.7 the `mjml` package is an optional peer dependency of `@vendure/email-plugin`.
+If you use this generator (it is the default when no `emailGenerator` is supplied to
+`EmailPlugin.init()`), install it explicitly:
+
+```bash
+npm install mjml
+```
+
+If you supply your own `emailGenerator` you do not need to install `mjml`.
 
 ```ts title="Signature"
 class HandlebarsMjmlGenerator implements EmailGenerator {

--- a/docs/docs/reference/core-plugins/email-plugin/index.mdx
+++ b/docs/docs/reference/core-plugins/email-plugin/index.mdx
@@ -2,7 +2,7 @@
 title: "EmailPlugin"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/email-plugin/src/plugin.ts" sourceLine="304" packageName="@vendure/email-plugin" />
+<GenerationInfo sourceFile="packages/email-plugin/src/plugin.ts" sourceLine="314" packageName="@vendure/email-plugin" />
 
 The EmailPlugin creates and sends transactional emails based on Vendure events. By default, it uses an [MJML](https://mjml.io/)-based
 email generator to generate the email body and [Nodemailer](https://nodemailer.com/about/) to send the emails.
@@ -26,6 +26,16 @@ You can also create your own handler and register them with the plugin - see the
 or
 
 `npm install @vendure/email-plugin`
+
+Since v3.7, the [`mjml`](https://mjml.io/) package is an optional peer dependency. If you use the
+default email generator (which is used unless you supply your own `emailGenerator` to
+`EmailPlugin.init()`), install it alongside the plugin:
+
+`yarn add mjml`
+
+or
+
+`npm install mjml`
 
 *Example*
 

--- a/docs/docs/reference/dashboard/list-views/paginated-list-data-table.mdx
+++ b/docs/docs/reference/dashboard/list-views/paginated-list-data-table.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PaginatedListDataTable
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/components/shared/paginated-list-data-table.tsx" sourceLine="347" packageName="@vendure/dashboard" since="3.4.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/components/shared/paginated-list-data-table.tsx" sourceLine="357" packageName="@vendure/dashboard" since="3.4.0" />
 
 A wrapper around the [DataTable](/reference/dashboard/list-views/data-table#datatable) component, which automatically configures functionality common to
 list queries that implement the `PaginatedList` interface, which is the common way of representing lists
@@ -207,7 +207,13 @@ interface PaginatedListDataTableProps<T extends TypedDocumentNode<U, V>, U exten
 
 <MemberInfo kind="property" type={`(searchTerm: string) => NonNullable<V['options']>['filter']`}   />
 
-
+Called whenever the debounced search term changes (including when it
+becomes empty). Return a partial filter to merge with the column /
+faceted filters. The returned filter is only applied when the term is
+non-empty — when the term is `''`, the returned value is discarded so
+that callers can write `{ field: { contains: searchTerm } }` without
+producing tautological `contains: ''` clauses. The callback itself is
+still invoked on every change so pages can use it as a state-sync hook.
 ### page
 
 <MemberInfo kind="property" type={`number`}   />

--- a/docs/docs/reference/typescript-api/import-export/default-asset-import-strategy-options.mdx
+++ b/docs/docs/reference/typescript-api/import-export/default-asset-import-strategy-options.mdx
@@ -1,0 +1,41 @@
+---
+title: "DefaultAssetImportStrategyOptions"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/config/asset-import-strategy/default-asset-import-strategy.ts" sourceLine="89" packageName="@vendure/core" since="1.7.0" />
+
+Options for [DefaultAssetImportStrategy](/reference/typescript-api/import-export/default-asset-import-strategy#defaultassetimportstrategy).
+
+```ts title="Signature"
+interface DefaultAssetImportStrategyOptions {
+    retryDelayMs?: number;
+    retryCount?: number;
+    allowPrivateNetworks?: boolean;
+}
+```
+
+<div className="members-wrapper">
+
+### retryDelayMs
+
+<MemberInfo kind="property" type={`number`} default={`200`}   />
+
+Delay between retries when a fetch fails, in milliseconds.
+### retryCount
+
+<MemberInfo kind="property" type={`number`} default={`3`}   />
+
+Maximum number of retries when a fetch fails.
+### allowPrivateNetworks
+
+<MemberInfo kind="property" type={`boolean`} default={`false`}  since="3.6.4"  />
+
+If `true`, the strategy permits fetching from hostnames that resolve to
+private, loopback, link-local or other non-public IP addresses. The
+default `false` rejects such hostnames in order to mitigate server-side
+request forgery against the host's internal network and cloud metadata
+services. Enable only when importing from a trusted internal asset
+server or for local development.
+
+
+</div>

--- a/docs/docs/reference/typescript-api/import-export/default-asset-import-strategy.mdx
+++ b/docs/docs/reference/typescript-api/import-export/default-asset-import-strategy.mdx
@@ -2,17 +2,14 @@
 title: "DefaultAssetImportStrategy"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/asset-import-strategy/default-asset-import-strategy.ts" sourceLine="50" packageName="@vendure/core" since="1.7.0" />
+<GenerationInfo sourceFile="packages/core/src/config/asset-import-strategy/default-asset-import-strategy.ts" sourceLine="127" packageName="@vendure/core" since="1.7.0" />
 
 The DefaultAssetImportStrategy is able to import paths from the local filesystem (taking into account the
 `importExportOptions.importAssetsDir` setting) as well as remote http/https urls.
 
 ```ts title="Signature"
 class DefaultAssetImportStrategy implements AssetImportStrategy {
-    constructor(options?: {
-            retryDelayMs: number;
-            retryCount: number;
-        })
+    constructor(options?: DefaultAssetImportStrategyOptions)
     init(injector: Injector) => ;
     getStreamFromPath(assetPath: string) => ;
 }

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3532,7 +3532,7 @@
                   "title": "EmailGenerator",
                   "slug": "email-generator",
                   "file": "docs/reference/core-plugins/email-plugin/email-generator.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-05-21T12:52:24+02:00"
                 },
                 {
                   "title": "EmailPluginOptions",
@@ -3565,7 +3565,7 @@
                   "lastModified": "2026-04-20T16:08:16+02:00"
                 }
               ],
-              "lastModified": "2026-01-28T14:49:21+01:00"
+              "lastModified": "2026-05-21T12:52:24+02:00"
             },
             {
               "title": "GraphiQLPlugin",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2048,7 +2048,13 @@
                   "title": "DefaultAssetImportStrategy",
                   "slug": "default-asset-import-strategy",
                   "file": "docs/reference/typescript-api/import-export/default-asset-import-strategy.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-05-21T10:54:42Z"
+                },
+                {
+                  "title": "DefaultAssetImportStrategyOptions",
+                  "slug": "default-asset-import-strategy-options",
+                  "file": "docs/reference/typescript-api/import-export/default-asset-import-strategy-options.mdx",
+                  "lastModified": "2026-05-21T10:54:42Z"
                 },
                 {
                   "title": "FastImporterService",
@@ -4133,7 +4139,7 @@
                   "title": "PaginatedListDataTable",
                   "slug": "paginated-list-data-table",
                   "file": "docs/reference/dashboard/list-views/paginated-list-data-table.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-05-21T10:54:42Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"

--- a/packages/email-plugin/package.json
+++ b/packages/email-plugin/package.json
@@ -30,8 +30,15 @@
         "express": "^5.1.0",
         "fs-extra": "^11.2.0",
         "handlebars": "^4.7.8",
-        "mjml": "^4.14.1",
         "nodemailer": "^6.9.4"
+    },
+    "peerDependencies": {
+        "mjml": "^4.14.1"
+    },
+    "peerDependenciesMeta": {
+        "mjml": {
+            "optional": true
+        }
     },
     "devDependencies": {
         "@types/dateformat": "^3.0.1",
@@ -40,6 +47,7 @@
         "@types/mjml": "^4.7.4",
         "@vendure/common": "3.6.3",
         "@vendure/core": "3.6.3",
+        "mjml": "^4.14.1",
         "rimraf": "^5.0.5",
         "typescript": "5.8.2"
     }

--- a/packages/email-plugin/src/generator/handlebars-mjml-generator.ts
+++ b/packages/email-plugin/src/generator/handlebars-mjml-generator.ts
@@ -1,6 +1,5 @@
 import dateFormat from 'dateformat';
 import Handlebars from 'handlebars';
-import mjml2html from 'mjml';
 
 import { InitializedEmailPluginOptions } from '../types';
 
@@ -11,11 +10,33 @@ import { EmailGenerator } from './email-generator';
  * Uses Handlebars (https://handlebarsjs.com/) to output MJML (https://mjml.io) which is then
  * compiled down to responsive email HTML.
  *
+ * Since v3.7 the `mjml` package is an optional peer dependency of `@vendure/email-plugin`.
+ * If you use this generator (it is the default when no `emailGenerator` is supplied to
+ * `EmailPlugin.init()`), install it explicitly:
+ *
+ * ```bash
+ * npm install mjml
+ * ```
+ *
+ * If you supply your own `emailGenerator` you do not need to install `mjml`.
+ *
  * @docsCategory core plugins/EmailPlugin
  * @docsPage EmailGenerator
  */
 export class HandlebarsMjmlGenerator implements EmailGenerator {
+    private mjml2html: typeof import('mjml');
+
     async onInit(options: InitializedEmailPluginOptions) {
+        try {
+            this.mjml2html = require('mjml') as typeof import('mjml');
+        } catch (e) {
+            throw new Error(
+                'The default HandlebarsMjmlGenerator requires the "mjml" package to be installed. ' +
+                    'Install it with `npm install mjml`, or pass a different `emailGenerator` to ' +
+                    '`EmailPlugin.init()`. Underlying error: ' +
+                    (e instanceof Error ? e.message : String(e)),
+            );
+        }
         if (options.templateLoader.loadPartials) {
             const partials = await options.templateLoader.loadPartials();
             partials.forEach(({ name, content }) => Handlebars.registerPartial(name, content));
@@ -35,7 +56,7 @@ export class HandlebarsMjmlGenerator implements EmailGenerator {
         const fromResult = compiledFrom(templateVars, templateOptions);
         const subjectResult = compiledSubject(templateVars, templateOptions);
         const mjml = compiledTemplate(templateVars, templateOptions);
-        const body = mjml2html(mjml).html;
+        const body = this.mjml2html(mjml).html;
         return { from: fromResult, subject: subjectResult, body };
     }
 

--- a/packages/email-plugin/src/plugin.ts
+++ b/packages/email-plugin/src/plugin.ts
@@ -58,6 +58,16 @@ import {
  *
  * `npm install \@vendure/email-plugin`
  *
+ * Since v3.7, the [`mjml`](https://mjml.io/) package is an optional peer dependency. If you use the
+ * default email generator (which is used unless you supply your own `emailGenerator` to
+ * `EmailPlugin.init()`), install it alongside the plugin:
+ *
+ * `yarn add mjml`
+ *
+ * or
+ *
+ * `npm install mjml`
+ *
  * @example
  * ```ts
  * import { defaultEmailHandlers, EmailPlugin, FileBasedTemplateLoader } from '\@vendure/email-plugin';


### PR DESCRIPTION
## Summary

Moves `mjml` from `@vendure/email-plugin`'s `dependencies` to optional `peerDependencies`. mjml is only required by the default `HandlebarsMjmlGenerator` and not by users who supply their own `emailGenerator` strategy. Its install footprint (140 transitive packages, 138 of them exclusive to mjml — by far the largest single subtree in the workspace) doesn't need to land on every Vendure install.

The default generator remains `HandlebarsMjmlGenerator`. The plugin's API surface is unchanged. mjml is now lazy-loaded inside `HandlebarsMjmlGenerator.onInit()`, so users who supply their own `emailGenerator` (e.g. for plain HTML email or a different template system) no longer pay the mjml install cost.

## Why a separate PR

Spun out of the dependency audit (#4761) and tracked alongside the audit's main PR (#4762) and the telemetry default-narrow PR (#4764). Like the telemetry PR, this one is a *behavioural / install-experience* change rather than a "drop unused" deletion, so it's worth reviewing on its own.

## What changes for users

| User type | Install change | Behaviour change |
|---|---|---|
| Uses default `HandlebarsMjmlGenerator` (no `emailGenerator` option supplied) | One extra command: `npm install mjml` | None — same code path, mjml just lazy-loaded |
| Supplies a custom `emailGenerator` (e.g. plain HTML, alternative template system) | **−138 transitive packages**, no mjml install needed | None |
| Already has mjml installed (e.g. existing project, workspace hoist) | None | None |

If a project ends up using `HandlebarsMjmlGenerator` *without* mjml installed (e.g. fresh install that hasn't followed the updated docs), the plugin throws a clear, actionable error at startup:

> The default HandlebarsMjmlGenerator requires the \"mjml\" package to be installed. Install it with \`npm install mjml\`, or pass a different \`emailGenerator\` to \`EmailPlugin.init()\`.

This fires at plugin init (`onInit`), not at first email send, so the failure is visible immediately on server boot.

## Impact

| Metric | Before | After | Δ |
|---|---:|---:|---:|
| `@vendure/email-plugin` direct `dependencies` | 7 | 6 | −1 |
| `@vendure/email-plugin` published prod transitive footprint | 219 | 81 | **−138** |
| Downstream install cost (custom-generator users) | 219 | 81 | −138 |
| Downstream install cost (default-generator users) | 219 | 219 (+1 extra `npm install`) | unchanged |
| Extra `node-fetch@2` transitive anchor (via mjml subtree) | present | gone for custom-generator users | partial unlock |

## Files changed

- `packages/email-plugin/src/generator/handlebars-mjml-generator.ts` — remove top-level `import mjml2html from 'mjml'`; lazy-load via `require()` inside `onInit()`; cache on instance; throw actionable error on require failure. Update class JSDoc to document the optional-peer story.
- `packages/email-plugin/src/plugin.ts` — JSDoc Installation section now includes the `npm install mjml` step.
- `packages/email-plugin/package.json` — mjml moved from `dependencies` to `peerDependencies` (with `peerDependenciesMeta.mjml.optional = true`) and added to `devDependencies` so the workspace install still provides it for the plugin's own tests and the dev-server.
- `docs/docs/reference/core-plugins/email-plugin/{index,email-generator}.mdx` — regenerated from the JSDoc updates.
- `bun.lock` — refreshed.

## Test plan

- [x] `bun install` resolves cleanly; mjml is still hoisted at workspace root (via plugin's devDep) so dev-server continues to work.
- [x] `bun run test` in `packages/email-plugin` — all 46 tests pass.
- [x] `bunx tsc -p packages/email-plugin/tsconfig.build.json --noEmit` — clean.
- [ ] Smoke-test dev-server: start server, trigger an email event (e.g. customer registration), confirm the email is generated correctly using the default MJML pipeline.
- [ ] Negative smoke-test: in a fresh project that does *not* install mjml, confirm the plugin throws the actionable error at server startup with the exact wording above.
- [ ] Custom-generator smoke-test: in a project that supplies `emailGenerator: new NoopEmailGenerator()` or a custom plain-HTML generator, confirm the server starts without requiring mjml.

## References

- Audit issue: #4761
- Companion PRs:
  - #4762 (Stages 1–3: drop unused deps)
  - #4764 (Stage 4: narrow telemetry default instrumentations)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1781952796&installation_id=128408429&pr_number=4766&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4766&signature=2c2aa34f66ea296497645a2d589bf92ff6daa20c2486c673775386c9dee0c057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->