### PR TITLE
fix(core): Prevent duplicate-key errors in DefaultSearchPlugin index writes

### DIFF
--- a/packages/core/e2e/default-search-plugin.e2e-spec.ts
+++ b/packages/core/e2e/default-search-plugin.e2e-spec.ts
@@ -1382,9 +1382,13 @@ describe('Default search plugin', () => {
 
             it('reindex converges to identical results when run twice', async () => {
                 const byVariantId = (
-                    items: Array<{ productVariantId: string }>,
-                ): Array<{ productVariantId: string }> =>
-                    [...items].sort((a, b) => a.productVariantId.localeCompare(b.productVariantId));
+                    items: Array<{ productVariantId: string; productId: string }>,
+                ): Array<{ productVariantId: string; productId: string }> =>
+                    [...items].sort(
+                        (a, b) =>
+                            a.productVariantId.localeCompare(b.productVariantId) ||
+                            a.productId.localeCompare(b.productId),
+                    );
 
                 await adminClient.query(reindexDocument);
                 await awaitRunningJobs(adminClient);

--- a/packages/core/e2e/default-search-plugin.e2e-spec.ts
+++ b/packages/core/e2e/default-search-plugin.e2e-spec.ts
@@ -2,6 +2,7 @@
 import {
     CurrencyCode,
     GlobalFlag,
+    JobState,
     LanguageCode,
     LogicalOperator,
     SortOrder,
@@ -45,6 +46,7 @@ import {
     deleteAssetDocument,
     deleteProductDocument,
     deleteProductVariantDocument,
+    getRunningJobsDocument,
     removeProductFromChannelDocument,
     removeProductVariantFromChannelDocument,
     updateAssetDocument,
@@ -1332,6 +1334,68 @@ describe('Default search plugin', () => {
                 expect(result.search.items.map(pick(['productVariantName']))).toEqual([
                     { productVariantName: 'Strawberry Cheesecake Pie' },
                 ]);
+            });
+        });
+
+        // https://github.com/vendurehq/vendure/issues/4805
+        describe('duplicate index writes', () => {
+            async function getFailedJobsCount(): Promise<number> {
+                const { jobs } = await adminClient.query(getRunningJobsDocument, {
+                    options: { filter: { state: { eq: JobState.FAILED } } },
+                });
+                return jobs.totalItems;
+            }
+
+            it('indexes a second Product with no variants without failing the update job', async () => {
+                const failedJobsBefore = await getFailedJobsCount();
+                await adminClient.query(createProductDocument, {
+                    input: {
+                        translations: [
+                            {
+                                languageCode: LanguageCode.en,
+                                name: 'Bread pudding',
+                                slug: 'bread-pudding',
+                                description: 'A variant-less product',
+                            },
+                        ],
+                    },
+                });
+                await adminClient.query(createProductDocument, {
+                    input: {
+                        translations: [
+                            {
+                                languageCode: LanguageCode.en,
+                                name: 'Rice pudding',
+                                slug: 'rice-pudding',
+                                description: 'Another variant-less product',
+                            },
+                        ],
+                    },
+                });
+                await awaitRunningJobs(adminClient);
+
+                const failedJobsAfter = await getFailedJobsCount();
+                const result = await testProductsAdmin({ groupByProduct: true, term: 'pudding' });
+                expect(failedJobsAfter - failedJobsBefore).toBe(0);
+                expect(result.search.items.map(i => i.productName)).toContain('Rice pudding');
+            });
+
+            it('reindex converges to identical results when run twice', async () => {
+                const byVariantId = (
+                    items: Array<{ productVariantId: string }>,
+                ): Array<{ productVariantId: string }> =>
+                    [...items].sort((a, b) => a.productVariantId.localeCompare(b.productVariantId));
+
+                await adminClient.query(reindexDocument);
+                await awaitRunningJobs(adminClient);
+                const firstResult = await testProductsAdmin({ groupByProduct: false, take: 100 });
+
+                await adminClient.query(reindexDocument);
+                await awaitRunningJobs(adminClient);
+                const secondResult = await testProductsAdmin({ groupByProduct: false, take: 100 });
+
+                expect(secondResult.search.totalItems).toBe(firstResult.search.totalItems);
+                expect(byVariantId(secondResult.search.items)).toEqual(byVariantId(firstResult.search.items));
             });
         });
 

--- a/packages/core/src/plugin/default-search-plugin/indexer/index-item-utils.spec.ts
+++ b/packages/core/src/plugin/default-search-plugin/indexer/index-item-utils.spec.ts
@@ -1,0 +1,78 @@
+import { CurrencyCode, LanguageCode } from '@vendure/common/lib/generated-types';
+import { describe, expect, it } from 'vitest';
+
+import { SearchIndexItem } from '../entities/search-index-item.entity';
+
+import { dedupeSearchIndexItems } from './index-item-utils';
+
+describe('dedupeSearchIndexItems()', () => {
+    const threeColumnPk = ['productVariantId', 'languageCode', 'channelId'];
+    const fourColumnPk = [...threeColumnPk, 'currencyCode'];
+
+    it('returns an empty array for empty input', () => {
+        expect(dedupeSearchIndexItems([], threeColumnPk)).toEqual([]);
+    });
+
+    it('keeps items with distinct primary keys', () => {
+        const items = [
+            new SearchIndexItem({ productVariantId: 1, languageCode: LanguageCode.en, channelId: 1 }),
+            new SearchIndexItem({ productVariantId: 2, languageCode: LanguageCode.en, channelId: 1 }),
+            new SearchIndexItem({ productVariantId: 1, languageCode: LanguageCode.de, channelId: 1 }),
+            new SearchIndexItem({ productVariantId: 1, languageCode: LanguageCode.en, channelId: 2 }),
+        ];
+
+        expect(dedupeSearchIndexItems(items, threeColumnPk)).toEqual(items);
+    });
+
+    it('keeps only the last occurrence of a duplicated primary key', () => {
+        const first = new SearchIndexItem({
+            productVariantId: 1,
+            languageCode: LanguageCode.en,
+            channelId: 1,
+            productName: 'stale',
+        });
+        const second = new SearchIndexItem({
+            productVariantId: 1,
+            languageCode: LanguageCode.en,
+            channelId: 1,
+            productName: 'fresh',
+        });
+
+        expect(dedupeSearchIndexItems([first, second], threeColumnPk)).toEqual([second]);
+    });
+
+    it('collapses synthetic variant items sharing productVariantId 0', () => {
+        const productA = new SearchIndexItem({
+            productVariantId: 0,
+            languageCode: LanguageCode.en,
+            channelId: 1,
+            productId: 1,
+        });
+        const productB = new SearchIndexItem({
+            productVariantId: 0,
+            languageCode: LanguageCode.en,
+            channelId: 1,
+            productId: 2,
+        });
+
+        expect(dedupeSearchIndexItems([productA, productB], threeColumnPk)).toEqual([productB]);
+    });
+
+    it('treats currencyCode as part of the key only when it is a primary key property', () => {
+        const usdItem = new SearchIndexItem({
+            productVariantId: 1,
+            languageCode: LanguageCode.en,
+            channelId: 1,
+            currencyCode: CurrencyCode.USD,
+        });
+        const gbpItem = new SearchIndexItem({
+            productVariantId: 1,
+            languageCode: LanguageCode.en,
+            channelId: 1,
+            currencyCode: CurrencyCode.GBP,
+        });
+
+        expect(dedupeSearchIndexItems([usdItem, gbpItem], fourColumnPk)).toEqual([usdItem, gbpItem]);
+        expect(dedupeSearchIndexItems([usdItem, gbpItem], threeColumnPk)).toEqual([gbpItem]);
+    });
+});

--- a/packages/core/src/plugin/default-search-plugin/indexer/index-item-utils.ts
+++ b/packages/core/src/plugin/default-search-plugin/indexer/index-item-utils.ts
@@ -1,0 +1,24 @@
+import { SearchIndexItem } from '../entities/search-index-item.entity';
+
+/**
+ * Deduplicates the given SearchIndexItems by their composite primary key, keeping the last
+ * occurrence of each key. The primary key properties are passed in rather than hard-coded
+ * because the primary key of the SearchIndexItem entity is dynamic: the `indexCurrencyCode`
+ * option of the DefaultSearchPlugin adds `currencyCode` as a fourth primary column.
+ *
+ * Deduplication is a prerequisite for persisting a batch with `upsert()`: postgres rejects
+ * an INSERT ... ON CONFLICT DO UPDATE statement which affects the same row more than once.
+ */
+export function dedupeSearchIndexItems(
+    items: SearchIndexItem[],
+    primaryKeyProperties: string[],
+): SearchIndexItem[] {
+    const itemsByPrimaryKey = new Map<string, SearchIndexItem>();
+    for (const item of items) {
+        const primaryKey = primaryKeyProperties
+            .map(property => String(item[property as keyof SearchIndexItem]))
+            .join(':');
+        itemsByPrimaryKey.set(primaryKey, item);
+    }
+    return Array.from(itemsByPrimaryKey.values());
+}

--- a/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
+++ b/packages/core/src/plugin/default-search-plugin/indexer/indexer.controller.ts
@@ -36,6 +36,7 @@ import {
     VariantChannelMessageData,
 } from '../types';
 
+import { dedupeSearchIndexItems } from './index-item-utils';
 import { MutableRequestContext } from './mutable-request-context';
 
 export const BATCH_SIZE = 1000;
@@ -375,6 +376,10 @@ export class IndexerController {
             where,
             take,
             skip,
+            // Ordering makes the take/skip pagination deterministic, otherwise variants
+            // can be repeated or skipped across batches when the catalog is concurrently
+            // modified during a reindex.
+            order: { id: 'ASC' },
             relationLoadStrategy: 'query',
         });
         return { variants, count };
@@ -509,9 +514,7 @@ export class IndexerController {
         }
         ctx.setChannel(originalChannel);
 
-        await this.queue.push(() =>
-            this.connection.getRepository(ctx, SearchIndexItem).save(items, { chunk: 2500 }),
-        );
+        await this.queue.push(() => this.upsertSearchIndexItems(ctx, items));
     }
 
     /**
@@ -546,7 +549,32 @@ export class IndexerController {
             collectionIds: [],
             collectionSlugs: [],
         });
-        await this.queue.push(() => this.connection.getRepository(ctx, SearchIndexItem).save(item));
+        await this.queue.push(() => this.upsertSearchIndexItems(ctx, [item]));
+    }
+
+    /**
+     * Persists the given items with an atomic upsert on the composite primary key, so that
+     * concurrent index writes (e.g. a reindex racing an update job in another worker process,
+     * or synthetic variant-less product rows, which all share `productVariantId: 0`) converge
+     * on the latest state rather than throwing a duplicate-key error, as the non-atomic
+     * check-then-insert of `save()` does.
+     * See https://github.com/vendurehq/vendure/issues/4805
+     */
+    private async upsertSearchIndexItems(ctx: RequestContext, items: SearchIndexItem[]) {
+        // The primary key is derived from the entity metadata because it is dynamic:
+        // the `indexCurrencyCode` option adds `currencyCode` as a fourth primary column.
+        const primaryKeyProperties = this.connection.rawConnection
+            .getMetadata(SearchIndexItem)
+            .primaryColumns.map(column => column.propertyName);
+        const dedupedItems = dedupeSearchIndexItems(items, primaryKeyProperties);
+        const repository = this.connection.getRepository(ctx, SearchIndexItem);
+        // A SearchIndexItem row binds ~24 parameters, so 500 rows per statement stays
+        // safely within the bound-parameter limits of all supported drivers (the lowest
+        // being sqlite's 32766).
+        const chunkSize = 500;
+        for (let i = 0; i < dedupedItems.length; i += chunkSize) {
+            await repository.upsert(dedupedItems.slice(i, i + chunkSize), primaryKeyProperties);
+        }
     }
 
     /**


### PR DESCRIPTION
# Description

Fixes #4805 — intermittent `QueryFailedError: duplicate key value violates unique constraint "PK_6470dd…"` on `search_index_item`, observed in our production instance (26 occurrences over ~3 weeks across `reindex` and `update-variants` jobs).

## Root causes

All in `IndexerController`:

1. **Unordered pagination** — `getSearchIndexQueryBuilder()` paginates the reindex with `take`/`skip` but no `order`, so (especially on postgres) variants can repeat or be skipped across batches under concurrent catalog writes, putting the same `(productVariantId, languageCode, channelId)` tuple into one batch twice. `save()` then classifies both occurrences as inserts and the chunked `INSERT` violates the PK deterministically.
2. **Non-atomic write** — `saveVariants()` persists with `repository.save(items, { chunk: 2500 })`, a check-then-insert. The `AsyncQueue` only serializes writes within one process, so index jobs running in separate worker processes race each other between the existence check and the `INSERT`.
3. **Synthetic variants share a primary key** — `saveSyntheticVariant()` rows all use `productVariantId: 0`, so variant-less products in the same channel/language collide on the PK whenever their writes race.

## The fix

- Add `order: { id: 'ASC' }` to the pagination query so batches are deterministic — in-batch duplicates are no longer generated in the first place.
- Replace both `save()` call sites with a chunked `repository.upsert()` so any remaining collision converges on the latest state instead of failing the whole indexing job. The conflict target is **derived from the entity's primary-column metadata**, so the dynamic fourth primary column added by `indexCurrencyCode: true` is handled automatically. (Precedent for `upsert()` in core: `DefaultCachePlugin`'s `sql-cache-strategy.ts`, which already runs on the sqljs e2e driver.)
- Dedupe each batch by the composite key (last write wins) before upserting. This is a correctness requirement rather than polish: postgres rejects an `INSERT … ON CONFLICT DO UPDATE` that affects the same row twice ("ON CONFLICT DO UPDATE command cannot affect row a second time"), so upsert without dedupe would trade one error for another.
- Chunk size is 500 (replacing `{ chunk: 2500 }`): a `SearchIndexItem` row binds ~24 parameters, so 500 rows ≈ 12k bound parameters per statement, safely within the limits of all supported drivers (the lowest being sqlite's 32766, which 2500 rows would exceed).

Persisted data is otherwise unchanged: `upsert()` routes values through the same column transformers as `save()`, the entity has no version/updatedAt columns, both call sites ignore the return value, and TypeORM's default `orUpdate` refreshes all non-conflict columns — the same full-row result as `save()`. On MySQL/MariaDB, `ON DUPLICATE KEY UPDATE` fires on any unique key, but the entity's only unique constraint is the PK, so the behavior matches pg/sqlite `ON CONFLICT`.

## Tests

- New unit spec for `dedupeSearchIndexItems()`: 3-column key, last-write-wins, the synthetic `productVariantId: 0` case, and the 4-column key with `currencyCode`. This deterministically covers the in-batch duplicate class that previously always threw.
- New e2e tests: indexing a second variant-less product completes without failing the job, and running `reindex` twice converges to identical results. To be transparent about their scope: the cross-process races aren't reproducible in single-process vitest (pre-fix, the colliding synthetic write happens to resolve as a serial update there), so these assert the post-fix invariants and exercise the new upsert write path on every driver in the CI matrix, rather than failing pre-fix.

The same fix (with a hardcoded 3-column conflict target) has been running as a `pnpm patch` in our production instance since 2026-06-05: 26 Sentry occurrences before, zero after.

# Breaking changes

None. No schema change, no migration, no API change. Upserts update rows in place, so there is no window where previously-indexed items disappear from search results.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4809"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783326307&installation_id=128408429&pr_number=4809&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4809&signature=46c5a86b0a67ea010fc5e5213d3ed525e65c110e361c6991ca3f5e3dee5d8b02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->