### PR TITLE
fix(ci): Drop actions:write from CLA app token (regression from #4787)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -23,12 +23,14 @@ jobs:
           app-id: ${{ secrets.CI_BOT_APP_ID }}
           private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
           # Least privilege: the CLA assistant stores signatures (contents), comments on PRs
-          # (pull-requests), sets the CLA commit status that gates merge (statuses), and
-          # re-triggers itself on "recheck" (actions). All four are required by the action.
+          # (pull-requests), and sets the CLA commit status that gates merge (statuses).
+          # NOTE: we do NOT request `actions: write` — the vendure-ci-automation-bot App only
+          # grants `actions: read`, and requesting a permission the App lacks hard-fails token
+          # creation. It isn't needed anyway: the "recheck" flow is driven by the issue_comment
+          # trigger (a new event re-runs this workflow), not by an API workflow re-run.
           permission-contents: write
           permission-pull-requests: write
           permission-statuses: write
-          permission-actions: write
 
       # Third-party actions are pinned to commit SHAs to prevent supply chain attacks
       # via mutable version tags. See https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions


### PR DESCRIPTION
## Problem

The CLA Assistant is failing on **every PR** since #4787 merged. The "Generate CI Bot Token" step errors out before the action even runs:

```
Failed to create token: The level of access for permissions requested
are not granted to this installation.
```

## Root cause

#4787 scoped the CLA app token to `contents` + `pull-requests` + `statuses` + `actions` (all `write`). But the **`vendure-ci-automation-bot` App installation only grants `actions: read`**, not write:

```
actions: read, contents: write, pull_requests: write, statuses: write, metadata: read
```

`actions/create-github-app-token` **hard-fails** when an explicitly-requested `permission-*` exceeds the App installation's grants — it doesn't silently trim. So requesting `actions: write` broke token creation entirely. (Before #4787 the token requested no explicit permissions and inherited the App's grants, so it worked.)

## Fix

Drop `permission-actions: write`. It isn't needed anyway — CLA Assistant Lite's "recheck" is driven by the **`issue_comment` trigger** (a new comment re-runs the workflow), not by an API workflow re-run, so `actions: write` was never exercised in this setup.

The remaining three — `contents`, `pull-requests`, `statuses` (all write) — are granted by the App and cover signature storage, PR comments, and the merge-gating status check. `statuses: write` is kept (it's granted and the status check relies on it).

## Lesson

Token-level least-privilege is **capped by the App installation's grants**; requesting beyond them is a hard error. The correct minimal set is `{what the action uses} ∩ {what the App grants}`.

Fixes the regression from #4787. Relates to #4772

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782460173&installation_id=128408429&pr_number=4789&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4789&signature=c96b682469214acde39560be253c11ef42c6e1b6362f893526ef334dbfc00c3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->