### PR TITLE
ci: Fix intermittent dashboard port race in Publish & Install

### DIFF
--- a/.github/workflows/publish_and_install.yml
+++ b/.github/workflows/publish_and_install.yml
@@ -141,14 +141,17 @@ jobs:
             - name: Kill dev server after smoke tests
               shell: bash
               run: |
-                  # Kill everything on port 3000 so dashboard tests can start fresh
-                  # (npm run dev spawns child processes that aren't killed by killing the parent)
+                  # Kill everything on ports 3000 and 5173 so the dashboard tests can start fresh.
+                  # `npm run dev` spawns child processes (server on 3000, dashboard Vite on 5173)
+                  # that aren't killed by killing the parent, so we kill by port. Freeing 5173 here
+                  # is essential: otherwise the smoke-test dashboard lingers and the next step's
+                  # dashboard fails to bind it.
                   if [[ "$RUNNER_OS" == "Windows" ]]; then
-                      # Windows: use netstat to find PID and taskkill
-                      netstat -ano | grep ':3000' | grep 'LISTENING' | awk '{print $5}' | head -1 | xargs -r taskkill //F //PID 2>/dev/null || true
+                      # Windows: use netstat to find PIDs and taskkill
+                      netstat -ano | grep -E ':(3000|5173)[[:space:]]' | grep 'LISTENING' | awk '{print $5}' | sort -u | xargs -r -I {} taskkill //F //PID {} 2>/dev/null || true
                   else
                       # Linux/macOS: use lsof
-                      lsof -ti:3000 | xargs kill 2>/dev/null || true
+                      lsof -ti:3000,5173 | xargs kill 2>/dev/null || true
                   fi
             - name: Copy files (Windows)
               if: runner.os == 'Windows'
@@ -186,27 +189,17 @@ jobs:
             - name: Start dashboard and run tests
               run: |
                 cd ~/install/test-app
-                # start the dev server in the background
+                # `npm run dev` already starts BOTH the Vendure server (port 3000) and the
+                # dashboard Vite dev server (port 5173) concurrently. Starting a second Vite
+                # on 5173 here caused an intermittent EADDRINUSE race against the one that
+                # `npm run dev` had already bound, so we rely on the single dev process.
                 npm run dev &
                 DEV_PID=$!
-                # Wait for the dev server to be available (use /health endpoint, not root)
+                # Wait for the server (use /health endpoint, not root) and the dashboard to be available
                 wait-on http://localhost:3000/health --timeout 60000
-                # Start the dashboard with --strictPort to fail fast if port is in use
-                npx vite --port 5173 --strictPort &
-                DASHBOARD_PID=$!
-                # Give Vite a moment to start or fail
-                sleep 3
-                # Check if Vite process is still running (it will exit immediately if port is in use)
-                if ! kill -0 $DASHBOARD_PID 2>/dev/null; then
-                    echo "Vite failed to start - port 5173 may be in use"
-                    exit 1
-                fi
-                # Wait for the dashboard to be available
                 wait-on http://localhost:5173/dashboard --timeout 120000
                 # Run the dashboard tests
                 NODE_PATH=~/install/test-app/node_modules node $GITHUB_WORKSPACE/.github/workflows/scripts/dashboard-tests.js
-                # Clean up dashboard process
-                kill $DASHBOARD_PID 2>/dev/null || true
                 # Clean up dev server process
                 kill $DEV_PID 2>/dev/null || true
             - name: Upload dashboard test screenshots


### PR DESCRIPTION
## Problem

The `Publish & Install` workflow intermittently fails the **"Start dashboard and run tests"** step with:

```
error when starting dev server:
Error: Port 5173 is already in use
Vite failed to start - port 5173 may be in use
##[error]Process completed with exit code 1.
```

This presents as a flake — it passes on some runs, fails on others — but it's a genuine race condition, not transient infrastructure.

## Root cause

In the scaffolded `@vendure/create` test-app, `npm run dev` uses `concurrently` to start **both** the Vendure server (port 3000) **and** the dashboard Vite dev server (port 5173) — visible in the logs via the `[server]` and `[dashboard]` prefixes.

The step then started a **second** Vite on the same port:

```bash
npm run dev &                          # already starts dashboard on 5173
wait-on http://localhost:3000/health   # only waits for the SERVER
npx vite --port 5173 --strictPort &    # second Vite on 5173 -> race
```

Whether the job passed came down to which Vite bound 5173 first:

- Server (3000) healthy **before** the `concurrently` dashboard binds 5173 → the explicit `npx vite` wins → ✅ passes (the duplicate fails silently).
- The `concurrently` dashboard binds 5173 **first** → `npx vite --strictPort` hits `EADDRINUSE` → ❌ exit 1.

There was also a latent leak: the **"Kill dev server after smoke tests"** step only freed port 3000 (`lsof -ti:3000`), leaving the smoke-test dashboard Vite squatting on 5173.

## Fix

1. **Remove the redundant second Vite start.** Since `npm run dev` already brings up the dashboard on 5173, just `wait-on` it directly. This eliminates the race entirely (also removes the `sleep 3` + `kill -0` liveness guard, replaced by `wait-on` on the actual readiness signal).
2. **Free port 5173 in the post-smoke-test cleanup** (alongside 3000), on both the Linux/macOS (`lsof`) and Windows (`netstat`/`taskkill`) branches, so no stale dashboard lingers between steps. The Windows port match is anchored with a trailing-whitespace class so it can't accidentally match an ephemeral port (e.g. `:51730`).

## Notes

- PRs only exercise the `ubuntu-latest` leg; the full 3-OS matrix runs on push to `master`/`minor`/`major`, so the Windows branch matters for those runs.
- No production code touched — workflow only.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782465852&installation_id=128408429&pr_number=4790&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4790&signature=3fac640b89e0278564eadb5dc10a6413831924c3120e09785cd6421ae186dbff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->