### PR TITLE
feat(core): Add custom field value resolver

### DIFF
--- a/packages/core/e2e/custom-fields.e2e-spec.ts
+++ b/packages/core/e2e/custom-fields.e2e-spec.ts
@@ -25,6 +25,7 @@ import { fixPostgresTimezone } from './utils/fix-pg-timezone';
 fixPostgresTimezone();
 
 const validateInjectorSpy = vi.fn();
+const resolveInjectorSpy = vi.fn();
 
 const customConfig = mergeConfig(testConfig(), {
     dbConnectionOptions: {
@@ -161,6 +162,16 @@ const customConfig = mergeConfig(testConfig(), {
                 name: 'stringList',
                 type: 'string',
                 list: true,
+                resolve: (value, injector, ctx, entity) => {
+                    const connection = injector.get(TransactionalConnection);
+                    resolveInjectorSpy({
+                        value,
+                        apiType: ctx.apiType,
+                        entityId: String(entity.id),
+                        connection,
+                    });
+                    return [`resolved:${String(entity.id)}`];
+                },
             },
             {
                 name: 'localeStringList',
@@ -729,6 +740,30 @@ describe('Custom fields', () => {
             expect(updateProduct.customFields.validateFn3).toBe('some value');
             expect(validateInjectorSpy).toHaveBeenCalledTimes(1);
             expect(validateInjectorSpy.mock.calls[0][0] instanceof TransactionalConnection).toBe(true);
+        });
+
+        it('can resolve custom field values for GraphQL reads without changing persisted values', async () => {
+            resolveInjectorSpy.mockClear();
+
+            const { updateProduct } = await adminClient.query(updateProductStringListDocument, {
+                id: 'T_1',
+                values: ['stored'],
+            });
+
+            expect(updateProduct.customFields.stringList).toEqual(['resolved:1']);
+            expect(resolveInjectorSpy).toHaveBeenCalledTimes(1);
+
+            const resolverCall = resolveInjectorSpy.mock.calls[0][0];
+            expect(resolverCall).toMatchObject({
+                value: ['stored'],
+                apiType: 'admin',
+                entityId: '1',
+            });
+            expect(resolverCall.connection).toBeInstanceOf(TransactionalConnection);
+
+            const ctx = await server.app.get(RequestContextService).create({ apiType: 'admin' });
+            const product = await server.app.get(ProductService).findOne(ctx, 1);
+            expect(product?.customFields.stringList).toEqual(['stored']);
         });
 
         it(
@@ -1439,6 +1474,17 @@ const updateProductIntListDocument = graphql(`
             id
             customFields {
                 intListWithValidation
+            }
+        }
+    }
+`);
+
+const updateProductStringListDocument = graphql(`
+    mutation UpdateProductStringList($id: ID!, $values: [String!]!) {
+        updateProduct(input: { id: $id, customFields: { stringList: $values } }) {
+            id
+            customFields {
+                stringList
             }
         }
     }

--- a/packages/core/src/api/config/configure-graphql-module.ts
+++ b/packages/core/src/api/config/configure-graphql-module.ts
@@ -1,8 +1,10 @@
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { DynamicModule } from '@nestjs/common';
+import { ModuleRef } from '@nestjs/core';
 import { GraphQLModule, GraphQLTypesLoader } from '@nestjs/graphql';
 import { GraphQLSchema, printSchema, ValidationContext } from 'graphql';
 
+import { Injector } from '../../common/injector';
 import { ConfigModule } from '../../config/config.module';
 import { ConfigService } from '../../config/config.service';
 import { I18nModule } from '../../i18n/i18n.module';
@@ -43,6 +45,7 @@ export function configureGraphQLModule(
             idCodecService: IdCodecService,
             typesLoader: GraphQLTypesLoader,
             customFieldRelationResolverService: CustomFieldRelationResolverService,
+            moduleRef: ModuleRef,
         ) => {
             return createGraphQLOptions(
                 i18nService,
@@ -50,6 +53,7 @@ export function configureGraphQLModule(
                 idCodecService,
                 typesLoader,
                 customFieldRelationResolverService,
+                new Injector(moduleRef),
                 getOptions(configService),
             );
         },
@@ -59,6 +63,7 @@ export function configureGraphQLModule(
             IdCodecService,
             GraphQLTypesLoader,
             CustomFieldRelationResolverService,
+            ModuleRef,
         ],
         imports: [ConfigModule, I18nModule, ApiSharedModule, ServiceModule],
     });
@@ -70,6 +75,7 @@ async function createGraphQLOptions(
     idCodecService: IdCodecService,
     typesLoader: GraphQLTypesLoader,
     customFieldRelationResolverService: CustomFieldRelationResolverService,
+    injector: Injector,
     options: GraphQLApiOptions,
 ): Promise<ApolloDriverConfig> {
     const builtSchema = await buildSchemaForApi(options.apiType);
@@ -78,6 +84,7 @@ async function createGraphQLOptions(
         customFieldRelationResolverService,
         options.apiType,
         builtSchema,
+        injector,
     );
 
     const apolloServerPlugins = [

--- a/packages/core/src/api/config/generate-resolvers.ts
+++ b/packages/core/src/api/config/generate-resolvers.ts
@@ -9,6 +9,7 @@ import {
     ErrorResult,
 } from '../../common/error/generated-graphql-admin-errors';
 import { shopErrorOperationTypeResolvers } from '../../common/error/generated-graphql-shop-errors';
+import { Injector } from '../../common/injector';
 import { Translatable } from '../../common/types/locale-types';
 import { ConfigService } from '../../config/config.service';
 import {
@@ -37,6 +38,7 @@ export async function generateResolvers(
     customFieldRelationResolverService: CustomFieldRelationResolverService,
     apiType: ApiType,
     schema: GraphQLSchema,
+    injector: Injector,
 ) {
     // Prevent `Type "Node" is missing a "resolveType" resolver.` warnings.
     // See https://github.com/apollographql/apollo-server/issues/1075
@@ -155,6 +157,7 @@ export async function generateResolvers(
         configService,
         customFieldRelationResolverService,
         schema,
+        injector,
     );
 
     const adminResolvers = {
@@ -192,8 +195,10 @@ function generateCustomFieldResolvers(
     configService: ConfigService,
     customFieldRelationResolverService: CustomFieldRelationResolverService,
     schema: GraphQLSchema,
+    injector: Injector,
 ) {
     const ENTITY_ID_KEY = '__entityId__';
+    const ENTITY_KEY = Symbol('entity');
     const adminResolvers: IResolvers = {};
     const shopResolvers: IResolvers = {};
 
@@ -212,10 +217,10 @@ function generateCustomFieldResolvers(
         // access to the entity id. Therefore, we attach it to the resolved value
         // so that it is available to the `relationResolver` below.
         const customFieldResolver: IFieldResolver<any, any> = (source: any) => {
-            return {
-                ...source.customFields,
-                [ENTITY_ID_KEY]: source.id,
-            };
+            const customFields = { ...source.customFields };
+            Object.defineProperty(customFields, ENTITY_ID_KEY, { value: source.id });
+            Object.defineProperty(customFields, ENTITY_KEY, { value: source });
+            return customFields;
         };
         const resolverObject = {
             customFields: customFieldResolver,
@@ -266,7 +271,14 @@ function generateCustomFieldResolvers(
                     });
                 };
             } else if (isStructType(fieldDef)) {
-                resolver = async (source: any) => {
+                resolver = async (source: any, args: any, context: any) => {
+                    const ctx = internal_getRequestContext(context.req);
+                    const resolvedValue = await resolveCustomFieldValue(
+                        fieldDef,
+                        source,
+                        source[fieldDef.name],
+                        ctx,
+                    );
                     const fields = fieldDef.fields;
                     function buildStructObject(valueFromDb: any) {
                         const result: Record<string, any> = {};
@@ -282,36 +294,25 @@ function generateCustomFieldResolvers(
                         return result;
                     }
                     if (fieldDef.list === true) {
-                        const structArray = Array.isArray(source[fieldDef.name])
-                            ? source[fieldDef.name]
-                            : source[fieldDef.name]
-                              ? [source[fieldDef.name]]
+                        const structArray = Array.isArray(resolvedValue)
+                            ? resolvedValue
+                            : resolvedValue
+                              ? [resolvedValue]
                               : [];
                         source[fieldDef.name] = structArray.map(buildStructObject);
                     } else {
-                        source[fieldDef.name] = buildStructObject(source[fieldDef.name]);
+                        source[fieldDef.name] = buildStructObject(resolvedValue);
                     }
 
                     return source[fieldDef.name];
                 };
-                adminResolvers[customFieldTypeName] = {
-                    ...adminResolvers[customFieldTypeName],
-                    [fieldDef.name]: resolver,
-                } as any;
-
-                if (fieldDef.public !== false && !excludeFromShopApi) {
-                    shopResolvers[customFieldTypeName] = {
-                        ...shopResolvers[customFieldTypeName],
-                        [fieldDef.name]: resolver,
-                    } as any;
-                }
             } else {
                 resolver = async (source: any, args: any, context: any) => {
                     const ctx = internal_getRequestContext(context.req);
                     if (!userHasPermissionsOnCustomField(ctx, fieldDef)) {
                         return null;
                     }
-                    return source[fieldDef.name];
+                    return resolveCustomFieldValue(fieldDef, source, source[fieldDef.name], ctx);
                 };
             }
 
@@ -339,6 +340,18 @@ function generateCustomFieldResolvers(
         }
     }
     return { adminResolvers, shopResolvers };
+
+    function resolveCustomFieldValue(
+        fieldDef: Exclude<CustomFieldConfig, RelationCustomFieldConfig>,
+        source: any,
+        value: unknown,
+        ctx: ReturnType<typeof internal_getRequestContext>,
+    ) {
+        if (typeof fieldDef.resolve !== 'function') {
+            return value;
+        }
+        return fieldDef.resolve(value, injector, ctx, source[ENTITY_KEY]);
+    }
 }
 
 function getCustomScalars(configService: ConfigService, apiType: 'admin' | 'shop') {

--- a/packages/core/src/config/custom-field/custom-field-types.ts
+++ b/packages/core/src/config/custom-field/custom-field-types.ts
@@ -33,6 +33,13 @@ import { RequestContext } from '../../api/common/request-context';
 import { Injector } from '../../common/injector';
 import { VendureEntity } from '../../entity/base/base.entity';
 
+export type CustomFieldValueResolver = (
+    value: unknown,
+    injector: Injector,
+    ctx: RequestContext,
+    entity: VendureEntity,
+) => unknown | Promise<unknown>;
+
 // prettier-ignore
 export type DefaultValueType<T extends CustomFieldType | StructFieldType> =
     T extends 'string' | 'localeString' | 'text' | 'localeText' ? string :
@@ -90,7 +97,18 @@ export type BaseTypedCustomFieldConfig<T extends CustomFieldType, C extends Cust
      * ```
      */
     ui?: UiComponentConfig<DefaultFormComponentId | string> | { dashboard?: boolean };
-};
+} & (T extends 'relation'
+    ? unknown
+    : {
+          /**
+           * @description
+           * Allows the value returned by the GraphQL API to be resolved dynamically.
+           * This does not affect the value persisted to the database.
+           *
+           * @since 3.7.0
+           */
+          resolve?: CustomFieldValueResolver;
+      });
 
 /**
  * @description


### PR DESCRIPTION
## Description 

This PR lets custom fields return a computed value when they are read through GraphQL. 
The value stored in database is not changed. Vendure still stores and validates custom fields the same way as before. 
The new hook only changes what Admin API or shop API returns for that custom field. 

Relates to #490 

## What Changed 

- Added a read-time resolver for non-relation custom fields
- Passed vendure Injector , RequestContext and Vendure Entity to the resolver. 
- Kept the stored database value changed 
- Added to e2e coverage showing graphql can return computed value without overwriting the stored value. 

This is useful for plugins that need to keep Vendure as the source of stored product data, while resolving the value shown to API clients from another system or from request context. For example, a plugin can store a fallback custom field value in Vendure, but return a channel/currency/entity-specific value from an external configuration or pricing service when the field is queried.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784188025&installation_id=128408429&pr_number=4836&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4836&signature=47c4798bd7e721599359e21c4a56f6d061554ccf281bc15e218b246b7c7fb346"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->