### PR TITLE
fix(dashboard): navigate to list page on channel switch when on detail page

### DIFF
--- a/packages/dashboard/src/lib/components/layout/channel-switcher.tsx
+++ b/packages/dashboard/src/lib/components/layout/channel-switcher.tsx
@@ -24,7 +24,7 @@ import { useSortedLanguages } from '@/vdb/hooks/use-sorted-languages.js';
 import { useUserSettings } from '@/vdb/hooks/use-user-settings.js';
 import { cn } from '@/vdb/lib/utils.js';
 import { Trans } from '@lingui/react/macro';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate, useRouterState } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { ManageLanguagesDialog } from './manage-languages-dialog.js';
 
@@ -58,6 +58,8 @@ export function ChannelSwitcher() {
         setContentLanguage,
     } = useUserSettings();
     const [showManageLanguagesDialog, setShowManageLanguagesDialog] = useState(false);
+    const navigate = useNavigate();
+    const currentPath = useRouterState({ select: s => s.location.pathname });
     const displayChannel = activeChannel;
 
     // Get available languages from server config
@@ -82,7 +84,18 @@ export function ChannelSwitcher() {
 
     const renderChannel = (channel: (typeof channels)[number]) => (
         <div key={channel.code}>
-            <DropdownMenuItem onClick={() => setActiveChannel(channel.id)} className="gap-2 p-2">
+            <DropdownMenuItem
+                onClick={() => {
+                    if (channel.id !== displayChannel?.id) {
+                        setActiveChannel(channel.id);
+                        const segments = currentPath.split('/').filter(Boolean);
+                        if (segments.length > 1) {
+                            navigate({ to: `/${segments[0]}` as any });
+                        }
+                    }
+                }}
+                className="gap-2 p-2"
+            >
                 <div
                     className={cn(
                         'flex size-8 items-center justify-center rounded border',

--- a/packages/dashboard/src/lib/components/layout/channel-switcher.tsx
+++ b/packages/dashboard/src/lib/components/layout/channel-switcher.tsx
@@ -24,7 +24,7 @@ import { useSortedLanguages } from '@/vdb/hooks/use-sorted-languages.js';
 import { useUserSettings } from '@/vdb/hooks/use-user-settings.js';
 import { cn } from '@/vdb/lib/utils.js';
 import { Trans } from '@lingui/react/macro';
-import { Link } from '@tanstack/react-router';
+import { Link, useNavigate, useRouter, useRouterState } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { ManageLanguagesDialog } from './manage-languages-dialog.js';
 
@@ -58,6 +58,9 @@ export function ChannelSwitcher() {
         setContentLanguage,
     } = useUserSettings();
     const [showManageLanguagesDialog, setShowManageLanguagesDialog] = useState(false);
+    const navigate = useNavigate();
+    const router = useRouter();
+    const currentPath = useRouterState({ select: s => s.location.pathname });
     const displayChannel = activeChannel;
 
     // Get available languages from server config
@@ -82,7 +85,20 @@ export function ChannelSwitcher() {
 
     const renderChannel = (channel: (typeof channels)[number]) => (
         <div key={channel.code}>
-            <DropdownMenuItem onClick={() => setActiveChannel(channel.id)} className="gap-2 p-2">
+            <DropdownMenuItem
+                onClick={() => {
+                    if (channel.id !== displayChannel?.id) {
+                        setActiveChannel(channel.id);
+                        const segments = currentPath.split('/').filter(Boolean);
+                        if (segments.length > 1 && channel.code !== DEFAULT_CHANNEL_CODE) {
+                            const target = `/${segments[0]}`;
+                            const exists = router.matchRoutes(target).length > 0;
+                            navigate({ to: (exists ? target : '/') as any });
+                        }
+                    }
+                }}
+                className="gap-2 p-2"
+            >
                 <div
                     className={cn(
                         'flex size-8 items-center justify-center rounded border',

--- a/packages/dashboard/src/lib/components/layout/channel-switcher.tsx
+++ b/packages/dashboard/src/lib/components/layout/channel-switcher.tsx
@@ -24,7 +24,7 @@ import { useSortedLanguages } from '@/vdb/hooks/use-sorted-languages.js';
 import { useUserSettings } from '@/vdb/hooks/use-user-settings.js';
 import { cn } from '@/vdb/lib/utils.js';
 import { Trans } from '@lingui/react/macro';
-import { Link, useNavigate, useRouterState } from '@tanstack/react-router';
+import { Link } from '@tanstack/react-router';
 import { useEffect, useState } from 'react';
 import { ManageLanguagesDialog } from './manage-languages-dialog.js';
 
@@ -58,8 +58,6 @@ export function ChannelSwitcher() {
         setContentLanguage,
     } = useUserSettings();
     const [showManageLanguagesDialog, setShowManageLanguagesDialog] = useState(false);
-    const navigate = useNavigate();
-    const currentPath = useRouterState({ select: s => s.location.pathname });
     const displayChannel = activeChannel;
 
     // Get available languages from server config
@@ -84,18 +82,7 @@ export function ChannelSwitcher() {
 
     const renderChannel = (channel: (typeof channels)[number]) => (
         <div key={channel.code}>
-            <DropdownMenuItem
-                onClick={() => {
-                    if (channel.id !== displayChannel?.id) {
-                        setActiveChannel(channel.id);
-                        const segments = currentPath.split('/').filter(Boolean);
-                        if (segments.length > 1 && channel.code !== DEFAULT_CHANNEL_CODE) {
-                            navigate({ to: `/${segments[0]}` as any });
-                        }
-                    }
-                }}
-                className="gap-2 p-2"
-            >
+            <DropdownMenuItem onClick={() => setActiveChannel(channel.id)} className="gap-2 p-2">
                 <div
                     className={cn(
                         'flex size-8 items-center justify-center rounded border',

--- a/packages/dashboard/src/lib/components/layout/channel-switcher.tsx
+++ b/packages/dashboard/src/lib/components/layout/channel-switcher.tsx
@@ -89,7 +89,7 @@ export function ChannelSwitcher() {
                     if (channel.id !== displayChannel?.id) {
                         setActiveChannel(channel.id);
                         const segments = currentPath.split('/').filter(Boolean);
-                        if (segments.length > 1) {
+                        if (segments.length > 1 && channel.code !== DEFAULT_CHANNEL_CODE) {
                             navigate({ to: `/${segments[0]}` as any });
                         }
                     }


### PR DESCRIPTION
## What's the bug

When you're on a detail page (like /orders/ABC-123) and switch channels,
the router re-runs the loader for that same URL with the new channel token.
That order belongs to the old channel so the API returns null, the loader
throws, and you land on a broken error screen. Only a full page refresh
gets you out.

## Why it happens

The router doesn't know the channel changed. it just tries to reload
whatever URL you're currently on. But that entity doesn't exist in the
new channel, so it crashes.

## What the fix does

When you switch to a different channel, we check if you're on a detail
page. If you are, we navigate to the parent list before the loader runs:

- /orders/ABC-123 → /orders
- /products/XYZ → /products
- /customers/123 → /customers

If you're already on a list page, nothing changes, the list just
refetches with the new channel token automatically.

## What else this fixes

The same crash was happening across all detail pages, orders, products,
customers, collections, promotions. This one change covers all of them
since the logic is purely URL-based, no entity-specific code needed.

Fixes #4826


https://github.com/user-attachments/assets/fc9b5685-73e2-4f7f-8a83-d9621ab08fd5



<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783682764&installation_id=128408429&pr_number=4827&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4827&signature=4b3067d8ab5acc430624422947024b6672af6105121e3814c77f9afa1d9f1cf8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->