### PR TITLE
fix(dashboard): initialize boolean configurable args

### DIFF
--- a/packages/dashboard/e2e/tests/catalog/collections.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/collections.spec.ts
@@ -293,3 +293,72 @@ test.describe('Issue #4389: Collection form dirty state with filters', () => {
         await expect(dp.formItem('Name').getByRole('textbox')).toHaveValue('E2E Filter Test Saved');
     });
 });
+
+test.describe('Issue #3548: Collection facet filter boolean args', () => {
+    let collectionId: string;
+
+    const detailPage = (page: Page) =>
+        new BaseDetailPage(page, {
+            newPath: '/collections/new',
+            pathPrefix: '/collections/',
+            newTitle: 'New collection',
+        });
+
+    test.afterEach(async ({ page }) => {
+        if (!collectionId) return;
+        const client = new VendureAdminClient(page);
+        await client.login();
+        await client.gql(
+            `
+            mutation ($id: ID!) { deleteCollection(id: $id) { result } }
+        `,
+            { id: collectionId },
+        );
+        collectionId = '';
+    });
+
+    // #3548 — A newly-added facet-value-filter should initialize the required
+    // containsAny boolean to the same explicit false value shown by the switch.
+    test('should allow saving a facet-value-filter without toggling Contains any', async ({ page }) => {
+        const client = new VendureAdminClient(page);
+        await client.login();
+        const { facetValues } = await client.gql(`
+            query { facetValues(options: { take: 1 }) { items { name } } }
+        `);
+        const facetValueName = facetValues.items[0].name as string;
+
+        const dp = detailPage(page);
+        await dp.gotoNew();
+        await dp.expectNewPageLoaded();
+
+        await dp.fillInput('Name', 'E2E Boolean Arg Filter');
+        await expect(dp.formItem('Slug').getByRole('textbox')).not.toHaveValue('', { timeout: 5_000 });
+
+        await page.getByRole('button', { name: /Add collection filter/i }).click();
+        await page.getByRole('menuitem', { name: /Filter by facet values/i }).click();
+        await page.getByRole('button', { name: /Add facet values/i }).click();
+        await page.getByPlaceholder('Search facet values...').fill(facetValueName);
+        await page.getByRole('option', { name: facetValueName, exact: true }).click();
+
+        await expect(dp.createButton).toBeEnabled({ timeout: 5_000 });
+        await dp.clickCreate();
+        await dp.expectNavigatedToExisting();
+        collectionId = new URL(page.url()).pathname.split('/').pop() ?? '';
+
+        const { collection } = await client.gql(
+            `
+            query ($id: ID!) {
+                collection(id: $id) {
+                    filters {
+                        code
+                        args { name value }
+                    }
+                }
+            }
+        `,
+            { id: collectionId },
+        );
+        const facetFilter = collection.filters.find((filter: any) => filter.code === 'facet-value-filter');
+        expect(facetFilter?.args).toEqual(expect.arrayContaining([{ name: 'containsAny', value: 'false' }]));
+    });
+});

--- a/packages/dashboard/e2e/tests/catalog/collections.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/collections.spec.ts
@@ -294,6 +294,7 @@ test.describe('Issue #4389: Collection form dirty state with filters', () => {
     });
 });
 
+// #3548 — Collection facet filter boolean args
 test.describe('Issue #3548: Collection facet filter boolean args', () => {
     let collectionId: string;
 
@@ -317,8 +318,6 @@ test.describe('Issue #3548: Collection facet filter boolean args', () => {
         collectionId = '';
     });
 
-    // #3548 — A newly-added facet-value-filter should initialize the required
-    // containsAny boolean to the same explicit false value shown by the switch.
     test('should allow saving a facet-value-filter without toggling Contains any', async ({ page }) => {
         const client = new VendureAdminClient(page);
         await client.login();

--- a/packages/dashboard/e2e/tests/catalog/collections.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/collections.spec.ts
@@ -318,7 +318,9 @@ test.describe('Issue #3548: Collection facet filter boolean args', () => {
         collectionId = '';
     });
 
-    test('should allow saving a facet-value-filter without toggling Contains any', async ({ page }) => {
+    test('should initialize containsAny through the UI when adding a facet-value-filter', async ({
+        page,
+    }) => {
         const client = new VendureAdminClient(page);
         await client.login();
         const { facetValues } = await client.gql(`
@@ -339,6 +341,9 @@ test.describe('Issue #3548: Collection facet filter boolean args', () => {
         await page.getByPlaceholder('Search facet values...').fill(facetValueName);
         await page.getByRole('option', { name: facetValueName, exact: true }).click();
 
+        await expect(
+            page.locator('[data-slot="field"]').filter({ hasText: 'Contains any' }).getByRole('switch'),
+        ).not.toBeChecked();
         await expect(dp.createButton).toBeEnabled({ timeout: 5_000 });
         await dp.clickCreate();
         await dp.expectNavigatedToExisting();

--- a/packages/dashboard/src/app/common/duplicate-entity-dialog.tsx
+++ b/packages/dashboard/src/app/common/duplicate-entity-dialog.tsx
@@ -1,4 +1,5 @@
 import { ConfigurableOperationInput as ConfigurableOperationInputComponent } from '@/vdb/components/shared/configurable-operation-input.js';
+import { getInitialConfigArgValue } from '@/vdb/components/shared/configurable-operation-utils.js';
 import { Button } from '@/vdb/components/ui/button.js';
 import {
     Dialog,
@@ -54,7 +55,7 @@ export function DuplicateEntityDialog({
                 arguments:
                     matchingDuplicator.args?.map(arg => ({
                         name: arg.name,
-                        value: arg.defaultValue != null ? arg.defaultValue.toString() : '',
+                        value: getInitialConfigArgValue(arg),
                     })) || [],
             });
         }

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx
@@ -1,4 +1,5 @@
 import { ConfigurableOperationInput } from '@/vdb/components/shared/configurable-operation-input.js';
+import { getInitialConfigArgValue } from '@/vdb/components/shared/configurable-operation-utils.js';
 import { FormFieldWrapper } from '@/vdb/components/shared/form-field-wrapper.js';
 import { Button } from '@/vdb/components/ui/button.js';
 import {
@@ -120,7 +121,7 @@ export function FulfillOrderDialog({ order, onSuccess }: Readonly<FulfillOrderDi
                 code: defaultHandler.code,
                 arguments: defaultHandler.args.map(arg => ({
                     name: arg.name,
-                    value: arg.defaultValue != null ? arg.defaultValue.toString() : '',
+                    value: getInitialConfigArgValue(arg),
                 })),
             });
         }

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-multi-selector.tsx
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-multi-selector.tsx
@@ -14,6 +14,7 @@ import { ConfigurableOperationInput as ConfigurableOperationInputType } from '@v
 import { Plus } from 'lucide-react';
 import { useCallback, useEffect, useRef } from 'react';
 import { ConfigurableOperationInput } from './configurable-operation-input.js';
+import { getInitialConfigArgValue } from './configurable-operation-utils.js';
 
 /**
  * Props interface for ConfigurableOperationMultiSelector component
@@ -178,7 +179,7 @@ export function ConfigurableOperationMultiSelector({
                 code: operation.code,
                 arguments: operationDef.args.map(arg => ({
                     name: arg.name,
-                    value: arg.defaultValue != null ? arg.defaultValue.toString() : arg.list ? '[]' : '',
+                    value: getInitialConfigArgValue(arg),
                 })),
             },
         ]);

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-selector.tsx
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-selector.tsx
@@ -12,6 +12,7 @@ import { useQuery } from '@tanstack/react-query';
 import { ConfigurableOperationInput as ConfigurableOperationInputType } from '@vendure/common/lib/generated-types';
 import { Plus } from 'lucide-react';
 import { ConfigurableOperationInput } from './configurable-operation-input.js';
+import { getInitialConfigArgValue } from './configurable-operation-utils.js';
 
 /**
  * Props interface for ConfigurableOperationSelector component
@@ -103,7 +104,7 @@ export function ConfigurableOperationSelector({
             code: operation.code,
             arguments: operationDef.args.map(arg => ({
                 name: arg.name,
-                value: arg.defaultValue != null ? arg.defaultValue.toString() : '',
+                value: getInitialConfigArgValue(arg),
             })),
         });
     };

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-utils.spec.ts
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-utils.spec.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+
+import { ConfigurableOperationDefFragment } from '@/vdb/graphql/fragments.js';
+import { getInitialConfigArgValue } from './configurable-operation-utils.js';
+
+type ConfigArgDef = ConfigurableOperationDefFragment['args'][number];
+
+const argDef = (overrides: Partial<ConfigArgDef>): ConfigArgDef =>
+    ({
+        name: 'test',
+        type: 'string',
+        required: true,
+        defaultValue: null,
+        list: false,
+        ui: null,
+        label: 'Test',
+        description: null,
+        ...overrides,
+    }) as ConfigArgDef;
+
+describe('getInitialConfigArgValue', () => {
+    it('should initialize list args as JSON arrays', () => {
+        expect(getInitialConfigArgValue(argDef({ list: true }))).toBe('[]');
+        expect(getInitialConfigArgValue(argDef({ list: true, defaultValue: true }))).toBe('[true]');
+    });
+
+    it('should initialize boolean scalar args without defaults as false', () => {
+        expect(getInitialConfigArgValue(argDef({ type: 'boolean' }))).toBe('false');
+    });
+
+    it('should preserve scalar defaults and empty scalar fallback', () => {
+        expect(getInitialConfigArgValue(argDef({ defaultValue: 1 }))).toBe('1');
+        expect(getInitialConfigArgValue(argDef({ type: 'string' }))).toBe('');
+    });
+});

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-utils.spec.ts
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-utils.spec.ts
@@ -32,4 +32,18 @@ describe('getInitialConfigArgValue', () => {
         expect(getInitialConfigArgValue(argDef({ defaultValue: 1 }))).toBe('1');
         expect(getInitialConfigArgValue(argDef({ type: 'string' }))).toBe('');
     });
+
+    // The `!= null` guard must treat falsy-but-defined defaults (0, false, '') as
+    // real values rather than absent. A naive truthy check (`if (arg.defaultValue)`)
+    // would drop these and fall through to the type-based fallbacks.
+    it('should preserve falsy-but-defined scalar defaults', () => {
+        expect(getInitialConfigArgValue(argDef({ type: 'int', defaultValue: 0 }))).toBe('0');
+        expect(getInitialConfigArgValue(argDef({ type: 'boolean', defaultValue: false }))).toBe('false');
+        expect(getInitialConfigArgValue(argDef({ type: 'string', defaultValue: '' }))).toBe('');
+    });
+
+    it('should wrap falsy-but-defined list defaults in a JSON array', () => {
+        expect(getInitialConfigArgValue(argDef({ list: true, defaultValue: 0 }))).toBe('[0]');
+        expect(getInitialConfigArgValue(argDef({ list: true, defaultValue: false }))).toBe('[false]');
+    });
 });

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-utils.ts
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-utils.ts
@@ -1,0 +1,18 @@
+import { ConfigurableOperationDefFragment } from '@/vdb/graphql/fragments.js';
+
+type ConfigurableOperationArgDef = ConfigurableOperationDefFragment['args'][number];
+
+export function getInitialConfigArgValue(arg: ConfigurableOperationArgDef): string {
+    if (arg.defaultValue != null) {
+        return arg.defaultValue.toString();
+    }
+    if (arg.list) {
+        return '[]';
+    }
+    // Required boolean args render as an off switch by default, so persist the
+    // same explicit false value that the UI communicates to validation.
+    if (arg.type === 'boolean') {
+        return 'false';
+    }
+    return '';
+}

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-utils.ts
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-utils.ts
@@ -3,11 +3,11 @@ import { ConfigurableOperationDefFragment } from '@/vdb/graphql/fragments.js';
 type ConfigurableOperationArgDef = ConfigurableOperationDefFragment['args'][number];
 
 export function getInitialConfigArgValue(arg: ConfigurableOperationArgDef): string {
+    if (arg.list) {
+        return arg.defaultValue != null ? JSON.stringify([arg.defaultValue]) : '[]';
+    }
     if (arg.defaultValue != null) {
         return arg.defaultValue.toString();
-    }
-    if (arg.list) {
-        return '[]';
     }
     // Required boolean args render as an off switch by default, so persist the
     // same explicit false value that the UI communicates to validation.


### PR DESCRIPTION
## Problem

In the React Dashboard, adding a collection `facet-value-filter` can leave the collection form invalid until the `Contains any` switch is manually toggled.

The switch is visually rendered as unchecked/off, but the underlying configurable operation argument can be initialized as an empty string (`""`). Since `containsAny` is a required scalar argument, the Create/Update button remains disabled even though the UI appears to show a valid `false` value.

Refs #3548

## Root cause

New configurable operation arguments are initialized from their `defaultValue` when present. For args without a default, list args are initialized as `[]`, but scalar args fall back to an empty string.

That means a required boolean arg without a `defaultValue` starts as:

```json
{ "name": "containsAny", "value": "" }
```

`BooleanInput` renders string values as checked only when the value is `"true"`, so `""` is shown as off/false. However, `ConfigurableOperationInput` validation correctly treats a required scalar `""` as invalid.

So the UI and validation disagree:

- UI: unchecked switch, looks like `false`
- internal value: `""`
- validation: invalid required scalar

## Fix

Introduce shared configurable operation arg initialization used by both the single and multi configurable operation selectors.

The initialization now preserves existing behavior for defaults and list args, while making boolean args explicit:

- `defaultValue != null` -> `defaultValue.toString()`
- list args -> `"[]"`
- boolean args without a default -> `"false"`
- other scalar args without a default -> `""`

This keeps the switch UI and required scalar validation aligned without changing `BooleanInput`, validation rules, or legacy stored-data handling.

## Test plan

- [x] `bun run --cwd packages/dashboard check-types`
- [x] `CI=true VITE_TEST_PORT=5176 bunx playwright test --config e2e/playwright.config.ts e2e/tests/catalog/collections.spec.ts --reporter=list`

The new E2E regression creates a collection with `facet-value-filter`, selects a facet value, does not toggle `Contains any`, verifies the Create button becomes enabled, saves the collection, and asserts the saved args include `containsAny: "false"`.

## Breaking changes

None.

## Screenshots

Not applicable. The regression is covered by an E2E test.

## Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782534887&installation_id=128408429&pr_number=4794&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4794&signature=e40556bf10f0fc67c80f6f5af0ce2c494a8f9e208ce059acb295c0edffe21869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->