### PR TITLE
ci: Restrict npm publish dispatch to maintainers (Tier 2)

### DIFF
--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -23,6 +23,16 @@ on:
 jobs:
   # Determine which publish type(s) to run based on trigger
   setup:
+    # Restrict who can manually trigger a publish. `schedule` (nightlies) and
+    # `release` events are unaffected; only `workflow_dispatch` is gated, and
+    # only the listed maintainers may dispatch. A non-permitted dispatch skips
+    # this job, and `publish` (needs: setup) is skipped with it.
+    # This is the UX/first-line guard; actual enforcement against branch-based
+    # bypass is the `npm-publish` environment + npm trust `--env` binding below.
+    if: >-
+      github.event_name != 'workflow_dispatch' ||
+      github.actor == 'michaelbromley' ||
+      github.actor == 'dlhck'
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
@@ -41,6 +51,13 @@ jobs:
   publish:
     needs: setup
     runs-on: ubuntu-latest
+    # The OIDC token minted for this job carries an `environment: npm-publish`
+    # claim, which the npm trusted publishers require (`npm trust --env`). The
+    # environment's deployment-branch policy (master, minor, v* tags) is
+    # enforced by GitHub before the job runs, so a publish cannot originate
+    # from an arbitrary branch — closing the workflow_dispatch branch-bypass.
+    # The environment has NO required reviewers, so nightlies stay unattended.
+    environment: npm-publish
     permissions:
       contents: read
       id-token: write

--- a/scripts/npm-trust-bulk.sh
+++ b/scripts/npm-trust-bulk.sh
@@ -41,6 +41,12 @@ source "$SCRIPT_DIR/_vendure-packages.sh"
 
 REPO="vendurehq/vendure"
 WORKFLOW_FILE="publish_to_npm.yml"
+# GitHub Actions environment the publish job runs in. Binding the trust to this
+# environment means npm only accepts OIDC tokens carrying this `environment`
+# claim — and GitHub only grants that claim to runs allowed by the environment's
+# deployment-branch policy. The `environment:` key MUST be present on the publish
+# job in publish_to_npm.yml before running this, or every publish will be rejected.
+ENVIRONMENT="npm-publish"
 
 ASSUME_YES=0
 DRY_RUN=0
@@ -61,6 +67,7 @@ echo "    if existing trust entry found: npm trust revoke <pkg> --id <id>"
 echo "    npm trust github <pkg> \\"
 echo "        --file $WORKFLOW_FILE \\"
 echo "        --repo $REPO \\"
+echo "        --environment $ENVIRONMENT \\"
 echo "        --allow-publish --allow-stage-publish --yes"
 echo "    npm access set mfa=publish <pkg>"
 echo
@@ -148,6 +155,7 @@ for pkg in "${VENDURE_PACKAGES[@]}"; do
       if npm trust github "$pkg" \
           --file "$WORKFLOW_FILE" \
           --repo "$REPO" \
+          --environment "$ENVIRONMENT" \
           --allow-publish \
           --allow-stage-publish \
           --yes; then
@@ -163,7 +171,7 @@ for pkg in "${VENDURE_PACKAGES[@]}"; do
         echo "  !! revoked but the replacement could not be created, so CI publishing" >&2
         echo "  !! for this package is broken until fixed. Re-run this script to retry," >&2
         echo "  !! or recreate manually: npm trust github $pkg --file $WORKFLOW_FILE \\" >&2
-        echo "  !!   --repo $REPO --allow-publish --allow-stage-publish" >&2
+        echo "  !!   --repo $REPO --environment $ENVIRONMENT --allow-publish --allow-stage-publish" >&2
         failed+=("$pkg (trust — LEFT WITH NO ENTRY; re-run to fix)")
       else
         failed+=("$pkg (trust)")


### PR DESCRIPTION
## Summary

Restricts who can trigger the npm publish workflow and closes the `workflow_dispatch` branch-bypass, while keeping scheduled nightlies fully unattended. Builds on the staged-publishing work in #4772.

GitHub has no native "only these users can dispatch this workflow" setting (trigger permission = repo write). This achieves it with two composing layers:

1. **Actor guard** (`if: github.actor`) on the `setup` job — only `michaelbromley` / `dlhck` can meaningfully `workflow_dispatch`. `schedule` and `release` events are unaffected. This is the first-line / UX guard.
2. **`npm-publish` GitHub environment** bound to the npm trusted publishers via `--env`. The publish job's OIDC token carries an `environment: npm-publish` claim, which npm now requires. GitHub only grants that claim to runs permitted by the environment's **deployment-branch policy** (`master`, `minor`, `v*` tags). A run from an arbitrary branch therefore either fails the branch policy (if it keeps `environment:`) or gets no env claim (if it strips it) — and npm rejects it either way. The environment has **no required reviewers**, so nightlies need no human approval.

Why this and not required-reviewers (Tier 3): required reviewers would gate *every* publish, including the nightly cron. Deployment-branch policy enforces "publishes only originate from trusted refs" automatically.

## Changes

- `.github/workflows/publish_to_npm.yml`: actor guard on `setup`; `environment: npm-publish` on `publish`.
- `scripts/npm-trust-bulk.sh`: pass `--environment npm-publish` when (re)creating trusted publishers.

## ⚠️ Pre-merge checklist (ordered — must be done in this sequence)

The trust `--env` requirement and the workflow's `environment:` claim must come up in lockstep, or publishes break. Merging the workflow *before* the trust re-run is safe (npm ignores an unrequired claim); re-running trust *before* the workflow provides the claim would reject all publishes.

- [x] **1. Create the `npm-publish` environment** (Settings → Environments → New environment):
  - Name exactly `npm-publish` (must match `--env` and the workflow).
  - **Deployment branches and tags → Selected branches and tags**, add:
    - branch `master`
    - branch `minor`
    - tag `v*`  _(release events run from the version tag, not a branch)_
  - **No required reviewers** (leave unchecked) — keeps nightlies unattended.
  - No environment secrets needed (publishing uses OIDC, not tokens).
- [x] **2. Merge this PR** (needs code-owner approval from @michaelbromley / @dlhck per CODEOWNERS). After merge the publish job emits the `environment: npm-publish` claim; npm doesn't require it yet, so existing publishes keep working.
- [ ] **3. Re-run `./scripts/npm-trust-bulk.sh`** (now passes `--env npm-publish`). This updates all 15 trust entries to require the claim. From here, only runs entering the `npm-publish` environment can publish.
- [ ] **4. Verify**:
  - Manually `workflow_dispatch` a `master-nightly` **from the `master` branch** as a permitted maintainer → publishes succeed.
  - (Optional) Confirm a dispatch attempt by a non-permitted user is skipped, and a dispatch from a non-allowed branch is blocked by the environment.

> [!NOTE]
> `workflow_dispatch` should be run **from the `master` branch** (the matrix handles checking out `minor` internally for the minor-nightly leg). Dispatching from other branches will be blocked by the deployment-branch policy by design.

Relates to #4772

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782401307&installation_id=128408429&pr_number=4785&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4785&signature=64932a20cffdbeceb1d2646e1dea9b42dd4a7f5e60f0a4771bb748350546f4fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->