### PR TITLE
ci: Pin all GitHub Actions to SHA and bump off deprecated Node 20 runtime

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -13,7 +13,7 @@ inputs:
 runs:
     using: 'composite'
     steps:
-        - uses: actions/setup-node@v4
+        - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
           with:
               node-version: ${{ inputs.node-version }}
         - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/back_merge.yml
+++ b/.github/workflows/back_merge.yml
@@ -55,13 +55,13 @@ jobs:
         steps:
             - name: Generate CI Bot Token
               id: app-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
               with:
                   app-id: ${{ secrets.CI_BOT_APP_ID }}
                   private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
 
             - name: Checkout target branch
-              uses: actions/checkout@v4
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
               with:
                   token: ${{ steps.app-token.outputs.token }}
                   ref: ${{ needs.resolve-branches.outputs.target }}

--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -38,7 +38,7 @@ jobs:
             packages: ${{ steps.check.outputs.packages }}
             dashboard: ${{ steps.check.outputs.dashboard }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
               with:
                   fetch-depth: 0
             - name: Detect changed paths
@@ -80,7 +80,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - uses: ./.github/actions/setup
             - name: Build
               run: bun run build
@@ -96,7 +96,7 @@ jobs:
             matrix:
                 node: [20.x, 22.x, 24.x]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - uses: ./.github/actions/setup
               with:
                   node-version: ${{ matrix.node }}
@@ -112,7 +112,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - uses: ./.github/actions/setup
             - name: Check i18n catalogs are in sync
               working-directory: packages/dashboard
@@ -129,13 +129,13 @@ jobs:
             matrix:
                 shard: [1, 2, 3, 4]
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - uses: ./.github/actions/setup
             - name: Build
               run: bunx lerna run ci --scope @vendure/testing --include-dependencies
             - name: Cache Playwright browsers
               id: playwright-cache
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
               with:
                   path: ~/.cache/ms-playwright
                   key: playwright-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
@@ -159,7 +159,7 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
               with:
                   fetch-depth: 0
             - name: SonarQube Scan
@@ -183,7 +183,7 @@ jobs:
             matrix:
                 node: ${{ github.event_name == 'pull_request' && fromJSON('["22.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - uses: ./.github/actions/setup
               with:
                   node-version: ${{ matrix.node }}
@@ -220,7 +220,7 @@ jobs:
             matrix:
                 node: ${{ github.event_name == 'pull_request' && fromJSON('["22.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - uses: ./.github/actions/setup
               with:
                   node-version: ${{ matrix.node }}
@@ -256,7 +256,7 @@ jobs:
             matrix:
                 node: ${{ github.event_name == 'pull_request' && fromJSON('["22.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - uses: ./.github/actions/setup
               with:
                   node-version: ${{ matrix.node }}
@@ -293,7 +293,7 @@ jobs:
             matrix:
                 node: ${{ github.event_name == 'pull_request' && fromJSON('["22.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - uses: ./.github/actions/setup
               with:
                   node-version: ${{ matrix.node }}

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - name: Generate CI Bot Token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
         with:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
           private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -12,9 +12,9 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - name: Use Node.js 22
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 22
             - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0

--- a/.github/workflows/deploy_dashboard.yml
+++ b/.github/workflows/deploy_dashboard.yml
@@ -36,7 +36,7 @@ jobs:
             pull-requests: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v4
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
             - name: Setup environment
               uses: ./.github/actions/setup

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -35,7 +35,7 @@ jobs:
                 working-directory: docs
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
 
             - name: Setup Bun
               uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
@@ -56,13 +56,13 @@ jobs:
         steps:
             - name: Generate CI Bot Token
               id: app-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
               with:
                   app-id: ${{ secrets.CI_BOT_APP_ID }}
                   private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
 
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
               with:
                   token: ${{ steps.app-token.outputs.token }}
                   ref: ${{ github.head_ref || github.ref }}

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -27,19 +27,19 @@ jobs:
         steps:
             - name: Generate CI Bot Token
               id: app-token
-              uses: actions/create-github-app-token@v2
+              uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
               with:
                   app-id: ${{ secrets.CI_BOT_APP_ID }}
                   private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
 
             - name: Checkout PR branch
-              uses: actions/checkout@v4
+              uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
               with:
                   token: ${{ steps.app-token.outputs.token }}
                   ref: ${{ github.head_ref }}
 
             - name: Setup Node.js
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: '22'
 
@@ -86,7 +86,7 @@ jobs:
               if: steps.diff.outputs.changed == 'true'
               id: ai-message
               continue-on-error: true
-              uses: actions/ai-inference@v1
+              uses: actions/ai-inference@b81b2afb8390ee6839b494a404766bef6493c7d9 # v1.2.8
               with:
                   model: openai/gpt-4o-mini
                   max-tokens: 100

--- a/.github/workflows/publish_and_install.yml
+++ b/.github/workflows/publish_and_install.yml
@@ -37,9 +37,9 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - name: Use Node.js 22.x
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: 22.x
             - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
@@ -73,7 +73,7 @@ jobs:
                   cd $HOME/.config/verdaccio
                   tar -czf verdaccio-storage.tar.gz storage htpasswd
             - name: Upload Verdaccio storage
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                   name: verdaccio-storage
                   path: ~/.config/verdaccio/verdaccio-storage.tar.gz
@@ -92,13 +92,13 @@ jobs:
                 node-version: ${{ github.event_name == 'pull_request' && fromJSON('["22.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
             fail-fast: false
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
             - name: Use Node.js ${{ matrix.node-version }}
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
               with:
                   node-version: ${{ matrix.node-version }}
             - name: Download Verdaccio storage
-              uses: actions/download-artifact@v4
+              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
               with:
                   name: verdaccio-storage
                   path: ~/verdaccio-download
@@ -171,7 +171,7 @@ jobs:
                 cd ~/install/test-app
                 node setup-test-plugin.js
             - name: Cache Playwright browsers
-              uses: actions/cache@v4
+              uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
               with:
                   path: ~/.cache/ms-playwright
                   key: playwright-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
@@ -211,7 +211,7 @@ jobs:
                 kill $DEV_PID 2>/dev/null || true
             - name: Upload dashboard test screenshots
               if: always()
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
               with:
                 name: dashboard-test-screenshots-${{ matrix.os }}-${{ matrix.node-version }}
                 path: /tmp/dashboard-test-*.png

--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -68,7 +68,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ matrix.type == 'minor-nightly' && 'minor' || matrix.type == 'master-nightly' && 'master' || '' }}
           fetch-depth: ${{ matrix.type == 'release' && 1 || 0 }}
@@ -88,7 +88,7 @@ jobs:
 
       - name: Setup Node.js
         if: matrix.type == 'release' || steps.commit_check.outputs.should_publish == 'true'
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: '24.x'
           registry-url: 'https://registry.npmjs.org'

--- a/.github/workflows/stale_bot.yml
+++ b/.github/workflows/stale_bot.yml
@@ -13,7 +13,7 @@ jobs:
     sweep:
         runs-on: ubuntu-latest
         steps:
-            - uses: actions/stale@v9 # v9 or later
+            - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639 # v9.1.0
               with:
                   days-before-stale: 30
                   days-before-close: 3


### PR DESCRIPTION
## Summary

Completes the SHA-pinning hardening follow-up from #4772, and clears the Node 20 action-runtime deprecation surfaced by a recent publish run.

- **Pins every `actions/*` reference to a full commit SHA** (with a `# vX.Y.Z` comment) across all workflow files and the `.github/actions/setup` composite. Mutable floating tags (`@v4` etc.) are a supply-chain vector: a compromised tag can be silently repointed to malicious code. A SHA is immutable.
- **Bumps the action runtimes off the deprecated Node 20**:
  - `actions/checkout` v4 → **v5.0.1** (Node 24)
  - `actions/setup-node` v4 **and** v6 → **v6.4.0** (Node 24), including inside the `setup` composite where most usage lives
- Other pinned actions: `create-github-app-token` v2.2.2, `upload-artifact` v4.6.2, `download-artifact` v4.3.0, `cache` v4.3.0, `stale` v9.1.0, `ai-inference` v1.2.8.

This clears the runner warning: *"Node.js 20 actions are deprecated … forced to Node 24 from June 2, removed Sept 16."*

## Scope notes

- **Third-party actions** (bun, sonarqube, peter-evans×2, contributor-assistant) were **already** SHA-pinned and are unchanged.
- **The project's tested/supported Node versions are intentionally untouched** (matrices still `20.x/22.x/24.x`; `engines` unchanged). Node 20 is EOL, but dropping support is a breaking release decision for a separate PR against `major`, not a CI chore.
- Pure `@ref` swaps — no structural workflow changes.

## Verification

- All 36 `actions/*` references confirmed as full 40-char SHA + version comment; no remaining floating `@vN` tags.
- Watch this PR's own CI run: the `checkout@v5` / `setup-node@v6` bumps should run green, and the Node 20 deprecation annotation should be gone.

Relates to #4772

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782418125&installation_id=128408429&pr_number=4786&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4786&signature=13d4c9b498cec2c68542ffda4e1c58aebbdc1bc0fcf73a88eaf38a5d4fd06f36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->