### PR TITLE
fix(dashboard): allow selecting nullable select items

### DIFF
--- a/packages/dashboard/e2e/fixtures/e2e-shared-config.ts
+++ b/packages/dashboard/e2e/fixtures/e2e-shared-config.ts
@@ -53,6 +53,13 @@ export const e2eCustomFields: CustomFields = {
             label: [{ languageCode: LanguageCode.en, value: 'Priority' }],
             options: [{ value: 'low' }, { value: 'medium' }, { value: 'high' }],
         },
+        {
+            name: 'featureType',
+            type: 'string',
+            nullable: true,
+            label: [{ languageCode: LanguageCode.en, value: 'Feature Type' }],
+            options: [{ value: 'standard' }, { value: 'premium' }],
+        },
         // ── SEO tab ──
         {
             name: 'seoTitle',

--- a/packages/dashboard/e2e/tests/catalog/custom-fields.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/custom-fields.spec.ts
@@ -81,6 +81,7 @@ test.describe('Custom Fields', () => {
 
     // ─── Nullable option select ──────────────────────────────────────────
 
+    // #4801 — allow selecting and clearing nullable select items
     test('should allow selecting and clearing a nullable option select', async ({ page }) => {
         await goToFirstProduct(page);
         const dp = detailPage(page);
@@ -99,6 +100,7 @@ test.describe('Custom Fields', () => {
         await expect(featureTypeCombobox).not.toContainText('premium');
     });
 
+    // #4801 — create product without setting a nullable option select
     test('should create a product without setting a nullable option select', async ({ page }) => {
         const dp = detailPage(page);
         await dp.gotoNew();

--- a/packages/dashboard/e2e/tests/catalog/custom-fields.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/custom-fields.spec.ts
@@ -76,6 +76,42 @@ test.describe('Custom Fields', () => {
         await expect(dp.formItem('Additional Info').getByRole('textbox')).toBeVisible();
         // string with options → combobox
         await expect(dp.formItem('Priority').getByRole('combobox')).toBeVisible();
+        await expect(dp.formItem('Feature Type').getByRole('combobox')).toBeVisible();
+    });
+
+    // ─── Nullable option select ──────────────────────────────────────────
+
+    test('should allow selecting and clearing a nullable option select', async ({ page }) => {
+        await goToFirstProduct(page);
+        const dp = detailPage(page);
+        const featureTypeCombobox = dp.formItem('Feature Type').getByRole('combobox');
+
+        // Base UI Select shows placeholder state via data-placeholder on the trigger,
+        // not as visible text in the combobox accessible name.
+        await expect(featureTypeCombobox).toHaveAttribute('data-placeholder', '');
+
+        await dp.selectOption('Feature Type', 'premium');
+        await expect(featureTypeCombobox).toContainText('premium');
+
+        await featureTypeCombobox.click();
+        await page.getByRole('listbox').getByRole('option').first().click();
+        await expect(featureTypeCombobox).toHaveAttribute('data-placeholder', '');
+        await expect(featureTypeCombobox).not.toContainText('premium');
+    });
+
+    test('should create a product without setting a nullable option select', async ({ page }) => {
+        const dp = detailPage(page);
+        await dp.gotoNew();
+        await dp.expectNewPageLoaded();
+
+        await dp.fillInput('Product name', 'Nullable Feature Type Product');
+        await expect(dp.formItem('Slug').getByRole('textbox')).not.toHaveValue('', { timeout: 5_000 });
+        await expect(dp.formItem('Feature Type').getByRole('combobox')).toHaveAttribute('data-placeholder', '');
+        await expect(dp.createButton).toBeEnabled({ timeout: 10_000 });
+
+        await dp.clickCreate();
+        await dp.expectSuccessToast(/Successfully created product/);
+        await dp.expectNavigatedToExisting();
     });
 
     // ─── Tab grouping ────────────────────────────────────────────────────

--- a/packages/dashboard/src/lib/components/data-input/select-with-options.tsx
+++ b/packages/dashboard/src/lib/components/data-input/select-with-options.tsx
@@ -8,6 +8,7 @@ import {
 } from '@/vdb/framework/form-engine/form-engine-types.js';
 import {
     extractFieldOptions,
+    isFieldNullable,
     isReadonlyField,
     isStringFieldWithOptions,
     isStringStructFieldWithOptions,
@@ -83,24 +84,30 @@ export function SelectWithOptions({
     }
 
     // For single fields, use regular Select
-    const currentValue = value ?? '';
+    const isNullable = isFieldNullable(fieldDef);
+    const selectValue = isNullable ? (value == null || value === '' ? null : value) : (value ?? '');
 
-    const handleValueChange = (value: string) => {
-        if (value) {
-            onChange(value);
+    const handleValueChange = (newValue: string | null) => {
+        if (isNullable) {
+            onChange(newValue ?? null);
+        } else if (newValue) {
+            onChange(newValue);
         }
     };
 
     const selectItems = Object.fromEntries(
         options.map(option => [option.value, option.label ? getTranslation(option.label) : option.value]),
     );
+    // Add a null item for nullable selects
+    if (isNullable) selectItems.null = '';
 
     return (
-        <Select value={currentValue} onValueChange={handleValueChange} disabled={readOnly} items={selectItems}>
+        <Select value={selectValue} onValueChange={handleValueChange} disabled={readOnly} items={selectItems}>
             <SelectTrigger className="mb-0">
                 <SelectValue placeholder={placeholder || <Trans>Select an option</Trans>} />
             </SelectTrigger>
             <SelectContent>
+                {isNullable && <SelectItem value={null}>{'\u00a0'}</SelectItem>}
                 {options.map(option => (
                     <SelectItem key={option.value} value={option.value}>
                         {option.label ? getTranslation(option.label) : option.value}

--- a/packages/dashboard/src/lib/framework/form-engine/form-schema-tools.spec.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/form-schema-tools.spec.ts
@@ -2,6 +2,7 @@ import { FieldInfo } from '@/vdb/framework/document-introspection/get-document-s
 import { describe, expect, it } from 'vitest';
 
 import {
+    applyNullableSelectCustomFieldDefaults,
     createFormSchemaFromFields,
     getDefaultValuesFromFields,
     getZodTypeFromField,
@@ -642,6 +643,44 @@ describe('form-schema-tools', () => {
             const fields: FieldInfo[] = [createMockField('value', type, true)];
             const defaults = getDefaultValuesFromFields(fields, 'en');
             expect(defaults.value).toBe(expected);
+        });
+
+        it('nullable string custom field with options should default to null', () => {
+            const fields: FieldInfo[] = [
+                createMockField('customFields', 'Object', false, false, [
+                    createMockField('featureType', 'String', true),
+                ]),
+            ];
+            const customFieldConfigs = [
+                {
+                    name: 'featureType',
+                    type: 'string',
+                    nullable: true,
+                    readonly: false,
+                    list: false,
+                    options: [{ value: 'standard' }, { value: 'premium' }],
+                },
+            ] as any[];
+
+            const defaults = getDefaultValuesFromFields(fields, 'en', customFieldConfigs);
+            expect(defaults.customFields.featureType).toBeNull();
+        });
+
+        it('applyNullableSelectCustomFieldDefaults should normalize empty string to null', () => {
+            const values = { customFields: { featureType: '' } };
+            const customFieldConfigs = [
+                {
+                    name: 'featureType',
+                    type: 'string',
+                    nullable: true,
+                    readonly: false,
+                    list: false,
+                    options: [{ value: 'a' }],
+                },
+            ] as any[];
+
+            const result = applyNullableSelectCustomFieldDefaults(values, customFieldConfigs);
+            expect(result.customFields.featureType).toBeNull();
         });
     });
 

--- a/packages/dashboard/src/lib/framework/form-engine/form-schema-tools.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/form-schema-tools.ts
@@ -4,6 +4,7 @@ import {
     isScalarType,
 } from '@/vdb/framework/document-introspection/get-document-structure.js';
 import {
+    ConfigurableFieldDef,
     CustomFieldConfig,
     DateTimeCustomFieldConfig,
     FloatCustomFieldConfig,
@@ -12,6 +13,7 @@ import {
     StructCustomFieldConfig,
     StructField,
 } from '@/vdb/framework/form-engine/form-engine-types.js';
+import { isStringFieldWithOptions, isStructCustomFieldConfig } from '@/vdb/framework/form-engine/utils.js';
 import { z, ZodRawShape, ZodType, ZodTypeAny } from '@/vdb/lib/zod.js';
 
 function mapGraphQLCustomFieldToConfig(field: StructField) {
@@ -335,7 +337,11 @@ export function createFormSchemaFromFields(
     return z.object(schemaConfig);
 }
 
-export function getDefaultValuesFromFields(fields: FieldInfo[], defaultLanguageCode?: string) {
+export function getDefaultValuesFromFields(
+    fields: FieldInfo[],
+    defaultLanguageCode?: string,
+    customFieldConfigs?: CustomFieldConfig[],
+) {
     const defaultValues: Record<string, any> = {};
     for (const field of fields) {
         if (field.typeInfo) {
@@ -349,7 +355,71 @@ export function getDefaultValuesFromFields(fields: FieldInfo[], defaultLanguageC
             defaultValues[field.name] = getDefaultValueFromField(field, defaultLanguageCode);
         }
     }
-    return defaultValues;
+    return applyNullableSelectCustomFieldDefaults(defaultValues, customFieldConfigs);
+}
+
+/**
+ * Nullable string fields with options should default to `null`, not `''`.
+ */
+export function applyNullableSelectCustomFieldDefaults<T extends Record<string, any>>(
+    values: T,
+    customFieldConfigs?: CustomFieldConfig[],
+): T {
+    if (!customFieldConfigs?.length || values.customFields == null) return values;
+
+    return {
+        ...values,
+        customFields: applyNullableSelectDefaultsToCustomFieldsObject(
+            values.customFields,
+            customFieldConfigs,
+        ),
+    };
+}
+
+function applyNullableSelectDefaultsToCustomFieldsObject(
+    customFieldsDefaults: Record<string, any>,
+    configs: CustomFieldConfig[],
+): Record<string, any> {
+    const result = { ...customFieldsDefaults };
+    for (const config of configs) {
+        const fieldDef = config as ConfigurableFieldDef;
+        if (isStructCustomFieldConfig(fieldDef)) {
+            const structValue = result[fieldDef.name];
+            if (structValue && typeof structValue === 'object' && !Array.isArray(structValue)) {
+                result[fieldDef.name] = applyNullableSelectDefaultsToStructFields(
+                    structValue,
+                    fieldDef.fields,
+                );
+            }
+        } else if (
+            config.type === 'string' &&
+            isStringFieldWithOptions(config as ConfigurableFieldDef) &&
+            config.nullable !== false &&
+            (result[config.name] === '' || result[config.name] === undefined)
+        ) {
+            result[config.name] = null;
+        }
+    }
+    return result;
+}
+
+function applyNullableSelectDefaultsToStructFields(
+    structDefaults: Record<string, any>,
+    fields: StructField[],
+): Record<string, any> {
+    const result = { ...structDefaults };
+    for (const field of fields) {
+        const subFieldConfig = mapGraphQLCustomFieldToConfig(field);
+        if (
+            subFieldConfig.type === 'string' &&
+            isStringFieldWithOptions(subFieldConfig as ConfigurableFieldDef) &&
+            subFieldConfig.nullable !== false &&
+            (result[field.name] === '' || result[field.name] === undefined)
+        ) {
+            result[field.name] = null;
+        }
+    }
+    return result;
 }
 
 export function getDefaultValueFromField(field: FieldInfo, defaultLanguageCode?: string) {

--- a/packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx
+++ b/packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx
@@ -6,7 +6,11 @@ import { useForm } from 'react-hook-form';
 import { useChannel } from '../../hooks/use-channel.js';
 import { useServerConfig } from '../../hooks/use-server-config.js';
 import { getOperationVariablesFields } from '../document-introspection/get-document-structure.js';
-import { createFormSchemaFromFields, getDefaultValuesFromFields } from './form-schema-tools.js';
+import {
+    applyNullableSelectCustomFieldDefaults,
+    createFormSchemaFromFields,
+    getDefaultValuesFromFields,
+} from './form-schema-tools.js';
 import {
     convertEmptyStringsToNull,
     removeEmptyIdFields,
@@ -133,8 +137,8 @@ export function useGeneratedForm<
         [updateFields, customFieldConfig],
     );
     const defaultValues = useMemo(
-        () => getDefaultValuesFromFields(updateFields, activeChannel?.defaultLanguageCode),
-        [updateFields, activeChannel?.defaultLanguageCode],
+        () => getDefaultValuesFromFields(updateFields, activeChannel?.defaultLanguageCode, customFieldConfig),
+        [updateFields, activeChannel?.defaultLanguageCode, customFieldConfig],
     );
     const processedEntity = useMemo(
         () => ensureTranslationsForAllLanguages(entity, availableLanguages, defaultValues),
@@ -147,13 +151,12 @@ export function useGeneratedForm<
         [defaultValues, availableLanguages],
     );
 
-    const values = useMemo(
-        () =>
-            processedEntity
-                ? transformRelationFields(updateFields, setValuesRef.current(processedEntity))
-                : processedDefaultValues,
-        [processedEntity, processedDefaultValues, updateFields],
-    );
+    const values = useMemo(() => {
+        const raw = processedEntity
+            ? transformRelationFields(updateFields, setValuesRef.current(processedEntity))
+            : processedDefaultValues;
+        return applyNullableSelectCustomFieldDefaults(raw, customFieldConfig);
+    }, [processedEntity, processedDefaultValues, updateFields, customFieldConfig]);
 
     const form = useForm({
         resolver: async (values, context, options) => {

--- a/packages/dashboard/src/lib/framework/form-engine/utils.spec.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/utils.spec.ts
@@ -5,10 +5,12 @@ import { FieldInfo, getOperationVariablesFields } from '../document-introspectio
 
 import {
     convertEmptyStringsToNull,
+    isFieldNullable,
     removeEmptyIdFields,
     stripNullNullableFields,
     transformRelationFields,
 } from './utils.js';
+import { ConfigurableFieldDef } from "./form-engine-types.js";
 
 const createProductDocument = graphql(`
     mutation CreateProduct($input: CreateProductInput!) {
@@ -672,5 +674,53 @@ describe('stripNullNullableFields', () => {
         const result = stripNullNullableFields(values, fields);
         expect(values.threshold).toBeNull();
         expect(result).toEqual({});
+    });
+});
+
+describe('isFieldNullable', () => {
+    it('should return true for nullable custom fields', () => {
+        expect(
+            isFieldNullable({
+                name: 'featureType',
+                type: 'string',
+                nullable: true,
+                readonly: false,
+                list: false,
+            } as ConfigurableFieldDef),
+        ).toBe(true);
+    });
+
+    it('should return false for non-nullable custom fields', () => {
+        expect(
+            isFieldNullable({
+                name: 'priority',
+                type: 'string',
+                nullable: false,
+                readonly: false,
+                list: false,
+            } as ConfigurableFieldDef),
+        ).toBe(false);
+    });
+
+    it('should return true for nullable struct sub-fields', () => {
+        expect(
+            isFieldNullable({
+                name: 'kind',
+                type: 'string',
+                nullable: true,
+                options: [{ value: 'a' }],
+            } as ConfigurableFieldDef),
+        ).toBe(true);
+    });
+
+    it('should return false for configurable operation args', () => {
+        expect(
+            isFieldNullable({
+                name: 'arg',
+                type: 'string',
+                list: false,
+                ui: { options: [{ value: 'a' }] },
+            } as ConfigurableFieldDef),
+        ).toBe(false);
     });
 });

--- a/packages/dashboard/src/lib/framework/form-engine/utils.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/utils.ts
@@ -445,6 +445,20 @@ export function isNullableField(input: ConfigurableFieldDef): boolean {
 }
 
 /**
+ * Determines if a custom field or struct sub-field allows null values.
+ * Configurable operation args are never treated as nullable.
+ */
+export function isFieldNullable(input: ConfigurableFieldDef | StructField): boolean {
+    if (isCustomFieldConfig(input as ConfigurableFieldDef)) {
+        return (input as ConfigurableFieldDef & { nullable?: boolean }).nullable !== false;
+    }
+    if ('nullable' in input && input.nullable) {
+        return true;
+    }
+    return false;
+}
+
+/**
  * Handles nested form submission to prevent event bubbling in nested forms.
  * This is useful when you have a form inside a dialog that's within another form.
  *


### PR DESCRIPTION
# Description

Allows selecting an empty option in dropdown/select, mimicking the Angular Admin UI to support nullable custom fields.

Currently, we can't use the dashboard because custom fields that are nullable are init as an empty string throwing the following error:

```
Failed to create promotion
GraphQL Request Error: The custom field "featureType" value [""] is invalid. Valid options are ['welcome-gift', 'we-forest', 'loyalty-level1', 'loyalty-level2', 'loyalty-level3', 'birthday-gift', 'product-variant-upsell']
```

# Breaking changes

Nope!

# Screenshots

<img width="400" height="150" alt="image" src="https://github.com/user-attachments/assets/11d46bb4-d37d-4305-8891-d801f3ff202e" />

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4801"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782912425&installation_id=128408429&pr_number=4801&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4801&signature=d1a47650d8976a0cef7e31f6d619aa97a799a468c24fba45fabc8064c6bb991d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->