### PR TITLE
fix(dashboard): prevent struct custom field overflow in narrow contai…

### DIFF
--- a/packages/dashboard/src/lib/components/data-input/struct-form-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/struct-form-input.tsx
@@ -61,10 +61,10 @@ function DisplayMode({
             <dl className="grid grid-cols-2 divide-y divide-muted -mt-2">
                 {fieldDef.fields.map(structField => (
                     <React.Fragment key={structField.name}>
-                        <dt className="text-sm font-medium text-muted-foreground py-2">
+                        <dt className="text-sm font-medium text-muted-foreground py-2 min-w-0">
                             {getTranslation(structField.label) ?? structField.name}
                         </dt>
-                        <dd className="text-sm text-foreground py-2">
+                        <dd className="text-sm text-foreground py-2 min-w-0 break-words">
                             {formatFieldValue(watchedStructValue[structField.name], structField)}
                         </dd>
                     </React.Fragment>


### PR DESCRIPTION
# Description

Fixes #4780

Struct custom field values (e.g. coordinates like `85.36084579999999`) overflow their container when rendered in narrow layouts such as the order detail side column. This is caused by CSS grid children defaulting to `min-width: auto` and no word-break rule being applied to the `<dd>` value cells.

**Changes:**
- Added `overflow-hidden` to the struct field display mode container as a safety net
- Added `min-w-0 break-all` to `<dd>` value cells so long unbroken numbers wrap within their grid track

This affects any struct custom field rendered in a narrow container, not just Fulfillment.

# Breaking changes

None.

# Screenshots

<img width="286" height="820" alt="image" src="https://github.com/user-attachments/assets/8f86edf5-7180-4d38-9394-238f3b11cbaa" />


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4781"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782246292&installation_id=128408429&pr_number=4781&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4781&signature=ba9f5f4d1be5b38f5bbcf4d67c8ffcf190f1d66da9b453801e8a7bec6215f6a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->