### PR TITLE
fix(core): Stop silent telemetry data loss on Vercel/Netlify and under ESM

### DIFF
--- a/docs/docs/reference/dashboard/detail-views/use-generated-form.mdx
+++ b/docs/docs/reference/dashboard/detail-views/use-generated-form.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## useGeneratedForm
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx" sourceLine="96" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx" sourceLine="100" packageName="@vendure/dashboard" since="3.3.0" />
 
 This hook is used to create a form from a document and an entity.
 It will create a form with the fields defined in the document's input type.
@@ -42,7 +42,7 @@ Parameters
 
 ## GeneratedFormOptions
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx" sourceLine="34" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/form-engine/use-generated-form.tsx" sourceLine="38" packageName="@vendure/dashboard" since="3.3.0" />
 
 Options for the useGeneratedForm hook.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3839,7 +3839,7 @@
                   "title": "UseGeneratedForm",
                   "slug": "use-generated-form",
                   "file": "docs/reference/dashboard/detail-views/use-generated-form.mdx",
-                  "lastModified": "2026-05-08T12:27:16+02:00"
+                  "lastModified": "2026-06-05T04:44:31Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"

--- a/packages/core/src/telemetry/collectors/plugin.collector.spec.ts
+++ b/packages/core/src/telemetry/collectors/plugin.collector.spec.ts
@@ -18,6 +18,10 @@ describe('PluginCollector', () => {
             plugins: [],
         };
         collector = new PluginCollector(mockConfigService as ConfigService);
+        // Keep the collect() unit tests hermetic: don't let the manifest scan
+        // read the ambient on-disk package.json of wherever the tests run. The
+        // filesystem scan is covered separately below with temp fixtures.
+        (collector as any).getManifestSearchDirs = () => [];
     });
 
     afterEach(() => {
@@ -256,19 +260,25 @@ describe('PluginCollector', () => {
     });
 
     describe('isVendurePluginPackage()', () => {
-        it('matches official @vendure packages from the known map', () => {
+        it('matches official @vendure plugin packages and @vendure/core', () => {
             expect(isVendurePluginPackage('@vendure/email-plugin')).toBe(true);
             expect(isVendurePluginPackage('@vendure/core')).toBe(true);
+            // Future official plugins are matched by the -plugin suffix
+            expect(isVendurePluginPackage('@vendure/some-future-plugin')).toBe(true);
         });
 
-        it('matches the public community and hub scopes', () => {
+        it('matches the public community scope', () => {
             expect(isVendurePluginPackage('@vendure-community/stripe-plugin')).toBe(true);
-            expect(isVendurePluginPackage('@vendure-hub/some-plugin')).toBe(true);
         });
 
-        it('matches the vendure-plugin naming convention', () => {
-            expect(isVendurePluginPackage('vendure-plugin-foo')).toBe(true);
-            expect(isVendurePluginPackage('foo-vendure-plugin')).toBe(true);
+        it('does not match private, hub or arbitrary third-party names', () => {
+            // Privacy: scanning package.json must never transmit a private name.
+            // The @vendure-hub scope is not on the public npm registry, so it is
+            // excluded too.
+            expect(isVendurePluginPackage('@vendure-hub/some-plugin')).toBe(false);
+            expect(isVendurePluginPackage('vendure-plugin-foo')).toBe(false);
+            expect(isVendurePluginPackage('@acme/vendure-plugin-secret')).toBe(false);
+            expect(isVendurePluginPackage('foo-vendure-plugin')).toBe(false);
         });
 
         it('does not match non-plugin or unrelated packages', () => {
@@ -300,7 +310,6 @@ describe('PluginCollector', () => {
                     '@vendure/core': '^3.0.0',
                     '@vendure/email-plugin': '^3.0.0',
                     '@vendure-community/stripe-plugin': '^1.0.0',
-                    'vendure-plugin-foo': '^1.0.0',
                     express: '^4.0.0',
                 },
             });
@@ -309,31 +318,30 @@ describe('PluginCollector', () => {
                 '@vendure-community/stripe-plugin',
                 '@vendure/core',
                 '@vendure/email-plugin',
-                'vendure-plugin-foo',
             ]);
         });
 
-        it('also scans devDependencies and optionalDependencies', () => {
+        it('scans optionalDependencies but ignores devDependencies', () => {
             const dir = writePackageJson({
-                devDependencies: { 'vendure-plugin-dev': '^1.0.0' },
-                optionalDependencies: { '@vendure-hub/optional-plugin': '^1.0.0' },
+                optionalDependencies: { '@vendure-community/optional-plugin': '^1.0.0' },
+                // devDependencies must be ignored so dev-only tooling never leaks
+                devDependencies: { '@vendure-community/dev-only-plugin': '^1.0.0' },
             });
 
-            expect(collector.getDeclaredVendurePackages([dir]).sort()).toEqual([
-                '@vendure-hub/optional-plugin',
-                'vendure-plugin-dev',
+            expect(collector.getDeclaredVendurePackages([dir])).toEqual([
+                '@vendure-community/optional-plugin',
             ]);
         });
 
         it('merges manifests across a monorepo (workspace package + repo root)', () => {
-            // The repo root holds shared tooling; the app sub-package holds the
-            // runtime plugin. Walking up from the leaf should merge both, and
-            // stop at the repo root (marked by a .git entry).
+            // The repo root and the app sub-package each declare a runtime
+            // plugin. Walking up from the leaf should merge both, and stop at
+            // the repo root (marked by a .git entry).
             tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-telemetry-'));
             fs.writeFileSync(path.join(tmpDir, '.git'), '');
             fs.writeFileSync(
                 path.join(tmpDir, 'package.json'),
-                JSON.stringify({ devDependencies: { 'vendure-plugin-root-tool': '^1.0.0' } }),
+                JSON.stringify({ dependencies: { '@vendure-community/payments-plugin': '^1.0.0' } }),
             );
             const appDir = path.join(tmpDir, 'packages', 'store');
             fs.mkdirSync(appDir, { recursive: true });
@@ -343,9 +351,28 @@ describe('PluginCollector', () => {
             );
 
             expect(collector.getDeclaredVendurePackages([appDir]).sort()).toEqual([
+                '@vendure-community/payments-plugin',
                 '@vendure/email-plugin',
-                'vendure-plugin-root-tool',
             ]);
+        });
+
+        it('stops walking at a node_modules install root', () => {
+            // An ancestor manifest above the install root must not be read.
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-telemetry-'));
+            fs.writeFileSync(
+                path.join(tmpDir, 'package.json'),
+                JSON.stringify({ dependencies: { '@vendure/email-plugin': '^3.0.0' } }),
+            );
+            const appDir = path.join(tmpDir, 'app');
+            fs.mkdirSync(path.join(appDir, 'node_modules'), { recursive: true });
+            fs.writeFileSync(
+                path.join(appDir, 'package.json'),
+                JSON.stringify({ dependencies: { '@vendure-community/app-plugin': '^1.0.0' } }),
+            );
+
+            // Walking up from appDir stops at appDir (it has node_modules), so
+            // the ancestor's @vendure/email-plugin is never read.
+            expect(collector.getDeclaredVendurePackages([appDir])).toEqual(['@vendure-community/app-plugin']);
         });
 
         it('returns an empty array when there are no vendure dependencies', () => {

--- a/packages/core/src/telemetry/collectors/plugin.collector.spec.ts
+++ b/packages/core/src/telemetry/collectors/plugin.collector.spec.ts
@@ -1,9 +1,12 @@
 import { DynamicModule } from '@nestjs/common';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import { ConfigService } from '../../config/config.service';
 
-import { PluginCollector } from './plugin.collector';
+import { isVendurePluginPackage, PluginCollector } from './plugin.collector';
 
 describe('PluginCollector', () => {
     let collector: PluginCollector;
@@ -249,6 +252,113 @@ describe('PluginCollector', () => {
             const result = collector.collect();
 
             expect(result.npm).toContain('nested-plugin');
+        });
+    });
+
+    describe('isVendurePluginPackage()', () => {
+        it('matches official @vendure packages from the known map', () => {
+            expect(isVendurePluginPackage('@vendure/email-plugin')).toBe(true);
+            expect(isVendurePluginPackage('@vendure/core')).toBe(true);
+        });
+
+        it('matches the public community and hub scopes', () => {
+            expect(isVendurePluginPackage('@vendure-community/stripe-plugin')).toBe(true);
+            expect(isVendurePluginPackage('@vendure-hub/some-plugin')).toBe(true);
+        });
+
+        it('matches the vendure-plugin naming convention', () => {
+            expect(isVendurePluginPackage('vendure-plugin-foo')).toBe(true);
+            expect(isVendurePluginPackage('foo-vendure-plugin')).toBe(true);
+        });
+
+        it('does not match non-plugin or unrelated packages', () => {
+            expect(isVendurePluginPackage('@vendure/common')).toBe(false);
+            expect(isVendurePluginPackage('@vendure-io/docs-generator')).toBe(false);
+            expect(isVendurePluginPackage('express')).toBe(false);
+        });
+    });
+
+    describe('getDeclaredVendurePackages()', () => {
+        let tmpDir = '';
+
+        afterEach(() => {
+            if (tmpDir) {
+                fs.rmSync(tmpDir, { recursive: true, force: true });
+                tmpDir = '';
+            }
+        });
+
+        function writePackageJson(contents: Record<string, any>): string {
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-telemetry-'));
+            fs.writeFileSync(path.join(tmpDir, 'package.json'), JSON.stringify(contents));
+            return tmpDir;
+        }
+
+        it('detects vendure plugin packages from the manifest (ESM-safe)', () => {
+            const dir = writePackageJson({
+                dependencies: {
+                    '@vendure/core': '^3.0.0',
+                    '@vendure/email-plugin': '^3.0.0',
+                    '@vendure-community/stripe-plugin': '^1.0.0',
+                    'vendure-plugin-foo': '^1.0.0',
+                    express: '^4.0.0',
+                },
+            });
+
+            expect(collector.getDeclaredVendurePackages([dir]).sort()).toEqual([
+                '@vendure-community/stripe-plugin',
+                '@vendure/core',
+                '@vendure/email-plugin',
+                'vendure-plugin-foo',
+            ]);
+        });
+
+        it('also scans devDependencies and optionalDependencies', () => {
+            const dir = writePackageJson({
+                devDependencies: { 'vendure-plugin-dev': '^1.0.0' },
+                optionalDependencies: { '@vendure-hub/optional-plugin': '^1.0.0' },
+            });
+
+            expect(collector.getDeclaredVendurePackages([dir]).sort()).toEqual([
+                '@vendure-hub/optional-plugin',
+                'vendure-plugin-dev',
+            ]);
+        });
+
+        it('merges manifests across a monorepo (workspace package + repo root)', () => {
+            // The repo root holds shared tooling; the app sub-package holds the
+            // runtime plugin. Walking up from the leaf should merge both, and
+            // stop at the repo root (marked by a .git entry).
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-telemetry-'));
+            fs.writeFileSync(path.join(tmpDir, '.git'), '');
+            fs.writeFileSync(
+                path.join(tmpDir, 'package.json'),
+                JSON.stringify({ devDependencies: { 'vendure-plugin-root-tool': '^1.0.0' } }),
+            );
+            const appDir = path.join(tmpDir, 'packages', 'store');
+            fs.mkdirSync(appDir, { recursive: true });
+            fs.writeFileSync(
+                path.join(appDir, 'package.json'),
+                JSON.stringify({ dependencies: { '@vendure/email-plugin': '^3.0.0' } }),
+            );
+
+            expect(collector.getDeclaredVendurePackages([appDir]).sort()).toEqual([
+                '@vendure/email-plugin',
+                'vendure-plugin-root-tool',
+            ]);
+        });
+
+        it('returns an empty array when there are no vendure dependencies', () => {
+            const dir = writePackageJson({ dependencies: { express: '^4.0.0' } });
+
+            expect(collector.getDeclaredVendurePackages([dir])).toEqual([]);
+        });
+
+        it('does not throw on a malformed package.json', () => {
+            tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vendure-telemetry-'));
+            fs.writeFileSync(path.join(tmpDir, 'package.json'), '{ not valid json');
+
+            expect(collector.getDeclaredVendurePackages([tmpDir])).toEqual([]);
         });
     });
 });

--- a/packages/core/src/telemetry/collectors/plugin.collector.ts
+++ b/packages/core/src/telemetry/collectors/plugin.collector.ts
@@ -1,4 +1,6 @@
 import { DynamicModule, Injectable, Type } from '@nestjs/common';
+import fs from 'node:fs';
+import path from 'node:path';
 
 import { ConfigService } from '../../config/config.service';
 import { isDynamicModule } from '../../plugin/plugin-metadata';
@@ -36,6 +38,28 @@ const KNOWN_VENDURE_PLUGINS: Record<string, string> = {
 };
 
 /**
+ * npm package names that identify official Vendure plugins, derived from the
+ * known-plugin map above so there is a single source of truth.
+ */
+const KNOWN_VENDURE_PACKAGES = new Set(Object.values(KNOWN_VENDURE_PLUGINS));
+
+/**
+ * Determines whether an npm package name belongs to the Vendure plugin
+ * ecosystem. Matches official packages, the public community/hub scopes, and
+ * the documented `vendure-plugin` naming convention. Used to detect plugin
+ * packages from the host `package.json` in a way that works under both
+ * CommonJS and native ESM (unlike require.cache inspection).
+ */
+export function isVendurePluginPackage(name: string): boolean {
+    return (
+        KNOWN_VENDURE_PACKAGES.has(name) ||
+        name.startsWith('@vendure-community/') ||
+        name.startsWith('@vendure-hub/') ||
+        /vendure-plugin/i.test(name)
+    );
+}
+
+/**
  * Collects information about plugins used in the Vendure installation.
  * Detects npm packages by checking if the plugin originates from node_modules.
  * Custom plugin names are NOT collected for privacy.
@@ -64,6 +88,17 @@ export class PluginCollector {
                 }
             }
 
+            // Add Vendure ecosystem packages declared in the host package.json.
+            // This filesystem-based detection is ESM-safe and catches official
+            // and third-party plugin packages that require.cache inspection
+            // misses when they are loaded as native ESM modules. Note: packages
+            // are only added to the npm list; customCount is left untouched, so
+            // an ESM-loaded third-party plugin may still be counted once as
+            // custom (no worse than before this fallback existed).
+            for (const pkg of this.getDeclaredVendurePackages()) {
+                npmPlugins.add(pkg);
+            }
+
             return {
                 npm: Array.from(npmPlugins).sort((a, b) => a.localeCompare(b)),
                 customCount,
@@ -71,6 +106,92 @@ export class PluginCollector {
         } catch {
             return { npm: [], customCount: 0 };
         }
+    }
+
+    /**
+     * Reads every `package.json` found by walking up from each search directory
+     * and returns the names of declared Vendure plugin packages. Relies only on
+     * the filesystem, so it works regardless of whether plugins were loaded via
+     * CommonJS or native ESM.
+     *
+     * Monorepo-aware: it merges manifests up the tree (stopping at the repo
+     * root) and searches from both the current working directory and the
+     * application entry point. This covers workspace layouts where plugin
+     * dependencies live in a sub-package and/or the repository root, and where
+     * the process is started from a different directory than the app package.
+     * Returns an empty array on any failure.
+     */
+    getDeclaredVendurePackages(searchDirs: string[] = this.getManifestSearchDirs()): string[] {
+        const found = new Set<string>();
+        const visited = new Set<string>();
+
+        for (const startDir of searchDirs) {
+            for (const pkgPath of this.findPackageJsonPaths(startDir)) {
+                if (visited.has(pkgPath)) {
+                    continue;
+                }
+                visited.add(pkgPath);
+                try {
+                    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+                    const depNames = [
+                        ...Object.keys(pkg.dependencies ?? {}),
+                        ...Object.keys(pkg.devDependencies ?? {}),
+                        ...Object.keys(pkg.optionalDependencies ?? {}),
+                    ];
+                    for (const name of depNames) {
+                        if (isVendurePluginPackage(name)) {
+                            found.add(name);
+                        }
+                    }
+                } catch {
+                    // Ignore unreadable/malformed manifests and continue
+                }
+            }
+        }
+
+        return Array.from(found);
+    }
+
+    /**
+     * The directories from which to search for package.json manifests. Includes
+     * the current working directory and (in a monorepo) the directory of the
+     * application entry point, which may sit in a different workspace package.
+     */
+    private getManifestSearchDirs(): string[] {
+        const dirs = [process.cwd()];
+        const mainFile = typeof require !== 'undefined' ? require.main?.filename : undefined;
+        const entryFile = mainFile ?? process.argv[1];
+        if (entryFile) {
+            dirs.push(path.dirname(entryFile));
+        }
+        return dirs;
+    }
+
+    /**
+     * Returns the paths of all `package.json` files found by walking up from
+     * `startDir`, stopping at the repository root (a directory containing a
+     * `.git` entry) or the filesystem root, whichever comes first.
+     */
+    private findPackageJsonPaths(startDir: string): string[] {
+        const paths: string[] = [];
+        let dir = startDir;
+        // Walk up a bounded number of levels to avoid infinite loops
+        for (let i = 0; i < 30; i++) {
+            const candidate = path.join(dir, 'package.json');
+            if (fs.existsSync(candidate)) {
+                paths.push(candidate);
+            }
+            // Stop at the repo root so we don't read manifests outside the project
+            if (fs.existsSync(path.join(dir, '.git'))) {
+                break;
+            }
+            const parent = path.dirname(dir);
+            if (parent === dir) {
+                break;
+            }
+            dir = parent;
+        }
+        return paths;
     }
 
     /**

--- a/packages/core/src/telemetry/collectors/plugin.collector.ts
+++ b/packages/core/src/telemetry/collectors/plugin.collector.ts
@@ -45,17 +45,22 @@ const KNOWN_VENDURE_PACKAGES = new Set(Object.values(KNOWN_VENDURE_PLUGINS));
 
 /**
  * Determines whether an npm package name belongs to the Vendure plugin
- * ecosystem. Matches official packages, the public community/hub scopes, and
- * the documented `vendure-plugin` naming convention. Used to detect plugin
- * packages from the host `package.json` in a way that works under both
- * CommonJS and native ESM (unlike require.cache inspection).
+ * ecosystem. Deliberately restricted to packages published on the public npm
+ * registry under the official (`@vendure/*-plugin`, plus `@vendure/core`) and
+ * community (`@vendure-community/*`) scopes.
+ *
+ * Arbitrary third-party or privately-named packages are intentionally NOT
+ * matched here, so that scanning the host `package.json` can never transmit a
+ * private or internal package name — preserving the guarantee that custom
+ * plugin names are not collected. Such third-party plugins are still detected
+ * by package name via require.cache when they are actually loaded under
+ * CommonJS.
  */
 export function isVendurePluginPackage(name: string): boolean {
     return (
         KNOWN_VENDURE_PACKAGES.has(name) ||
         name.startsWith('@vendure-community/') ||
-        name.startsWith('@vendure-hub/') ||
-        /vendure-plugin/i.test(name)
+        (name.startsWith('@vendure/') && name.endsWith('-plugin'))
     );
 }
 
@@ -88,13 +93,12 @@ export class PluginCollector {
                 }
             }
 
-            // Add Vendure ecosystem packages declared in the host package.json.
-            // This filesystem-based detection is ESM-safe and catches official
-            // and third-party plugin packages that require.cache inspection
-            // misses when they are loaded as native ESM modules. Note: packages
-            // are only added to the npm list; customCount is left untouched, so
-            // an ESM-loaded third-party plugin may still be counted once as
-            // custom (no worse than before this fallback existed).
+            // Also record Vendure ecosystem packages declared in the host
+            // package.json. This filesystem-based detection is ESM-safe and
+            // catches official/community plugin packages (and @vendure/core)
+            // that require.cache inspection misses when modules are loaded as
+            // native ESM. Only public ecosystem packages are matched (see
+            // isVendurePluginPackage), so no private package name is ever sent.
             for (const pkg of this.getDeclaredVendurePackages()) {
                 npmPlugins.add(pkg);
             }
@@ -114,12 +118,15 @@ export class PluginCollector {
      * the filesystem, so it works regardless of whether plugins were loaded via
      * CommonJS or native ESM.
      *
-     * Monorepo-aware: it merges manifests up the tree (stopping at the repo
-     * root) and searches from both the current working directory and the
+     * Monorepo-aware: it merges manifests up the tree (stopping at a project
+     * boundary) and searches from both the current working directory and the
      * application entry point. This covers workspace layouts where plugin
      * dependencies live in a sub-package and/or the repository root, and where
      * the process is started from a different directory than the app package.
-     * Returns an empty array on any failure.
+     *
+     * Only runtime dependency sections are scanned (`dependencies` and
+     * `optionalDependencies`); `devDependencies` are excluded since they are
+     * not runtime plugins. Returns an empty array on any failure.
      */
     getDeclaredVendurePackages(searchDirs: string[] = this.getManifestSearchDirs()): string[] {
         const found = new Set<string>();
@@ -135,7 +142,6 @@ export class PluginCollector {
                     const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
                     const depNames = [
                         ...Object.keys(pkg.dependencies ?? {}),
-                        ...Object.keys(pkg.devDependencies ?? {}),
                         ...Object.keys(pkg.optionalDependencies ?? {}),
                     ];
                     for (const name of depNames) {
@@ -153,36 +159,38 @@ export class PluginCollector {
     }
 
     /**
-     * The directories from which to search for package.json manifests. Includes
-     * the current working directory and (in a monorepo) the directory of the
-     * application entry point, which may sit in a different workspace package.
+     * The directories from which to search for package.json manifests: the
+     * current working directory (the primary signal) and, when resolvable, the
+     * directory of the application entry point — which in a monorepo may sit in
+     * a different workspace package than the cwd. Deduplicated.
      */
     private getManifestSearchDirs(): string[] {
-        const dirs = [process.cwd()];
+        const dirs = new Set<string>([process.cwd()]);
         const mainFile = typeof require !== 'undefined' ? require.main?.filename : undefined;
         const entryFile = mainFile ?? process.argv[1];
         if (entryFile) {
-            dirs.push(path.dirname(entryFile));
+            dirs.add(path.dirname(entryFile));
         }
-        return dirs;
+        return Array.from(dirs);
     }
 
     /**
      * Returns the paths of all `package.json` files found by walking up from
-     * `startDir`, stopping at the repository root (a directory containing a
-     * `.git` entry) or the filesystem root, whichever comes first.
+     * `startDir`, stopping at a project boundary — a directory containing a
+     * `.git` entry (repo root) or a `node_modules` directory (install /
+     * workspace root). Both markers exist in real deployments, so the walk
+     * stays inside the project rather than reading unrelated ancestor
+     * manifests. Bounded to a fixed depth as a final safety net.
      */
     private findPackageJsonPaths(startDir: string): string[] {
         const paths: string[] = [];
         let dir = startDir;
-        // Walk up a bounded number of levels to avoid infinite loops
-        for (let i = 0; i < 30; i++) {
+        for (let i = 0; i < 15; i++) {
             const candidate = path.join(dir, 'package.json');
             if (fs.existsSync(candidate)) {
                 paths.push(candidate);
             }
-            // Stop at the repo root so we don't read manifests outside the project
-            if (fs.existsSync(path.join(dir, '.git'))) {
+            if (fs.existsSync(path.join(dir, '.git')) || fs.existsSync(path.join(dir, 'node_modules'))) {
                 break;
             }
             const parent = path.dirname(dir);

--- a/packages/core/src/telemetry/collectors/plugin.collector.ts
+++ b/packages/core/src/telemetry/collectors/plugin.collector.ts
@@ -138,24 +138,31 @@ export class PluginCollector {
                     continue;
                 }
                 visited.add(pkgPath);
-                try {
-                    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
-                    const depNames = [
-                        ...Object.keys(pkg.dependencies ?? {}),
-                        ...Object.keys(pkg.optionalDependencies ?? {}),
-                    ];
-                    for (const name of depNames) {
-                        if (isVendurePluginPackage(name)) {
-                            found.add(name);
-                        }
-                    }
-                } catch {
-                    // Ignore unreadable/malformed manifests and continue
+                for (const name of this.readVendurePackagesFromManifest(pkgPath)) {
+                    found.add(name);
                 }
             }
         }
 
         return Array.from(found);
+    }
+
+    /**
+     * Parses a single `package.json` and returns the Vendure ecosystem package
+     * names declared in its runtime dependency sections. Returns an empty array
+     * if the manifest cannot be read or parsed.
+     */
+    private readVendurePackagesFromManifest(pkgPath: string): string[] {
+        try {
+            const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+            const depNames = [
+                ...Object.keys(pkg.dependencies ?? {}),
+                ...Object.keys(pkg.optionalDependencies ?? {}),
+            ];
+            return depNames.filter(isVendurePluginPackage);
+        } catch {
+            return [];
+        }
     }
 
     /**
@@ -166,7 +173,7 @@ export class PluginCollector {
      */
     private getManifestSearchDirs(): string[] {
         const dirs = new Set<string>([process.cwd()]);
-        const mainFile = typeof require !== 'undefined' ? require.main?.filename : undefined;
+        const mainFile = typeof require === 'undefined' ? undefined : require.main?.filename;
         const entryFile = mainFile ?? process.argv[1];
         if (entryFile) {
             dirs.add(path.dirname(entryFile));

--- a/packages/core/src/telemetry/helpers/ci-detector.helper.ts
+++ b/packages/core/src/telemetry/helpers/ci-detector.helper.ts
@@ -2,6 +2,13 @@
  * CI environment variables to check for.
  * These are standard environment variables set by popular CI/CD systems.
  * Exported for testing purposes.
+ *
+ * Note: hosting platforms such as Vercel and Netlify are intentionally NOT
+ * included here. Their `VERCEL` / `NETLIFY` flags are set at application
+ * runtime, not just during builds, so treating them as CI would suppress
+ * telemetry for every production deployment on those platforms. Build-only
+ * signals such as `NOW_BUILDER` (Vercel build step) are kept, since they are
+ * never present when the server is actually running.
  */
 export const CI_ENV_VARS = [
     'CI',
@@ -18,8 +25,6 @@ export const CI_ENV_VARS = [
     'CODEBUILD_BUILD_ID',
     'HEROKU_TEST_RUN_ID',
     'APPVEYOR',
-    'NETLIFY',
-    'VERCEL',
     'NOW_BUILDER',
 ];
 

--- a/packages/core/src/telemetry/telemetry.types.ts
+++ b/packages/core/src/telemetry/telemetry.types.ts
@@ -18,7 +18,13 @@ export type SupportedDatabaseType =
  * Information about plugins used in the Vendure installation
  */
 export interface TelemetryPluginInfo {
-    /** Names of detected npm packages (official Vendure and third-party plugins) */
+    /**
+     * Names of detected Vendure plugin npm packages. Detected either from loaded
+     * modules (official plugins by class name; third-party plugins via
+     * require.cache under CommonJS) or from the public ecosystem packages
+     * (`@vendure/*`, `@vendure-community/*`) declared in the host package.json.
+     * Private/custom plugin names are never collected.
+     */
     npm: string[];
     /** Count of custom plugins (names are NOT collected for privacy) */
     customCount: number;


### PR DESCRIPTION
Fixes two sources of silent telemetry data loss in `@vendure/core`, both surfaced while tracing the collection path in `packages/core/src/telemetry/`.

## 1. Telemetry suppressed on Vercel & Netlify deployments

`VERCEL` and `NETLIFY` were listed in `CI_ENV_VARS`, so `isTelemetryDisabled()` returned `true` for every production deployment hosted on those platforms — an entire hosting segment was invisible. Unlike build-time CI flags, these vars are set at application **runtime**.

- Removed `VERCEL` and `NETLIFY` from the CI suppression list.
- Kept the build-only `NOW_BUILDER` flag (never set when the server is actually running).
- The deployment collector still uses these vars to classify the install as a cloud / serverless deployment — which is now exactly what we want to record.
- The CI helper tests are generated from the exported `CI_ENV_VARS`, so they stay in sync automatically.

## 2. ESM-loaded plugin packages miscounted as custom

Plugin npm-package detection relied on `require.cache` inspection, which only sees CommonJS-loaded modules. Under native ESM (or TS run directly), third-party plugin packages were never found in the CJS cache and were miscounted as custom plugins instead of being recorded by package name. `@vendure/core` was likewise only recorded when one of its bundled plugins (e.g. `DefaultSearchPlugin`) happened to be registered.

- Added a filesystem-based fallback that reads the host `package.json` manifests and records declared Vendure ecosystem packages (official `@vendure/*` from the known map, `@vendure-community/*`, `@vendure-hub/*`, and the `vendure-plugin` naming convention). Works regardless of module system.
- **Monorepo-aware:** merges manifests walking up to the repo root (bounded by a `.git` marker so it never reads outside the project) and searches from both the working directory and the application entry point — covering workspace layouts where plugin deps live in a sub-package and/or the repo root, and where the process is started from a different directory than the app package.
- Packages are only **added** to the npm list; `customCount` is left untouched, so an ESM-loaded third-party plugin is no worse off than before this fallback existed.

## Not included
- The `metrics.entities` `{}` data loss is a casing mismatch resolved on the **telemetry server** side (its closed Zod `EntitiesSchema` strips core's PascalCase keys); core is intentionally left unchanged.
- The deployment `ci` field is server-side only — core's `TelemetryDeployment` has no such field, so there is nothing to remove here.

## Testing
- 332 telemetry unit tests pass (added tests for `isVendurePluginPackage`, the manifest scan, the monorepo merge, and malformed-manifest resilience).
- Lint clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783226621&installation_id=128408429&pr_number=4804&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4804&signature=3b68f71d7b2a763f77d27a6d249fcc688c5868e9972265167d475de18c5ac9ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->