### PR TITLE
ci: Scope GitHub App tokens to least privilege

### DIFF
--- a/.github/workflows/back_merge.yml
+++ b/.github/workflows/back_merge.yml
@@ -59,7 +59,8 @@ jobs:
               with:
                   app-id: ${{ secrets.CI_BOT_APP_ID }}
                   private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
-                  # Least privilege: token is only used to push the back-merge to the target branch.
+                  # Least privilege: token is used to push the back-merge to the target branch and
+                  # to look up the bot user id (a public /users endpoint needing no extra permission).
                   permission-contents: write
 
             - name: Checkout target branch

--- a/.github/workflows/back_merge.yml
+++ b/.github/workflows/back_merge.yml
@@ -59,6 +59,8 @@ jobs:
               with:
                   app-id: ${{ secrets.CI_BOT_APP_ID }}
                   private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
+                  # Least privilege: token is only used to push the back-merge to the target branch.
+                  permission-contents: write
 
             - name: Checkout target branch
               uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,9 +22,13 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
           private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
-          # Least privilege: CLA assistant stores signatures (contents) and comments on PRs.
+          # Least privilege: the CLA assistant stores signatures (contents), comments on PRs
+          # (pull-requests), sets the CLA commit status that gates merge (statuses), and
+          # re-triggers itself on "recheck" (actions). All four are required by the action.
           permission-contents: write
           permission-pull-requests: write
+          permission-statuses: write
+          permission-actions: write
 
       # Third-party actions are pinned to commit SHAs to prevent supply chain attacks
       # via mutable version tags. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -22,6 +22,9 @@ jobs:
         with:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
           private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
+          # Least privilege: CLA assistant stores signatures (contents) and comments on PRs.
+          permission-contents: write
+          permission-pull-requests: write
 
       # Third-party actions are pinned to commit SHAs to prevent supply chain attacks
       # via mutable version tags. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -60,6 +60,8 @@ jobs:
               with:
                   app-id: ${{ secrets.CI_BOT_APP_ID }}
                   private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
+                  # Least privilege: token is only used to commit & push the regenerated manifest.
+                  permission-contents: write
 
             - name: Checkout
               uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -31,6 +31,8 @@ jobs:
               with:
                   app-id: ${{ secrets.CI_BOT_APP_ID }}
                   private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
+                  # Least privilege: token is only used to commit & push regenerated docs to the PR branch.
+                  permission-contents: write
 
             - name: Checkout PR branch
               uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1


### PR DESCRIPTION
## Summary

Adds explicit `permission-*` inputs to every `actions/create-github-app-token` step. Without them, the generated token inherits **all** permissions granted to the CI Bot App installation, which is broader than any of these jobs needs. Scoping to least privilege limits the blast radius if a token leaks or a step is compromised.

Flagged by CodeRabbit/zizmor on #4786 — pre-existing (not introduced by the SHA-pin PR), tracked as a follow-up on #4772.

## Scoping (minimum per workflow)

| Workflow | What the token does | Permissions granted |
|---|---|---|
| `back_merge.yml` | push the back-merge to the target branch | `contents: write` |
| `docs_ci.yml` | commit & push regenerated `manifest.json` | `contents: write` |
| `generate_docs.yml` | commit & push regenerated docs to the PR branch | `contents: write` |
| `cla.yml` | store CLA signatures + comment on PRs (CLA assistant) | `contents: write` + `pull-requests: write` |

Reading the bot user id via `gh api /users/<slug>[bot]` needs no extra input — `metadata: read` is implicit for app tokens.

## Notes

- PR/issue operations in `back_merge.yml` (create/comment) use `secrets.GITHUB_TOKEN`, **not** the app token, so they're unaffected.
- The App installation must, of course, grant at least these permissions (it already does — these jobs run today).
- Pure additive change; no behavioural difference for the happy path, only a tighter token.

Relates to #4772

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782419303&installation_id=128408429&pr_number=4787&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4787&signature=5bef6a15bc814659bace9eafc9e1f093fb83cf880964e54069388f01d0b32e09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->