### PR TITLE
ci: Gate the npm publish release trigger to maintainers

### DIFF
--- a/.github/workflows/publish_to_npm.yml
+++ b/.github/workflows/publish_to_npm.yml
@@ -23,16 +23,19 @@ on:
 jobs:
   # Determine which publish type(s) to run based on trigger
   setup:
-    # Restrict who can manually trigger a publish. `schedule` (nightlies) and
-    # `release` events are unaffected; only `workflow_dispatch` is gated, and
-    # only the listed maintainers may dispatch. A non-permitted dispatch skips
-    # this job, and `publish` (needs: setup) is skipped with it.
+    # Restrict who can trigger a publish to the listed maintainers. Both
+    # `workflow_dispatch` (manual) and `release` (a published GitHub Release)
+    # are user-initiated, so both are gated on `github.actor`; a publish
+    # triggered by anyone else skips this job, and `publish` (needs: setup)
+    # is skipped with it. `schedule` (nightly cron) is not user-initiated and
+    # is always allowed.
     # This is the UX/first-line guard; actual enforcement against branch-based
-    # bypass is the `npm-publish` environment + npm trust `--env` binding below.
+    # bypass is the `npm-publish` environment + npm trust `--env` binding below,
+    # and creation of the `v*` release tags is restricted by a tag ruleset.
     if: >-
-      github.event_name != 'workflow_dispatch' ||
-      github.actor == 'michaelbromley' ||
-      github.actor == 'dlhck'
+      github.event_name == 'schedule' ||
+      ((github.event_name == 'release' || github.event_name == 'workflow_dispatch') &&
+       (github.actor == 'michaelbromley' || github.actor == 'dlhck'))
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}


### PR DESCRIPTION
## Summary

Closes a gap in the publish-trigger restrictions: the actor guard on `publish_to_npm.yml` previously covered only `workflow_dispatch`, leaving the **`release` trigger ungated**. Any team member with repo write could publish a GitHub Release and trigger a staged publish.

This extends the guard so **both** user-initiated triggers (`release` and `workflow_dispatch`) require `github.actor` to be a release maintainer (@michaelbromley / @dlhck). `schedule` (nightly cron) is not user-initiated and stays allowed.

```yaml
if: >-
  github.event_name == 'schedule' ||
  ((github.event_name == 'release' || github.event_name == 'workflow_dispatch') &&
   (github.actor == 'michaelbromley' || github.actor == 'dlhck'))
```

## Why this matters (T4 in the threat model)

A release runs from a tag ref, and the `npm-publish` environment's deployment-branch policy already blocks releases from non-`v*` tags. The residual gap was: a write-access member could create a `v*` tag on a malicious commit, publish a Release, and get the packages **staged** (the 2FA approval step was the only thing stopping `latest`). This guard stops a non-maintainer's release before it stages.

## Companion control (GitHub setting, not in this PR)

A **tag ruleset on `v*`** restricting tag creation to the release maintainers is the GitHub-enforced half — it prevents the malicious `v*` tag from being created at all. Recommended alongside this PR:

```bash
gh api repos/vendurehq/vendure/rulesets -X POST --input - <<'JSON'
{
  "name": "Protect release tags (v*)",
  "target": "tag",
  "enforcement": "active",
  "conditions": { "ref_name": { "include": ["refs/tags/v*"], "exclude": [] } },
  "rules": [ { "type": "creation" }, { "type": "update" }, { "type": "deletion" } ]
}
JSON
```
(Add the maintainers to the ruleset bypass list so they can still create release tags.)

## Defence-in-depth recap for the release path

1. `release` trigger now gated to maintainers (this PR)
2. `npm-publish` environment blocks non-`v*` tag releases
3. tag ruleset blocks non-maintainers creating `v*` tags (companion setting)
4. staged publishing + 2FA approval — final backstop to `latest`

Relates to #4772

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782459595&installation_id=128408429&pr_number=4788&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4788&signature=0916e85aed1c83f58e639b2c501e7a8783a54b02dcdae5eb5412e731c7a7cc8b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->