### PR TITLE
fix(ci): Install chromium-headless-shell for dashboard e2e

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -138,12 +138,17 @@ jobs:
               uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
               with:
                   path: ~/.cache/ms-playwright
-                  key: playwright-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
-                  restore-keys: |
-                      playwright-${{ runner.os }}-
+                  # The key version prefix (v2) lets us evict caches poisoned by an
+                  # earlier incomplete browser install. No restore-keys: a prefix
+                  # fallback would drag stale browser binaries forward on a Playwright
+                  # version bump, and an exact hit on that poisoned cache then skips
+                  # the install step indefinitely.
+                  key: playwright-v2-${{ runner.os }}-${{ hashFiles('**/bun.lock') }}
             - name: Install Playwright browsers
               if: steps.playwright-cache.outputs.cache-hit != 'true'
-              run: bunx playwright install chromium
+              # chromium-headless-shell is a separate download since Playwright 1.49
+              # and is what headless CI runs actually launch.
+              run: bunx playwright install chromium chromium-headless-shell
               working-directory: packages/dashboard
             - name: Install Playwright system deps
               run: bunx playwright install-deps chromium


### PR DESCRIPTION
## Problem

All four `dashboard e2e` shards fail at browser launch:

```
Error: browserType.launch: Executable doesn't exist at
.../chromium_headless_shell-1208/chrome-headless-shell-linux64/chrome-headless-shell
```

The failing test is the Playwright `auth.setup.ts` setup project. When setup can't launch a browser, every dependent test is skipped (`1 failed, 71 did not run`), so all shards die fast and identically.

## Root cause

Two compounding issues in the `dashboard-e2e` job:

1. **Incomplete browser install.** The job ran `bunx playwright install chromium`. Since Playwright **1.49**, headless mode launches a separately-downloaded `chromium-headless-shell` binary, which `install chromium` does not fetch. The dashboard runs Playwright **1.58.2** (headless shell build 1208) — exactly the missing executable.

2. **Cache masked the gap.** Browsers are cached at `~/.cache/ms-playwright` keyed on `bun.lock`, with the install step gated on a cache miss. A `restore-keys` prefix dragged stale browser binaries forward across Playwright bumps; once an incomplete browser set was saved under the current key, every later run got an **exact** cache hit and skipped the install step indefinitely — so the missing 1208 headless shell was never repaired.

## Fix

- Install `chromium-headless-shell` alongside `chromium`.
- Bump the cache key prefix to `playwright-v2-` to evict the poisoned cache.
- Drop `restore-keys` so a future version bump produces a clean miss and full reinstall, with no stale carry-forward.

This is a CI-only change; no application code is affected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4800"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782905636&installation_id=128408429&pr_number=4800&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4800&signature=340fa97507f85ee9fe2a888a83deb2026f8f1de2a9b6654dcf53ec92588de738"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->