### PR TITLE
fix: add administrator and seller to createEntityConfigs

### DIFF
--- a/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
@@ -548,6 +548,56 @@ const createEntityConfigs = (i18n: any) => ({
             );
         },
     }),
+
+    Administrator: createRelationSelectorConfig({
+        ...createBaseEntityConfig('Administrator', i18n, 'emailAddress', 'lastName'),
+        listQuery: graphql(`
+            query GetAdministratorsForRelationSelector($options: AdministratorListOptions) {
+                administrators(options: $options) {
+                    items {
+                        id
+                        firstName
+                        lastName
+                        emailAddress
+                    }
+                    totalItems
+                }
+            }
+        `),
+        label: (item: any) => (
+            <EntityLabel
+                title={`${item.firstName} ${item.lastName}`}
+                subtitle={item.emailAddress}
+                placeholderLetter={item.firstName?.[0]?.toUpperCase() || 'A'}
+                rounded
+                tooltipText={`${item.firstName} ${item.lastName} (${item.emailAddress})`}
+            />
+        ),
+    }),
+
+    Seller: createRelationSelectorConfig({
+        ...createBaseEntityConfig('Seller', i18n),
+        listQuery: graphql(`
+            query GetSellersForRelationSelector($options: SellerListOptions) {
+                sellers(options: $options) {
+                    items {
+                        id
+                        name
+                    }
+                    totalItems
+                }
+            }
+        `),
+        label: (item: any) => (
+            <EntityLabel
+                title={item.name}
+                subtitle={`ID: ${item.id}`}
+                placeholderLetter={item.name?.[0]?.toUpperCase() || 'S'}
+                rounded
+                tooltipText={item.name}
+            />
+        ),
+    }),
 });
 
 type DefaultRelationInputProps = DashboardFormComponentProps & {

--- a/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
@@ -553,11 +553,13 @@ const createEntityConfigs = (i18n: any) => ({
         idKey: 'id',
         labelKey: 'lastName',
         placeholder: i18n`Search administrator...`,
-        searchFilterOperator: 'OR',
+        // Match the search term against any of the name/email fields independently
         buildSearchFilter: (term: string) => ({
-            firstName: { contains: term },
-            lastName: { contains: term },
-            emailAddress: { contains: term },
+            _or: [
+                { firstName: { contains: term } },
+                { lastName: { contains: term } },
+                { emailAddress: { contains: term } },
+            ],
         }),
         listQuery: graphql(`
             query GetAdministratorsForRelationSelector($options: AdministratorListOptions) {

--- a/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
@@ -550,7 +550,15 @@ const createEntityConfigs = (i18n: any) => ({
     }),
 
     Administrator: createRelationSelectorConfig({
-        ...createBaseEntityConfig('Administrator', i18n, 'emailAddress', 'lastName'),
+        idKey: 'id',
+        labelKey: 'lastName',
+        placeholder: i18n`Search administrator...`,
+        searchFilterOperator: 'OR',
+        buildSearchFilter: (term: string) => ({
+            firstName: { contains: term },
+            lastName: { contains: term },
+            emailAddress: { contains: term },
+        }),
         listQuery: graphql(`
             query GetAdministratorsForRelationSelector($options: AdministratorListOptions) {
                 administrators(options: $options) {
@@ -591,7 +599,7 @@ const createEntityConfigs = (i18n: any) => ({
         label: (item: any) => (
             <EntityLabel
                 title={item.name}
-                subtitle={item.name}
+                subtitle={''}
                 placeholderLetter={item.name?.[0]?.toUpperCase() || 'S'}
                 rounded
                 tooltipText={item.name}

--- a/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
@@ -591,7 +591,7 @@ const createEntityConfigs = (i18n: any) => ({
         label: (item: any) => (
             <EntityLabel
                 title={item.name}
-                subtitle={`ID: ${item.id}`}
+                subtitle={item.name}
                 placeholderLetter={item.name?.[0]?.toUpperCase() || 'S'}
                 rounded
                 tooltipText={item.name}

--- a/packages/dashboard/src/lib/components/data-input/relation-selector.tsx
+++ b/packages/dashboard/src/lib/components/data-input/relation-selector.tsx
@@ -33,6 +33,11 @@ export interface RelationSelectorConfig<T = any> {
     multiple?: boolean;
     /** Custom filter function for search */
     buildSearchFilter?: (searchTerm: string) => any;
+    /**
+     * Logical operator applied to the search filter fields. Use 'OR' when
+     * `buildSearchFilter` returns multiple fields that should be matched independently.
+     */
+    searchFilterOperator?: 'AND' | 'OR';
     /** Custom filter function for fetching by IDs */
     buildIdsFilter?: (ids: string[]) => any;
     /** Custom label renderer function for rich display */
@@ -132,6 +137,9 @@ export function useRelationSelector<T>(config: RelationSelectorConfig<T>) {
             // Add search filter if there's a search term
             if (debouncedSearch.trim().length > 0) {
                 variables.options.filter = buildFilter(debouncedSearch.trim());
+                if (config.searchFilterOperator) {
+                    variables.options.filterOperator = config.searchFilterOperator;
+                }
             }
 
             const response = (await api.query(config.listQuery, variables)) as any;

--- a/packages/dashboard/src/lib/components/data-input/relation-selector.tsx
+++ b/packages/dashboard/src/lib/components/data-input/relation-selector.tsx
@@ -33,11 +33,6 @@ export interface RelationSelectorConfig<T = any> {
     multiple?: boolean;
     /** Custom filter function for search */
     buildSearchFilter?: (searchTerm: string) => any;
-    /**
-     * Logical operator applied to the search filter fields. Use 'OR' when
-     * `buildSearchFilter` returns multiple fields that should be matched independently.
-     */
-    searchFilterOperator?: 'AND' | 'OR';
     /** Custom filter function for fetching by IDs */
     buildIdsFilter?: (ids: string[]) => any;
     /** Custom label renderer function for rich display */
@@ -137,9 +132,6 @@ export function useRelationSelector<T>(config: RelationSelectorConfig<T>) {
             // Add search filter if there's a search term
             if (debouncedSearch.trim().length > 0) {
                 variables.options.filter = buildFilter(debouncedSearch.trim());
-                if (config.searchFilterOperator) {
-                    variables.options.filterOperator = config.searchFilterOperator;
-                }
             }
 
             const response = (await api.query(config.listQuery, variables)) as any;


### PR DESCRIPTION
# Description

Adds relation selector configurations for `Administrator` and `Seller` entity types in the Dashboard's `DefaultRelationInput` component.

Previously, relation-type custom fields targeting these entities (e.g. `{ name: 'assignedRider', type: 'relation', entity: Administrator }`) would fall back to a plain text input showing only the raw entity ID. Now they render a proper searchable selector with meaningful labels:

- **Administrator**: Shows `firstName lastName` as title, `emailAddress` as subtitle, searchable by last name
- **Seller**: Shows `name` as title, searchable by name

Fixes #4778

> **Note:** Other entity types with list queries (Country, Zone, StockLocation, TaxCategory, Role, Tag, etc.) could also be added as relation selector configs if there's demand. Happy to add more in a follow-up.

# Breaking changes

None.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4779"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782161137&installation_id=128408429&pr_number=4779&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4779&signature=475420f20dfacb101e48880acf2ef1f7fe964c3df5c4ee28bb5f1f5f1607ee6e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->