### PR TITLE
fix(dashboard): only send edited stock levels on variant update

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
@@ -127,10 +127,8 @@ function ProductVariantDetailPage() {
             };
         },
         transformUpdateInput: input => {
-            // Only send stock levels the admin actually edited. Core applies submitted
-            // stock as an absolute target relative to the current DB value, so resending
-            // unchanged page-load values would silently revert stock that changed
-            // concurrently (orders, another admin, integrations). See #4803.
+            // Only send stock levels the admin actually edited — see getChangedStockLevels
+            // and #4803 for why resending unchanged stock is destructive.
             const changedStockLevels = getChangedStockLevels(
                 input.stockLevels,
                 originalStockLevelsRef.current,

--- a/packages/dashboard/src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx
@@ -36,6 +36,7 @@ import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link, useNavigate } from '@tanstack/react-router';
 import { VariablesOf } from 'gql.tada';
 import { Edit2, Trash } from 'lucide-react';
+import { useEffect, useRef } from 'react';
 import { toast } from 'sonner';
 
 import { AddCurrencyDropdown } from './components/add-currency-dropdown.js';
@@ -47,6 +48,7 @@ import {
     stockLocationsQueryDocument,
     updateProductVariantDocument,
 } from './product-variants.graphql.js';
+import { getChangedStockLevels, StockLevelInput } from './utils/stock-levels.js';
 
 const pageId = 'product-variant-detail';
 
@@ -86,6 +88,10 @@ function ProductVariantDetailPage() {
         queryFn: () => api.query(stockLocationsQueryDocument, {}),
     });
 
+    // Holds the stock levels as loaded into the form, so the update transform can
+    // tell which ones the admin actually edited (see #4803).
+    const originalStockLevelsRef = useRef<StockLevelInput[] | undefined>(undefined);
+
     const { form, submitHandler, entity, isPending, resetForm } = useDetailPage({
         pageId,
         queryDocument: addCustomFields(productVariantDetailDocument, {
@@ -120,6 +126,21 @@ function ProductVariantDetailPage() {
                 customFields: entity.customFields,
             };
         },
+        transformUpdateInput: input => {
+            // Only send stock levels the admin actually edited. Core applies submitted
+            // stock as an absolute target relative to the current DB value, so resending
+            // unchanged page-load values would silently revert stock that changed
+            // concurrently (orders, another admin, integrations). See #4803.
+            const changedStockLevels = getChangedStockLevels(
+                input.stockLevels,
+                originalStockLevelsRef.current,
+            );
+            if (changedStockLevels.length === 0) {
+                const { stockLevels: _omittedStockLevels, ...rest } = input;
+                return rest;
+            }
+            return { ...input, stockLevels: changedStockLevels };
+        },
         params: { id: params.id },
         onSuccess: data => {
             toast.success(
@@ -141,6 +162,13 @@ function ProductVariantDetailPage() {
             );
         },
     });
+
+    useEffect(() => {
+        originalStockLevelsRef.current = entity?.stockLevels.map(stockLevel => ({
+            stockLocationId: stockLevel.stockLocation.id,
+            stockOnHand: stockLevel.stockOnHand,
+        }));
+    }, [entity]);
 
     const availableCurrencies = activeChannel?.availableCurrencyCodes ?? [];
     const [prices, taxCategoryId, stockLevels] = form.watch(['prices', 'taxCategoryId', 'stockLevels']);

--- a/packages/dashboard/src/app/routes/_authenticated/_product-variants/utils/stock-levels.spec.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_product-variants/utils/stock-levels.spec.ts
@@ -28,17 +28,33 @@ describe('getChangedStockLevels', () => {
         ]);
     });
 
-    it('does not send an unchanged location even when another location is edited', () => {
-        // The unedited location may have changed concurrently in the DB; resending its
+    it('sends only the edited location across many, leaving the others untouched', () => {
+        // Each unedited location may have changed concurrently in the DB; resending its
         // stale page-load value would overwrite that concurrent change.
+        const threeLocations = [
+            { stockLocationId: '1', stockOnHand: 100 },
+            { stockLocationId: '2', stockOnHand: 50 },
+            { stockLocationId: '3', stockOnHand: 25 },
+        ];
         const submitted = [
-            { stockLocationId: '1', stockOnHand: 120 },
+            { stockLocationId: '1', stockOnHand: 100 },
+            { stockLocationId: '2', stockOnHand: 70 },
+            { stockLocationId: '3', stockOnHand: 25 },
+        ];
+        expect(getChangedStockLevels(submitted, threeLocations)).toEqual([
+            { stockLocationId: '2', stockOnHand: 70 },
+        ]);
+    });
+
+    it('does not include a location edited then reverted to its original value', () => {
+        // Guards against switching to a dirty-flag approach: a field edited and changed
+        // back is still "dirty" in react-hook-form, but its value is unchanged, so it
+        // must not be resent.
+        const submitted = [
+            { stockLocationId: '1', stockOnHand: 100 }, // 100 -> 120 -> 100
             { stockLocationId: '2', stockOnHand: 50 },
         ];
-        expect(getChangedStockLevels(submitted, original)).not.toContainEqual({
-            stockLocationId: '2',
-            stockOnHand: 50,
-        });
+        expect(getChangedStockLevels(submitted, original)).toEqual([]);
     });
 
     it('includes newly-added stock locations', () => {
@@ -57,7 +73,12 @@ describe('getChangedStockLevels', () => {
         expect(getChangedStockLevels(submitted, undefined)).toEqual(submitted);
     });
 
-    it('returns empty for missing submitted', () => {
+    it('returns empty for an empty submitted array', () => {
+        expect(getChangedStockLevels([], original)).toEqual([]);
+    });
+
+    it('returns empty for null or undefined submitted', () => {
+        expect(getChangedStockLevels(null, original)).toEqual([]);
         expect(getChangedStockLevels(undefined, original)).toEqual([]);
     });
 });

--- a/packages/dashboard/src/app/routes/_authenticated/_product-variants/utils/stock-levels.spec.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_product-variants/utils/stock-levels.spec.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import { getChangedStockLevels } from './stock-levels.js';
+
+describe('getChangedStockLevels', () => {
+    const original = [
+        { stockLocationId: '1', stockOnHand: 100 },
+        { stockLocationId: '2', stockOnHand: 50 },
+    ];
+
+    it('returns nothing when no stock was edited', () => {
+        // #4803 — editing an unrelated field (e.g. SKU) resubmits page-load stock;
+        // it must not be sent back, or core would revert concurrent stock changes.
+        const submitted = [
+            { stockLocationId: '1', stockOnHand: 100 },
+            { stockLocationId: '2', stockOnHand: 50 },
+        ];
+        expect(getChangedStockLevels(submitted, original)).toEqual([]);
+    });
+
+    it('returns only the location whose value changed', () => {
+        const submitted = [
+            { stockLocationId: '1', stockOnHand: 120 },
+            { stockLocationId: '2', stockOnHand: 50 },
+        ];
+        expect(getChangedStockLevels(submitted, original)).toEqual([
+            { stockLocationId: '1', stockOnHand: 120 },
+        ]);
+    });
+
+    it('does not send an unchanged location even when another location is edited', () => {
+        // The unedited location may have changed concurrently in the DB; resending its
+        // stale page-load value would overwrite that concurrent change.
+        const submitted = [
+            { stockLocationId: '1', stockOnHand: 120 },
+            { stockLocationId: '2', stockOnHand: 50 },
+        ];
+        expect(getChangedStockLevels(submitted, original)).not.toContainEqual({
+            stockLocationId: '2',
+            stockOnHand: 50,
+        });
+    });
+
+    it('includes newly-added stock locations', () => {
+        const submitted = [
+            { stockLocationId: '1', stockOnHand: 100 },
+            { stockLocationId: '2', stockOnHand: 50 },
+            { stockLocationId: '3', stockOnHand: 0 },
+        ];
+        expect(getChangedStockLevels(submitted, original)).toEqual([
+            { stockLocationId: '3', stockOnHand: 0 },
+        ]);
+    });
+
+    it('treats missing original as all-new', () => {
+        const submitted = [{ stockLocationId: '1', stockOnHand: 10 }];
+        expect(getChangedStockLevels(submitted, undefined)).toEqual(submitted);
+    });
+
+    it('returns empty for missing submitted', () => {
+        expect(getChangedStockLevels(undefined, original)).toEqual([]);
+    });
+});

--- a/packages/dashboard/src/app/routes/_authenticated/_product-variants/utils/stock-levels.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_product-variants/utils/stock-levels.ts
@@ -8,11 +8,12 @@ export interface StockLevelInput {
  * loaded into the form (`original`): edited locations and newly-added locations.
  * Unchanged locations are dropped.
  *
- * Core applies submitted stock as an absolute target relative to the *current* DB
- * value, so resending an unchanged page-load value silently reverts any stock
- * movement (orders, another admin, integrations) that happened since the page was
- * opened. Mirrors the legacy Angular UI, which only sent dirty stock locations.
- * See #4803.
+ * Core treats a submitted `stockOnHand` as an absolute target and applies the delta
+ * against the *current* DB value (it no-ops when the value already matches). So
+ * resending an unchanged page-load value is harmless only while the DB value hasn't
+ * drifted — if stock moved concurrently (an order completed, another admin edited,
+ * an integration ran), the stale value silently reverts that movement. Mirrors the
+ * legacy Angular UI, which only sent dirty stock locations. See #4803.
  */
 export function getChangedStockLevels<T extends StockLevelInput>(
     submitted: readonly T[] | null | undefined,

--- a/packages/dashboard/src/app/routes/_authenticated/_product-variants/utils/stock-levels.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_product-variants/utils/stock-levels.ts
@@ -1,0 +1,30 @@
+export interface StockLevelInput {
+    stockLocationId: string;
+    stockOnHand: number;
+}
+
+/**
+ * Returns only the stock levels the admin actually changed relative to the values
+ * loaded into the form (`original`): edited locations and newly-added locations.
+ * Unchanged locations are dropped.
+ *
+ * Core applies submitted stock as an absolute target relative to the *current* DB
+ * value, so resending an unchanged page-load value silently reverts any stock
+ * movement (orders, another admin, integrations) that happened since the page was
+ * opened. Mirrors the legacy Angular UI, which only sent dirty stock locations.
+ * See #4803.
+ */
+export function getChangedStockLevels<T extends StockLevelInput>(
+    submitted: readonly T[] | null | undefined,
+    original: readonly StockLevelInput[] | null | undefined,
+): T[] {
+    if (!submitted) {
+        return [];
+    }
+    const originalByLocation = new Map((original ?? []).map(s => [s.stockLocationId, s.stockOnHand]));
+    return submitted.filter(level => {
+        const originalStockOnHand = originalByLocation.get(level.stockLocationId);
+        // Include new locations and locations whose value the admin edited.
+        return originalStockOnHand === undefined || originalStockOnHand !== level.stockOnHand;
+    });
+}


### PR DESCRIPTION
## Description

Fixes a silent data-loss bug on the React Dashboard product variant detail page.

On page load, `stockLevels` are copied into the form. Saving **any** dirty field (e.g. just the SKU) resubmits the full `updateProductVariant` input, including all `stockLevels` with their page-load values. Core treats a submitted `stockOnHand` as an absolute target and applies the delta against the **current** DB value, so resending an unchanged page-load value silently reverts any stock movement that happened concurrently since the page was opened — an order completing, another admin editing, an integration running. The mutation succeeds with a success toast and no error.

This restores the behaviour of the legacy Angular admin UI, which only sent stock levels when its stock sub-form was dirty.

## Approach

- New pure helper `getChangedStockLevels(submitted, original)` returns only the stock levels whose `stockOnHand` differs from what was loaded, plus newly-added locations.
- The variant page adds a `transformUpdateInput` that prunes `stockLevels` to only the changed ones (dropping the key entirely when none changed). The pristine baseline is held in a `useRef`, synced from the loaded entity via `useEffect`.
- Scoped deliberately to the variant page and `stockLevels` (the audited, invisible case). The broader class — the form engine resubmitting the full payload for other replace-semantics fields (`facetValueIds`, `assetIds`, scalar stock-config fields) — is tracked separately.

## To reproduce (before this fix)

1. Variant with `stockOnHand: 100`, open the variant detail page.
2. In another session/API, reduce stock to `95` without refreshing the page.
3. Edit only the SKU, click **Update**.
4. Stock is back at `100` — the concurrent change was reverted.

## Testing

- New unit tests for `getChangedStockLevels` covering: unchanged stock dropped, single-location edit, multi-location (only the edited one sent), **edited-then-reverted** (value-based, not dirty-flag), newly-added locations, and empty/null inputs.
- Full dashboard test suite green; typecheck and lint clean.

## Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784120451&installation_id=128408429&pr_number=4834&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4834&signature=e44dc1aa01e07fe9446bdf6f9ab71f478f401ab87763238dd804457ed689a28c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->