### PR TITLE
fix(dashboard): render full-width PageBlock with column="full"

### DIFF
--- a/docs/docs/guides/extending-the-dashboard/creating-pages/index.mdx
+++ b/docs/docs/guides/extending-the-dashboard/creating-pages/index.mdx
@@ -44,6 +44,59 @@ components internally use this same structure, so when using those top-level com
 in `Page` etc.
 :::
 
+## Block Columns
+
+The `PageLayout` arranges its `PageBlock` children into columns based on each block's `column` prop:
+
+- **`main`**: the wider main content area
+- **`side`**: the narrower sidebar
+- **`full`**: spans the full width of the layout, above the main/side columns
+
+```tsx title="src/plugins/example/dashboard/test-page.tsx"
+import { Page, PageBlock, PageLayout, PageTitle } from '@vendure/dashboard';
+
+export function TestPage() {
+    return (
+        <Page pageId="test-page">
+            <PageTitle>Test Page</PageTitle>
+            <PageLayout>
+                <PageBlock column="full" blockId="full-stuff">
+                    This block spans the full width
+                </PageBlock>
+                <PageBlock column="main" blockId="main-stuff">
+                    This will display in the main area
+                </PageBlock>
+                <PageBlock column="side" blockId="side-stuff">
+                    This will display in the side area
+                </PageBlock>
+            </PageLayout>
+        </Page>
+    );
+}
+```
+
+:::info
+Full-width blocks are always rendered **above** the `main`/`side` columns, regardless of their
+order among the `PageLayout` children. This makes `column="full"` well-suited to wide content such
+as data tables on list pages.
+:::
+
+### Full-width without a card
+
+A `PageBlock` wraps its content in a bordered card. If you want a full-width block with **no** card
+chrome — for example, a block that supplies its own container such as a `DataTable` — use the
+[FullWidthPageBlock](/reference/dashboard/page-layout/page-block) component instead:
+
+```tsx
+import { FullWidthPageBlock, Page, PageLayout, PageTitle } from '@vendure/dashboard';
+
+<PageLayout>
+    <FullWidthPageBlock blockId="list-table">
+        <DataTable /* ... */ />
+    </FullWidthPageBlock>
+</PageLayout>
+```
+
 ## Page Routes & Navigation
 
 Once you have defined a page component, you'll need to make it accessible to users with:

--- a/docs/docs/reference/dashboard/page-layout/index.mdx
+++ b/docs/docs/reference/dashboard/page-layout/index.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageLayout
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="218" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="228" packageName="@vendure/dashboard" since="3.3.0" />
 
 *
 This component governs the layout of the contents of a [Page](/reference/dashboard/page-layout/page#page) component.

--- a/docs/docs/reference/dashboard/page-layout/page-action-bar.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-action-bar.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageActionBar
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="389" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="403" packageName="@vendure/dashboard" since="3.3.0" />
 
 A component for displaying the main actions for a page. This should be used inside the [Page](/reference/dashboard/page-layout/page#page) component.
 
@@ -117,7 +117,7 @@ Parameters
 
 ## PageActionBarLeft
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="533" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="547" packageName="@vendure/dashboard" since="3.3.0" />
 
 The PageActionBarLeft component is not used and will be removed in a future version.
 
@@ -132,7 +132,7 @@ Parameters
 
 ## PageActionBarRight
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="773" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="787" packageName="@vendure/dashboard" since="3.3.0" />
 
 The PageActionBarRight component is used to display the right content of the action bar.
 

--- a/docs/docs/reference/dashboard/page-layout/page-action-bar.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-action-bar.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageActionBar
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="387" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="389" packageName="@vendure/dashboard" since="3.3.0" />
 
 A component for displaying the main actions for a page. This should be used inside the [Page](/reference/dashboard/page-layout/page#page) component.
 
@@ -117,7 +117,7 @@ Parameters
 
 ## PageActionBarLeft
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="531" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="533" packageName="@vendure/dashboard" since="3.3.0" />
 
 The PageActionBarLeft component is not used and will be removed in a future version.
 
@@ -132,7 +132,7 @@ Parameters
 
 ## PageActionBarRight
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="771" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="773" packageName="@vendure/dashboard" since="3.3.0" />
 
 The PageActionBarRight component is used to display the right content of the action bar.
 

--- a/docs/docs/reference/dashboard/page-layout/page-block.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-block.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="886" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="888" packageName="@vendure/dashboard" since="3.3.0" />
 
 *
 A component for displaying a block of content on a page. This should be used inside the [PageLayout](/reference/dashboard/page-layout/#pagelayout) component.
@@ -30,7 +30,7 @@ Parameters
 
 ## PageBlockProps
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="835" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="837" packageName="@vendure/dashboard" since="3.3.0" />
 
 Props used to configure the [PageBlock](/reference/dashboard/page-layout/page-block#pageblock) component.
 

--- a/docs/docs/reference/dashboard/page-layout/page-block.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-block.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="888" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="902" packageName="@vendure/dashboard" since="3.3.0" />
 
 *
 A component for displaying a block of content on a page. This should be used inside the [PageLayout](/reference/dashboard/page-layout/#pagelayout) component.
@@ -30,7 +30,7 @@ Parameters
 
 ## PageBlockProps
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="837" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="851" packageName="@vendure/dashboard" since="3.3.0" />
 
 Props used to configure the [PageBlock](/reference/dashboard/page-layout/page-block#pageblock) component.
 
@@ -82,7 +82,7 @@ An optional set of CSS classes to apply to the block.
 </div>
 ## FullWidthPageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="933" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="947" packageName="@vendure/dashboard" since="3.3.0" />
 
 **Status: Developer Preview**
 
@@ -100,7 +100,7 @@ Parameters
 
 ## CustomFieldsPageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="963" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="977" packageName="@vendure/dashboard" since="3.3.0" />
 
 *
 A component for displaying an auto-generated form for custom fields on a page.

--- a/docs/docs/reference/dashboard/page-layout/page-title.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-title.mdx
@@ -2,7 +2,7 @@
 title: "PageTitle"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="352" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="354" packageName="@vendure/dashboard" since="3.3.0" />
 
 A component for displaying the title of a page. This should be used inside the [Page](/reference/dashboard/page-layout/page#page) component.
 

--- a/docs/docs/reference/dashboard/page-layout/page-title.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-title.mdx
@@ -2,7 +2,7 @@
 title: "PageTitle"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="354" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="368" packageName="@vendure/dashboard" since="3.3.0" />
 
 A component for displaying the title of a page. This should be used inside the [Page](/reference/dashboard/page-layout/page#page) component.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -532,7 +532,7 @@
               "lastModified": "2026-02-12T16:47:03+01:00"
             }
           ],
-          "lastModified": "2026-02-12T16:47:03+01:00"
+          "lastModified": "2026-06-12T09:41:23+02:00"
         },
         {
           "title": "Customizing Pages",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -4161,19 +4161,19 @@
                   "title": "PageActionBar",
                   "slug": "page-action-bar",
                   "file": "docs/reference/dashboard/page-layout/page-action-bar.mdx",
-                  "lastModified": "2026-05-08T12:27:16+02:00"
+                  "lastModified": "2026-06-12T07:43:34Z"
                 },
                 {
                   "title": "PageBlock",
                   "slug": "page-block",
                   "file": "docs/reference/dashboard/page-layout/page-block.mdx",
-                  "lastModified": "2026-05-08T12:27:16+02:00"
+                  "lastModified": "2026-06-12T07:43:34Z"
                 },
                 {
                   "title": "PageTitle",
                   "slug": "page-title",
                   "file": "docs/reference/dashboard/page-layout/page-title.mdx",
-                  "lastModified": "2026-05-08T12:27:16+02:00"
+                  "lastModified": "2026-06-12T07:43:34Z"
                 },
                 {
                   "title": "UsePageBlock",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -4161,19 +4161,19 @@
                   "title": "PageActionBar",
                   "slug": "page-action-bar",
                   "file": "docs/reference/dashboard/page-layout/page-action-bar.mdx",
-                  "lastModified": "2026-06-12T07:43:34Z"
+                  "lastModified": "2026-06-12T07:54:02Z"
                 },
                 {
                   "title": "PageBlock",
                   "slug": "page-block",
                   "file": "docs/reference/dashboard/page-layout/page-block.mdx",
-                  "lastModified": "2026-06-12T07:43:34Z"
+                  "lastModified": "2026-06-12T07:54:02Z"
                 },
                 {
                   "title": "PageTitle",
                   "slug": "page-title",
                   "file": "docs/reference/dashboard/page-layout/page-title.mdx",
-                  "lastModified": "2026-06-12T07:43:34Z"
+                  "lastModified": "2026-06-12T07:54:02Z"
                 },
                 {
                   "title": "UsePageBlock",
@@ -4182,7 +4182,7 @@
                   "lastModified": "2026-01-28T14:49:21+01:00"
                 }
               ],
-              "lastModified": "2026-05-08T12:27:16+02:00"
+              "lastModified": "2026-06-12T07:54:02Z"
             },
             {
               "title": "Vite Plugin",

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
@@ -234,6 +234,20 @@ describe('PageLayout', () => {
         ]);
     });
 
+    // A directly-authored full-width block must render inside PageLayout on desktop. Regression:
+    // the layout engine only routed the FullWidthPageBlock *type* into the full-width column, so a
+    // plain <PageBlock column="full"> matched none of the main/side/full filters and silently vanished.
+    it('renders a directly-authored PageBlock with column="full" on desktop', () => {
+        const markup = renderPageLayout(
+            <PageBlock column="full" blockId="full-block">
+                <div data-testid="page-block-full">full</div>
+            </PageBlock>,
+            { isDesktop: true },
+        );
+
+        expect(getRenderedBlockIds(markup)).toEqual(['page-block-full']);
+    });
+
     it("won't render blocks without required permissions", () => {
         hasPermissionsMock.mockReturnValue(false);
 

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
@@ -259,7 +259,9 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
             // using `hasPermissions` over `PermissionGuard` as this would defeat the `isPageBlock` typeguard
             const willBlockRender = (
                 block: ExtensionBlockEntry,
-            ): block is ExtensionBlockEntry & { component: NonNullable<ExtensionBlockEntry['component']> } => {
+            ): block is ExtensionBlockEntry & {
+                component: NonNullable<ExtensionBlockEntry['component']>;
+            } => {
                 if (!block.component) return false;
                 if (typeof block.shouldRender === 'function' && !block.shouldRender(page)) {
                     return false;
@@ -315,7 +317,7 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
     }
 
     const fullWidthBlocks = finalChildArray.filter(
-        child => isPageBlock(child) && isOfType(child, FullWidthPageBlock),
+        child => isPageBlock(child) && (isOfType(child, FullWidthPageBlock) || child.props.column === 'full'),
     );
     const mainBlocks = finalChildArray.filter(child => isPageBlock(child) && child.props.column === 'main');
     const sideBlocks = finalChildArray.filter(child => isPageBlock(child) && child.props.column === 'side');
@@ -903,9 +905,7 @@ export function PageBlock({
     return (
         <PageBlockContext.Provider value={contextValue}>
             <LocationWrapper>
-                <Card
-                    className={cn('@container  w-full', className, 'animate-in fade-in duration-300')}
-                >
+                <Card className={cn('@container  w-full', className, 'animate-in fade-in duration-300')}>
                     {title || description ? (
                         <CardHeader>
                             {title && <CardTitle>{title}</CardTitle>}

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
@@ -205,6 +205,16 @@ function isPageBlock(child: unknown): child is React.ReactElement<PageBlockProps
     return hasColumn || hasBlockId;
 }
 
+// Single source of truth for which column a block belongs to. `FullWidthPageBlock` is
+// identified by type since it doesn't declare a `column` prop; everything else is keyed
+// off the `column` prop. Keep all bucketing in `PageLayout` going through this.
+function getBlockColumn(child: React.ReactElement<PageBlockProps>): 'main' | 'side' | 'full' {
+    if (isOfType(child, FullWidthPageBlock)) {
+        return 'full';
+    }
+    return child.props.column;
+}
+
 /**
  * @description *
  * This component governs the layout of the contents of a {@link Page} component.
@@ -317,10 +327,14 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
     }
 
     const fullWidthBlocks = finalChildArray.filter(
-        child => isPageBlock(child) && (isOfType(child, FullWidthPageBlock) || child.props.column === 'full'),
+        child => isPageBlock(child) && getBlockColumn(child) === 'full',
     );
-    const mainBlocks = finalChildArray.filter(child => isPageBlock(child) && child.props.column === 'main');
-    const sideBlocks = finalChildArray.filter(child => isPageBlock(child) && child.props.column === 'side');
+    const mainBlocks = finalChildArray.filter(
+        child => isPageBlock(child) && getBlockColumn(child) === 'main',
+    );
+    const sideBlocks = finalChildArray.filter(
+        child => isPageBlock(child) && getBlockColumn(child) === 'side',
+    );
 
     return (
         <div className={cn('w-full space-y-4', className, '@container/layout')}>
@@ -935,7 +949,7 @@ export function FullWidthPageBlock({
     className,
     blockId,
 }: Readonly<Pick<PageBlockProps, 'children' | 'className' | 'blockId'>>) {
-    const contextValue = useMemo(() => ({ blockId, column: 'main' as const }), [blockId]);
+    const contextValue = useMemo(() => ({ blockId, column: 'full' as const }), [blockId]);
     return (
         <PageBlockContext.Provider value={contextValue}>
             <LocationWrapper>


### PR DESCRIPTION
A directly-authored `<PageBlock column="full">` was silently dropped on desktop when placed inside a `PageLayout`.

## Root cause

`PageLayout` separates its child blocks into three columns before rendering, but it does so asymmetrically:

```ts
const fullWidthBlocks = finalChildArray.filter(
    child => isPageBlock(child) && isOfType(child, FullWidthPageBlock), // matched by component TYPE
);
const mainBlocks = finalChildArray.filter(child => isPageBlock(child) && child.props.column === "main");
const sideBlocks = finalChildArray.filter(child => isPageBlock(child) && child.props.column === "side");
```

The full-width bucket is matched by component **type** (`FullWidthPageBlock`), whereas main/side are matched by the `column` **prop**. A plain `<PageBlock column="full">` is the `PageBlock` type, so it fails the `FullWidthPageBlock` check, and its column is `"full"`, so it also fails both `=== "main"` and `=== "side"`. It falls through all three filters and never gets rendered.

`PageBlockProps.column` explicitly lists `"full"` as a valid value, so TypeScript accepts `<PageBlock column="full">` with no error — the type promises something the layout engine did not honour. It only rendered when the surrounding `PageLayout` was removed (the filtering lives inside it) or on a mobile viewport (the mobile branch renders the blocks without bucketing).

## Fix

The full-width filter now also matches `column === "full"`:

```ts
const fullWidthBlocks = finalChildArray.filter(
    child => isPageBlock(child) && (isOfType(child, FullWidthPageBlock) || child.props.column === "full"),
);
```

This preserves a useful distinction:

- `<PageBlock column="full">` → full-width **card** (bordered chrome)
- `<FullWidthPageBlock>` → full-width **bare** `<div>`, for self-contained content such as a `DataTable`

## Changes

- **Fix**: `page-layout.tsx` full-width filter now matches the `column="full"` prop.
- **Test**: regression test in `page-layout.spec.tsx`, verified to fail before the fix (`expected [] to deeply equal [ "page-block-full" ]`) and pass after.
- **Docs**: new "Block Columns" section in the Creating Pages guide covering the three columns, full-width placement behaviour, and when to use `FullWidthPageBlock`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4829"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783842132&installation_id=128408429&pr_number=4829&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4829&signature=568f2318c44764cc255c1f63f1d91e47241ef5254952b4ea9c862e994a26900c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->