### PR TITLE
fix(dashboard): Set default addresses when selecting customer on draft order

### DIFF
--- a/packages/dashboard/e2e/tests/sales/orders.spec.ts
+++ b/packages/dashboard/e2e/tests/sales/orders.spec.ts
@@ -157,6 +157,80 @@ test.describe('Orders', () => {
         await expect(page.getByTestId('page-heading')).toBeVisible();
     });
 
+    // selecting a customer on a draft order should populate the order's addresses
+    // from the customer's default addresses (parity with the Angular admin-ui, see #3196)
+    test('should populate default addresses when selecting a customer', async ({ page }) => {
+        test.setTimeout(60_000);
+
+        const client = new VendureAdminClient(page);
+        await client.login();
+
+        // Create a customer whose address is flagged as default shipping & billing.
+        // The seeded e2e customers have addresses without default flags.
+        const { createCustomer } = await client.gql(
+            `mutation ($input: CreateCustomerInput!) {
+                createCustomer(input: $input) {
+                    ... on Customer { id }
+                    ... on ErrorResult { errorCode message }
+                }
+            }`,
+            {
+                input: {
+                    firstName: 'Daphne',
+                    lastName: 'Defaults',
+                    emailAddress: `daphne.defaults.${Date.now()}@test.com`,
+                },
+            },
+        );
+        await client.gql(
+            `mutation ($customerId: ID!, $input: CreateAddressInput!) {
+                createCustomerAddress(customerId: $customerId, input: $input) { id }
+            }`,
+            {
+                customerId: createCustomer.id,
+                input: {
+                    fullName: 'Daphne Defaults',
+                    streetLine1: '42 Default Lane',
+                    city: 'Defaultville',
+                    postalCode: 'D1 1AA',
+                    countryCode: 'GB',
+                    defaultShippingAddress: true,
+                    defaultBillingAddress: true,
+                },
+            },
+        );
+
+        // Create a draft order and select the customer
+        const lp = listPage(page);
+        await lp.goto();
+        await lp.expectLoaded();
+        await lp.newButton.click();
+        await expect(page).toHaveURL(/\/orders\/draft\//, { timeout: 10_000 });
+
+        await page.getByRole('button', { name: /Select customer/i }).click();
+        await page.getByPlaceholder('Search customers...').fill('daphne');
+        // The customer list is debounced, so wait for the matching option
+        // rather than clicking the first one (which may be from a stale list)
+        const daphneOption = page.getByRole('option').filter({ hasText: 'Daphne Defaults' });
+        await expect(daphneOption.first()).toBeVisible({ timeout: 5_000 });
+        await daphneOption.first().click();
+
+        // Both the shipping and billing address blocks should be populated
+        // from the customer's default address
+        await expect(page.getByText('42 Default Lane')).toHaveCount(2, { timeout: 10_000 });
+
+        // Switching to a customer without default addresses should clear them again
+        await page.getByRole('button', { name: /Select customer/i }).click();
+        await page.getByPlaceholder('Search customers...').fill('hayden');
+        const haydenOption = page.getByRole('option').filter({ hasText: /hayden/i });
+        await expect(haydenOption.first()).toBeVisible({ timeout: 5_000 });
+        await haydenOption.first().click();
+
+        await expect(page.getByText('42 Default Lane')).toHaveCount(0, { timeout: 10_000 });
+        // The manual address selectors should be offered again
+        await expect(page.getByRole('button', { name: /Select address/i })).toHaveCount(2);
+    });
+
     // #4393 — custom order history entry types should be displayed with key-value data
     test('should display custom order history entry types', async ({ page }) => {
         test.setTimeout(60_000);

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx
@@ -2,27 +2,14 @@ import { Button } from '@/vdb/components/ui/button.js';
 import { Card } from '@/vdb/components/ui/card.js';
 import { Popover, PopoverContent, PopoverTrigger } from '@/vdb/components/ui/popover.js';
 import { api } from '@/vdb/graphql/api.js';
-import { graphql, ResultOf } from '@/vdb/graphql/graphql.js';
+import { ResultOf } from '@/vdb/graphql/graphql.js';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { cn } from '@/vdb/lib/utils.js';
 import { useQuery } from '@tanstack/react-query';
 import { Plus } from 'lucide-react';
 import { useState } from 'react';
 import { addressFragment } from '../../_customers/customers.graphql.js';
-
-const getCustomerAddressesDocument = graphql(
-    `
-        query GetCustomerAddresses($customerId: ID!) {
-            customer(id: $customerId) {
-                id
-                addresses {
-                    ...Address
-                }
-            }
-        }
-    `,
-    [addressFragment],
-);
+import { getCustomerAddressesDocument } from '../orders.graphql.js';
 
 type CustomerAddressesQuery = ResultOf<typeof getCustomerAddressesDocument>;
 

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/orders.graphql.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/orders.graphql.ts
@@ -5,6 +5,8 @@ import {
 } from '@/vdb/graphql/fragments.js';
 import { graphql } from '@/vdb/graphql/graphql.js';
 
+import { addressFragment } from '../_customers/customers.graphql.js';
+
 export const orderListDocument = graphql(`
     query GetOrders($options: OrderListOptions) {
         orders(options: $options) {
@@ -408,12 +410,29 @@ export const setCustomerForDraftOrderDocument = graphql(
                 __typename
                 ... on Order {
                     id
+                    customer {
+                        id
+                    }
                 }
                 ...ErrorResult
             }
         }
     `,
     [errorResultFragment],
+);
+
+export const getCustomerAddressesDocument = graphql(
+    `
+        query GetCustomerAddresses($customerId: ID!) {
+            customer(id: $customerId) {
+                id
+                addresses {
+                    ...Address
+                }
+            }
+        }
+    `,
+    [addressFragment],
 );
 
 export const setShippingAddressForDraftOrderDocument = graphql(`

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
@@ -26,12 +26,14 @@ import { CustomerAddressSelector } from './components/customer-address-selector.
 import { DraftOrderStatus } from './components/draft-order-status.js';
 import { EditOrderTable } from './components/edit-order-table.js';
 import { OrderAddress } from './components/order-address.js';
+import { addressFragment } from '../_customers/customers.graphql.js';
 import {
     addItemToDraftOrderDocument,
     adjustDraftOrderLineDocument,
     applyCouponCodeToDraftOrderDocument,
     deleteDraftOrderDocument,
     draftOrderEligibleShippingMethodsDocument,
+    getCustomerAddressesDocument,
     orderDetailDocument,
     removeCouponCodeFromDraftOrderDocument,
     removeDraftOrderLineDocument,
@@ -163,22 +165,47 @@ function DraftOrderPage() {
 
     const { mutate: setCustomerForDraftOrder } = useMutation({
         mutationFn: api.mutate(setCustomerForDraftOrderDocument),
-        onSuccess: (result: ResultOf<typeof setCustomerForDraftOrderDocument>) => {
+        onSuccess: async (result: ResultOf<typeof setCustomerForDraftOrderDocument>) => {
             const order = result.setCustomerForDraftOrder;
             switch (order.__typename) {
-                case 'Order':
+                case 'Order': {
                     toast.success(t`Customer set for order`);
 
-                    // When we change the customer, we should clear
-                    // any selected shipping/billing address
-                    if (entity?.shippingAddress) {
-                        unsetShippingAddressForDraftOrder({ orderId: entity.id });
+                    // When the customer changes, populate the shipping/billing
+                    // addresses from the customer's default addresses, or clear
+                    // any previously selected address if there is no default
+                    let addresses: Array<ResultOf<typeof addressFragment>> = [];
+                    if (order.customer) {
+                        const { customer } = await api.query(getCustomerAddressesDocument, {
+                            customerId: order.customer.id,
+                        });
+                        addresses = customer?.addresses ?? [];
                     }
-                    if (entity?.billingAddress) {
-                        unsetBillingAddressForDraftOrder({ orderId: entity.id });
+                    const defaultShippingAddress = addresses.find(
+                        address => address.defaultShippingAddress,
+                    );
+                    const defaultBillingAddress = addresses.find(
+                        address => address.defaultBillingAddress,
+                    );
+                    if (defaultShippingAddress) {
+                        setShippingAddressForDraftOrder({
+                            orderId: order.id,
+                            input: mapToAddressInput(defaultShippingAddress),
+                        });
+                    } else if (entity?.shippingAddress) {
+                        unsetShippingAddressForDraftOrder({ orderId: order.id });
+                    }
+                    if (defaultBillingAddress) {
+                        setBillingAddressForDraftOrder({
+                            orderId: order.id,
+                            input: mapToAddressInput(defaultBillingAddress),
+                        });
+                    } else if (entity?.billingAddress) {
+                        unsetBillingAddressForDraftOrder({ orderId: order.id });
                     }
                     refreshEntity();
                     break;
+                }
                 default:
                     toast.error(order.message);
                     break;
@@ -481,17 +508,7 @@ function DraftOrderPage() {
                                     onSelect={address => {
                                         setShippingAddressForDraftOrder({
                                             orderId: entity.id,
-                                            input: {
-                                                fullName: address.fullName,
-                                                company: address.company,
-                                                streetLine1: address.streetLine1,
-                                                streetLine2: address.streetLine2,
-                                                city: address.city,
-                                                province: address.province,
-                                                postalCode: address.postalCode,
-                                                countryCode: address.country.code,
-                                                phoneNumber: address.phoneNumber,
-                                            },
+                                            input: mapToAddressInput(address),
                                         });
                                     }}
                                 />
@@ -513,17 +530,7 @@ function DraftOrderPage() {
                                     onSelect={address => {
                                         setBillingAddressForDraftOrder({
                                             orderId: entity.id,
-                                            input: {
-                                                fullName: address.fullName,
-                                                company: address.company,
-                                                streetLine1: address.streetLine1,
-                                                streetLine2: address.streetLine2,
-                                                city: address.city,
-                                                province: address.province,
-                                                postalCode: address.postalCode,
-                                                countryCode: address.country.code,
-                                                phoneNumber: address.phoneNumber,
-                                            },
+                                            input: mapToAddressInput(address),
                                         });
                                     }}
                                 />
@@ -534,6 +541,22 @@ function DraftOrderPage() {
             </PageLayout>
         </Page>
     );
+}
+
+function mapToAddressInput(address: ResultOf<typeof addressFragment>) {
+    return {
+        fullName: address.fullName,
+        company: address.company,
+        streetLine1: address.streetLine1,
+        streetLine2: address.streetLine2,
+        city: address.city,
+        province: address.province,
+        postalCode: address.postalCode,
+        countryCode: address.country.code,
+        phoneNumber: address.phoneNumber,
+        defaultShippingAddress: address.defaultShippingAddress,
+        defaultBillingAddress: address.defaultBillingAddress,
+    };
 }
 
 function RemoveAddressButton(props: { onClick: () => void }) {

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx
@@ -187,21 +187,34 @@ function DraftOrderPage() {
                     const defaultBillingAddress = addresses.find(
                         address => address.defaultBillingAddress,
                     );
-                    if (defaultShippingAddress) {
-                        setShippingAddressForDraftOrder({
-                            orderId: order.id,
-                            input: mapToAddressInput(defaultShippingAddress),
-                        });
-                    } else if (entity?.shippingAddress) {
-                        unsetShippingAddressForDraftOrder({ orderId: order.id });
-                    }
-                    if (defaultBillingAddress) {
-                        setBillingAddressForDraftOrder({
-                            orderId: order.id,
-                            input: mapToAddressInput(defaultBillingAddress),
-                        });
-                    } else if (entity?.billingAddress) {
-                        unsetBillingAddressForDraftOrder({ orderId: order.id });
+                    // Sequence the address mutations: they all mutate the same
+                    // version-tracked Order, so firing them concurrently makes
+                    // the second read a stale version and fail with an
+                    // optimistic-lock error ("Record has changed since last
+                    // read"). Await each in turn, then refresh once at the end.
+                    try {
+                        if (defaultShippingAddress) {
+                            await api.mutate(setShippingAddressForDraftOrderDocument)({
+                                orderId: order.id,
+                                input: mapToAddressInput(defaultShippingAddress),
+                            });
+                        } else if (entity?.shippingAddress) {
+                            await api.mutate(unsetShippingAddressForDraftOrderDocument)({
+                                orderId: order.id,
+                            });
+                        }
+                        if (defaultBillingAddress) {
+                            await api.mutate(setBillingAddressForDraftOrderDocument)({
+                                orderId: order.id,
+                                input: mapToAddressInput(defaultBillingAddress),
+                            });
+                        } else if (entity?.billingAddress) {
+                            await api.mutate(unsetBillingAddressForDraftOrderDocument)({
+                                orderId: order.id,
+                            });
+                        }
+                    } catch (e) {
+                        toast.error(t`Failed to set address for order: ${e instanceof Error ? e.message : String(e)}`);
                     }
                     refreshEntity();
                     break;


### PR DESCRIPTION
# Description

## Summary

In the Angular Admin UI, selecting a customer on a draft order automatically populates the order's shipping and billing addresses from the customer's default addresses (added in v3.1.0 via #3196, closing #2342). This behavior was forgotten when the draft order page was reimplemented for the React dashboard: only the *clear-addresses-on-customer-change* half was ported. The `setCustomerForDraftOrder` `onSuccess` handler in `orders_.draft.$id.tsx` unconditionally unsets any previously-set addresses and never looks up the new customer's defaults — so selecting a customer always leaves the draft with no addresses, even when defaults are flagged.

This PR ports the admin-ui logic (`draft-order-detail.component.ts` → `setCustomer()`): after the customer is set, fetch the customer's addresses, then set the flagged default shipping/billing address on the draft order — or clear the previously-set address if the new customer has no default, so changing customers never leaves the old customer's address behind.

One small deviation from the admin-ui version: where admin-ui always fires set-or-unset, this only calls unset when an address was actually set before (preserving the dashboard's existing guard), avoiding redundant mutations and spurious "address unset" toasts on fresh drafts. The end state is identical in all cases.

## Changes

- `orders_.draft.$id.tsx`: on `setCustomerForDraftOrder` success, query the customer's addresses and call `setDraftOrderShippingAddress`/`setDraftOrderBillingAddress` with the flagged defaults, falling back to the existing unset behavior when no default exists. Extracts a `mapToAddressInput()` helper (same field mapping as admin-ui's, incl. the `defaultShippingAddress`/`defaultBillingAddress` flags) which also replaces the two duplicated inline mappings in the manual address-select paths.
- `orders.graphql.ts`: add `customer { id }` to the `SetCustomerForDraftOrder` selection set; move the `GetCustomerAddresses` document here from `customer-address-selector.tsx` so the page and the selector share one definition.
- `e2e/tests/sales/orders.spec.ts`: regression test — selecting a customer with flagged default addresses populates both address blocks; switching to a customer without defaults clears them and offers the manual selectors again.

A nice side effect: since the shipping address is now set right after customer selection, eligible shipping methods appear immediately, removing a manual step from the draft order flow.

# Breaking changes

None. Dashboard-only behavioral fix restoring Admin UI parity.

# Screenshots

Selecting a customer with default addresses on a fresh draft order now populates both address blocks (previously both remained "No address").

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

## Test plan

- New e2e test fails on `master` without the fix, passes with it
- Full `e2e/tests/sales/orders.spec.ts` suite passes (15/15) — the seeded e2e customers have no default-flagged addresses, so the existing manual address-select flow is unaffected
- Manually verified against the dev-server (sqlite): defaults populate on first selection; switching to a customer without defaults clears both addresses; a customer change replaces a previously-set address with the new customer's defaults; manual address selection still works
- `bun run check-types` clean

Relates to #2342 / #3196 (the admin-ui implementation of this behavior).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783352746&installation_id=128408429&pr_number=4810&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4810&signature=592bbfe2b4d8684819412b2f710f26dac1fd34e6bdd8d3f33dd76edeea481238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->