### PR TITLE
feat(dashboard): Add Uzbek (uz) translation for the Dashboard

### DIFF
--- a/packages/dashboard/lingui.config.js
+++ b/packages/dashboard/lingui.config.js
@@ -28,7 +28,8 @@ export default defineConfig({
         'ja',
         'bg',
         'nl',
-        'ro'
+        'ro',
+        'uz'
     ],
     orderBy: 'messageId',
     catalogs: [

--- a/packages/dashboard/src/i18n/locales/uz.po
+++ b/packages/dashboard/src/i18n/locales/uz.po
@@ -1,0 +1,5723 @@
+msgid ""
+msgstr ""
+"POT-Creation-Date: 2026-06-17 16:24+0500\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=utf-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: @lingui/cli\n"
+"Language: uz\n"
+"Project-Id-Version: \n"
+"Report-Msgid-Bugs-To: \n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Plural-Forms: \n"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:159
+#: src/lib/components/shared/customer-address-form.tsx:103
+msgid "Full Name"
+msgstr "To'liq ism"
+
+#: src/lib/components/data-input/relation-selector.tsx:408
+msgid "Select items"
+msgstr "Elementlarni tanlang"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:33
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:86
+msgid "View changes"
+msgstr "O'zgarishlarni ko'rish"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:122
+msgid "Tracking code"
+msgstr "Kuzatuv kodi"
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:113
+msgid "The selected permissions will be applied to the these channels."
+msgstr "Tanlangan ruxsatlar ushbu kanallarga qo'llaniladi."
+
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:248
+msgid "Product options"
+msgstr "Mahsulot variantlari"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:108
+msgid "New Tax Rate"
+msgstr "Yangi soliq stavkasi"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:150
+msgid "Assign an existing option group or create a new one"
+msgstr "Mavjud optsiya guruhini biriktiring yoki yangisini yarating"
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:33
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:77
+msgid "New role"
+msgstr "Yangi rol"
+
+#: src/lib/components/shared/customer-address-form.tsx:131
+msgid "Apartment, suite, etc."
+msgstr "Kvartira, ofis va h.k."
+
+#: src/lib/components/data-input/relation-selector.tsx:458
+#: src/lib/components/shared/facet-value-selector.tsx:214
+msgid "No more items"
+msgstr "Boshqa elementlar yo'q"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+msgid "Edit link"
+msgstr "Havolani tahrirlash"
+
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:25
+msgid "Add at least one item to the order"
+msgstr "Buyurtmaga kamida bitta element qo'shing"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:232
+msgid "Add products to create a test order"
+msgstr "Test buyurtma uchun mahsulot qo'shing"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:124
+msgid "Failed to create address"
+msgstr "Manzil yaratib bo'lmadi"
+
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:93
+#: src/app/routes/_authenticated/_roles/components/permissions-table-grid.tsx:174
+msgid "Toggle all"
+msgstr "Hammasini almashtirish"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+msgid "Edit JSON value"
+msgstr "JSON qiymatini tahrirlash"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:17
+msgid "Using external authentication strategy: {strategy}"
+msgstr "Tashqi autentifikatsiya strategiyasi: {strategy}"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:225
+msgid "Select a reason..."
+msgstr "Sababni tanlang..."
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:100
+msgid "Heading 5"
+msgstr "Sarlavha 5"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:52
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:58
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:86
+msgid "Failed to add payment"
+msgstr "To'lov qo'shib bo'lmadi"
+
+#: src/lib/framework/layout-engine/page-layout.tsx:746
+msgid "Updated"
+msgstr "Yangilandi"
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:79
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:85
+msgid "Failed to update global settings"
+msgstr "Global sozlamalarni yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:78
+msgid "Successfully fulfilled order"
+msgstr "Buyurtma muvaffaqiyatli bajarildi"
+
+#. placeholder {0}: selection.length
+#: src/app/common/delete-bulk-action.tsx:141
+msgid "Are you sure you want to delete {0} {entityName}?"
+msgstr "{0} {entityName} o'chirilsinmi?"
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:131
+msgid "Global out of stock threshold"
+msgstr "Global zaxira tugashi chegarasi"
+
+#: src/lib/components/layout/channel-switcher.tsx:194
+#: src/lib/components/layout/manage-languages-dialog.tsx:241
+msgid "Manage Languages"
+msgstr "Tillarni boshqarish"
+
+#. placeholder {0}: progress.completed
+#. placeholder {1}: progress.total
+#: src/app/common/duplicate-bulk-action.tsx:127
+msgid "Duplicating... ({0}/{1})"
+msgstr "Nusxalanmoqda... ({0}/{1})"
+
+#: src/lib/components/data-table/use-generated-columns.tsx:387
+msgid "Deleted successfully"
+msgstr "Muvaffaqiyatli o'chirildi"
+
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:25
+msgid "Deleted {selectionLength} assets"
+msgstr "{selectionLength} ta asset o'chirildi"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+msgid "Successfully updated tax rate"
+msgstr "Soliq stavkasi yangilandi"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:237
+msgid "Enter custom reason..."
+msgstr "Maxsus sababni kiriting..."
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:744
+msgid "Type"
+msgstr "Turi"
+
+#. placeholder {0}: entityName.toLowerCase()
+#. placeholder {0}: group.name
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
+#: src/lib/components/data-input/default-relation-input.tsx:676
+msgid "Select {0}"
+msgstr "{0} ni tanlang"
+
+#: src/app/routes/_authenticated/_facets/facets.tsx:67
+msgid "View values"
+msgstr "Qiymatlarni ko'rish"
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:214
+msgid "Delete row"
+msgstr "Qatorni o'chirish"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:228
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:178
+msgid "Conditions"
+msgstr "Shartlar"
+
+#: src/lib/components/layout/channel-switcher.tsx:99
+msgctxt "current channel"
+msgid "Current"
+msgstr "Joriy"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:326
+msgid "No fulfillments"
+msgstr "Bajarishlar yo'q"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:232
+msgid "When this is enabled, the prices entered in the product catalog will be included in the tax for the default tax zone."
+msgstr "Bu yoqilganda, mahsulot katalogidagi narxlar standart soliq hududi solig'iga kiritiladi."
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:291
+msgid "Draft order completed"
+msgstr "Qoralama buyurtma yakunlandi"
+
+#. placeholder {0}: currentInterval?.label
+#: src/app/routes/_authenticated/_system/job-queue.tsx:287
+msgid "Auto refresh: {0}"
+msgstr "Avtomatik yangilash: {0}"
+
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:34
+msgid "Successfully cancelled {fulfilled} job"
+msgstr "{fulfilled} ta ish bekor qilindi"
+
+#: src/app/common/delete-bulk-action.tsx:108
+msgid "Deleted {deleted} {entityName}"
+msgstr "{deleted} {entityName} o'chirildi"
+
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:29
+#: src/app/routes/_authenticated/_sellers/sellers.tsx:13
+#: src/app/routes/_authenticated/_sellers/sellers.tsx:22
+msgid "Sellers"
+msgstr "Sotuvchilar"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:269
+msgid "Options"
+msgstr "Optsiyalar"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:152
+msgid "Seller"
+msgstr "Sotuvchi"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:131
+msgid "SKU:"
+msgstr "SKU:"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:121
+msgid "Add payment"
+msgstr "To'lov qo'shish"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:40
+msgid "Test this shipping method by simulating an order to see if it's eligible and what the shipping cost would be."
+msgstr "Buyurtmani simulyatsiya qilib, ushbu yetkazib berish usuli mosligini va narxini sinab ko'ring."
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:36
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:17
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:24
+msgid "Stock Locations"
+msgstr "Zaxira joylashuvlari"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:293
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:170
+msgid "Fulfillment handler"
+msgstr "Bajarish ishlovchisi"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:247
+#: src/app/routes/_authenticated/_orders/orders.tsx:21
+#: src/app/routes/_authenticated/_orders/orders.tsx:37
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:48
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:62
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:76
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:128
+msgid "Orders"
+msgstr "Buyurtmalar"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:187
+msgid "Select roles"
+msgstr "Rollarni tanlang"
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+msgid "Successfully created role"
+msgstr "Rol yaratildi"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:454
+msgid "Are you sure you want to delete this variant?"
+msgstr "Ushbu variant o'chirilsinmi?"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:86
+msgid "Failed to create administrator"
+msgstr "Administrator yaratib bo'lmadi"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:327
+msgid "No"
+msgstr "Yo'q"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:147
+msgid "Successfully updated product variant"
+msgstr "Mahsulot varianti yangilandi"
+
+#: src/app/common/delete-bulk-action.tsx:114
+msgid "Failed to delete {failed} {entityName}: {allErrors}"
+msgstr "{failed} {entityName} o'chirib bo'lmadi: {allErrors}"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:160
+msgid "Successfully updated product"
+msgstr "Mahsulot yangilandi"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+msgid "Failed to update country"
+msgstr "Mamlakatni yangilab bo'lmadi"
+
+#: src/lib/components/shared/facet-value-selector.tsx:147
+msgid "Type at least 2 characters to search..."
+msgstr "Qidirish uchun kamida 2 ta belgi kiriting..."
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:121
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:182
+#: src/app/routes/_authenticated/_profile/profile.tsx:108
+msgid "Last name"
+msgstr "Familiya"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:106
+msgid "Link title"
+msgstr "Havola sarlavhasi"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:65
+msgid "Successfully updated customer group"
+msgstr "Mijozlar guruhi yangilandi"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:172
+msgid "Custom fields changed"
+msgstr "Maxsus maydonlar o'zgartirildi"
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:67
+msgid "Successfully created stock location"
+msgstr "Zaxira joylashuvi yaratildi"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:109
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:303
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:78
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:120
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:166
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:185
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:112
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:204
+msgid "Unknown error"
+msgstr "Noma'lum xato"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:200
+msgid "Refund total cannot be negative"
+msgstr "Pul qaytarish jami manfiy bo'lishi mumkin emas"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:153
+msgid "View details"
+msgstr "Tafsilotlarni ko'rish"
+
+#. placeholder {0}: entityIds.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx:95
+msgid "Select a channel to assign {0} {entityType} to"
+msgstr "{0} {entityType} ni biriktirish uchun kanalni tanlang"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:98
+msgid "Successfully created customer"
+msgstr "Mijoz yaratildi"
+
+#: src/lib/components/date-range-picker.tsx:39
+msgctxt "date-range"
+msgid "Last 7 days"
+msgstr "So'nggi 7 kun"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:90
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:96
+msgid "Failed to create channel"
+msgstr "Kanal yaratib bo'lmadi"
+
+#: src/lib/components/layout/dev-mode-indicator.tsx:14
+#: src/lib/components/layout/nav-user.tsx:144
+msgid "Dev Mode"
+msgstr "Dasturchi rejimi"
+
+#: src/app/routes/_authenticated/_roles/roles.tsx:88
+msgid "New Role"
+msgstr "Yangi rol"
+
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:28
+msgid "Failed to delete assets: {message}"
+msgstr "Assetlarni o'chirib bo'lmadi: {message}"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:105
+msgid "Return to stock"
+msgstr "Zaxiraga qaytarish"
+
+#: src/app/routes/_authenticated/_facets/facets.tsx:39
+msgid "Visibility"
+msgstr "Ko'rinish"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
+msgid "Product variants"
+msgstr "Mahsulot variantlari"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:36
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:85
+msgid "New customer group"
+msgstr "Yangi mijozlar guruhi"
+
+#. placeholder {0}: searchValue.trim()
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:159
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:176
+msgid "Create \"{0}\""
+msgstr "\"{0}\" ni yaratish"
+
+#: src/lib/components/data-table/views-sheet.tsx:238
+msgid "Rename"
+msgstr "Qayta nomlash"
+
+#: src/lib/components/layout/language-dialog.tsx:52
+msgid "Choose your preferred display language and locale settings"
+msgstr "Afzal ko'rgan ekran tili va lokal sozlamalarni tanlang"
+
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:87
+msgid "Successfully removed {successCount} option groups from channel"
+msgstr "{successCount} ta optsiya guruhi kanaldan olib tashlandi"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:76
+msgid "Shipping method is not eligible for this order"
+msgstr "Yetkazib berish usuli ushbu buyurtma uchun mos emas"
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:60
+msgid "Failed to update address"
+msgstr "Manzilni yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:44
+msgid "Address deleted successfully"
+msgstr "Manzil o'chirildi"
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:109
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:17
+msgid "Tax rate"
+msgstr "Soliq stavkasi"
+
+#. placeholder {0}: import { DataTableBulkActionItem } from '@/vdb/components/data-table/data-table-bulk-action-item.js'; import { BulkActionComponent } from '@/vdb/framework/extension-api/types/data-table.js'; import { api } from '@/vdb/graphql/api.js'; import { usePaginatedList } from '@/vdb/hooks/use-paginated-list.js'; import { plural } from '@lingui/core/macro'; import { Plural, useLingui } from '@lingui/react/macro'; import { useMutation } from '@tanstack/react-query'; import { Ban } from 'lucide-react'; import { toast } from 'sonner'; import { cancelJobDocument } from '../job-queue.graphql.js'; export const CancelJobsBulkAction: BulkActionComponent<any> = ({ selection, table }) => { const { refetchPaginatedList } = usePaginatedList(); const { t } = useLingui(); const cancellableJobs = selection.filter(job => job.state === 'RUNNING' || job.state === 'PENDING'); const cancellableCount = cancellableJobs.length; const { mutate, isPending } = useMutation({ mutationFn: async () => { const results = await Promise.allSettled( cancellableJobs.map(job => api.mutate(cancelJobDocument, { jobId: job.id })), ); const fulfilled = results.filter(r => r.status === 'fulfilled').length; const rejected = results.filter(r => r.status === 'rejected').length; return { fulfilled, rejected }; }, onSuccess: ({ fulfilled, rejected }) => { if (fulfilled > 0) { toast.success( plural(fulfilled, { one: t`Successfully cancelled ${fulfilled} job`, other: t`Successfully cancelled ${fulfilled} jobs`, }), ); } if (rejected > 0) { toast.error( plural(rejected, { one: t`Failed to cancel ${rejected} job`, other: t`Failed to cancel ${rejected} jobs`, }), ); } refetchPaginatedList(); table.resetRowSelection(); }, }); if (cancellableCount === 0) { return null; } return ( <DataTableBulkActionItem requiresPermission={['DeleteSettings', 'DeleteSystem']} onClick={() => mutate()} disabled={isPending} label={ <Plural value={cancellableCount} one={`Cancel ${cancellableCount} job`} other={`Cancel ${cancellableCount} jobs`} /> } confirmationText={ <Plural value={cancellableCount} one={`Are you sure you want to cancel ${cancellableCount} job? This action cannot be undone.`} other={`Are you sure you want to cancel ${cancellableCount} jobs? This action cannot be undone.`} /> } icon={Ban} className="text-destructive" /> ); }; 
+#. placeholder {1}: import { DataTableBulkActionItem } from '@/vdb/components/data-table/data-table-bulk-action-item.js'; import { BulkActionComponent } from '@/vdb/framework/extension-api/types/data-table.js'; import { api } from '@/vdb/graphql/api.js'; import { usePaginatedList } from '@/vdb/hooks/use-paginated-list.js'; import { plural } from '@lingui/core/macro'; import { Plural, useLingui } from '@lingui/react/macro'; import { useMutation } from '@tanstack/react-query'; import { Ban } from 'lucide-react'; import { toast } from 'sonner'; import { cancelJobDocument } from '../job-queue.graphql.js'; export const CancelJobsBulkAction: BulkActionComponent<any> = ({ selection, table }) => { const { refetchPaginatedList } = usePaginatedList(); const { t } = useLingui(); const cancellableJobs = selection.filter(job => job.state === 'RUNNING' || job.state === 'PENDING'); const cancellableCount = cancellableJobs.length; const { mutate, isPending } = useMutation({ mutationFn: async () => { const results = await Promise.allSettled( cancellableJobs.map(job => api.mutate(cancelJobDocument, { jobId: job.id })), ); const fulfilled = results.filter(r => r.status === 'fulfilled').length; const rejected = results.filter(r => r.status === 'rejected').length; return { fulfilled, rejected }; }, onSuccess: ({ fulfilled, rejected }) => { if (fulfilled > 0) { toast.success( plural(fulfilled, { one: t`Successfully cancelled ${fulfilled} job`, other: t`Successfully cancelled ${fulfilled} jobs`, }), ); } if (rejected > 0) { toast.error( plural(rejected, { one: t`Failed to cancel ${rejected} job`, other: t`Failed to cancel ${rejected} jobs`, }), ); } refetchPaginatedList(); table.resetRowSelection(); }, }); if (cancellableCount === 0) { return null; } return ( <DataTableBulkActionItem requiresPermission={['DeleteSettings', 'DeleteSystem']} onClick={() => mutate()} disabled={isPending} label={ <Plural value={cancellableCount} one={`Cancel ${cancellableCount} job`} other={`Cancel ${cancellableCount} jobs`} /> } confirmationText={ <Plural value={cancellableCount} one={`Are you sure you want to cancel ${cancellableCount} job? This action cannot be undone.`} other={`Are you sure you want to cancel ${cancellableCount} jobs? This action cannot be undone.`} /> } icon={Ban} className="text-destructive" /> ); }; 
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:33
+msgid "{fulfilled, plural, one {{0}} other {{1}}}"
+msgstr "{fulfilled, plural, one {{0}} other {{1}}}"
+
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:34
+msgid "Order draft isn't ready to be completed"
+msgstr "Buyurtma qoralamasi yakunlanishga tayyor emas"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:47
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:136
+msgid "New collection"
+msgstr "Yangi to'plam"
+
+#: src/app/routes/_authenticated/index.tsx:184
+msgid "Insights"
+msgstr "Tahlillar"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:210
+msgid "Run"
+msgstr "Ishga tushirish"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+msgid "Failed to update tax rate"
+msgstr "Soliq stavkasini yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:37
+msgid "This is the contents of the <0>{collectionName}</0> collection."
+msgstr "Bu <0>{collectionName}</0> to'plamining tarkibi."
+
+#: src/app/routes/_authenticated/_facets/facets.tsx:44
+msgid "private"
+msgstr "maxfiy"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:138
+msgid "Successfully created product option"
+msgstr "Mahsulot varianti yaratildi"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:501
+msgid "Parent product"
+msgstr "Asosiy mahsulot"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:196
+#: src/lib/components/shared/customer-address-form.tsx:141
+msgid "City"
+msgstr "Shahar"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:37
+#: src/app/routes/_authenticated/_administrators/administrators.tsx:15
+#: src/app/routes/_authenticated/_administrators/administrators.tsx:22
+msgid "Administrators"
+msgstr "Administratorlar"
+
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:86
+msgid "Gross price: <0/>"
+msgstr "Yalpi narx: <0/>"
+
+#: src/lib/components/data-table/data-table-pagination.tsx:82
+msgid "Go to next page"
+msgstr "Keyingi sahifaga o'tish"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:142
+msgid "Remove link"
+msgstr "Havolani olib tashlash"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:123
+msgid "This field is readonly"
+msgstr "Bu maydon faqat o'qish uchun"
+
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:32
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:80
+msgid "Order Count"
+msgstr "Buyurtmalar soni"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:92
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:59
+msgid "Successfully updated order"
+msgstr "Buyurtma yangilandi"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:199
+msgid "Inherit filters"
+msgstr "Filtrlarni meros qilib olish"
+
+#: src/lib/components/data-table/views-sheet.tsx:130
+msgid "Manage global saved views that are visible to all users"
+msgstr "Barcha foydalanuvchilarga ko'rinadigan global saqlangan ko'rinishlarni boshqarish"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:107
+msgid "Search payment methods..."
+msgstr "To'lov usullarini qidirish..."
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:217
+msgid "Shipping address unset for order"
+msgstr "Buyurtma uchun yetkazib berish manzili o'rnatilmagan"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:432
+msgid "Create {enabledCount} variants"
+msgstr "{enabledCount} ta variant yaratish"
+
+#. placeholder {0}: entry.data.paymentId
+#. placeholder {1}: entry.data.to
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:26
+msgid "Payment #{0} transitioned to {1}"
+msgstr "To'lov #{0} {1} holatiga o'tdi"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:46
+msgid "Error loading customer history: {0}"
+msgstr "Mijoz tarixini yuklashda xato: {0}"
+
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:53
+msgid "Successfully removed {selectionLength} {entityType} from channel"
+msgstr "{selectionLength} ta {entityType} kanaldan olib tashlandi"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:158
+msgid "Add option value"
+msgstr "Optsiya qiymatini qo'shish"
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:41
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:94
+msgid "Global Settings"
+msgstr "Global sozlamalar"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:30
+msgid "is after"
+msgstr "keyin"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:139
+msgid "Successfully updated product option"
+msgstr "Mahsulot varianti yangilandi"
+
+#: src/app/routes/_authenticated/_product-variants/components/product-variant-bulk-actions.tsx:95
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:159
+#: src/app/routes/_authenticated/_products/components/product-bulk-actions.tsx:89
+msgid "Edit facet values"
+msgstr "Faset qiymatlarini tahrirlash"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:175
+msgid "Adding..."
+msgstr "Qo'shilmoqda..."
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:340
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:427
+msgid "Move Collections"
+msgstr "To'plamlarni ko'chirish"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:139
+#: src/app/routes/_authenticated/_administrators/administrators.tsx:55
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:170
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:32
+#: src/app/routes/_authenticated/_roles/roles.tsx:18
+#: src/app/routes/_authenticated/_roles/roles.tsx:27
+msgid "Roles"
+msgstr "Rollar"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:395
+msgid "Grid view"
+msgstr "Jadval ko'rinishi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:48
+msgid "Failed to delete address"
+msgstr "Manzilni o'chirib bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:59
+msgid "No shipping methods available"
+msgstr "Yetkazib berish usullari mavjud emas"
+
+#: src/lib/components/data-table/views-sheet.tsx:108
+msgid "Global view converted to personal view successfully"
+msgstr "Global ko'rinish shaxsiyga aylantirildi"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:99
+msgid "Fulfillment transitioned"
+msgstr "Bajarish o'tkazildi"
+
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:42
+msgid "Are you sure you want to delete {selectionLength} assets?"
+msgstr "{selectionLength} ta asset o'chirilsinmi?"
+
+#: src/lib/components/login/login-form.tsx:105
+msgid "Sign in"
+msgstr "Kirish"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:398
+msgid "List view"
+msgstr "Ro'yxat ko'rinishi"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:164
+msgid "Test Order"
+msgstr "Sinov buyurtmasi"
+
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:23
+msgid "Select a customer to continue"
+msgstr "Davom etish uchun mijozni tanlang"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:73
+msgid "Successfully assigned option group"
+msgstr "Optsiya guruhi tayinlandi"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:30
+msgid "Run Test"
+msgstr "Sinovni ishga tushirish"
+
+#: src/app/routes/_authenticated/_product-variants/components/variant-price-detail.tsx:83
+msgid "Tax rate: {taxRate}%"
+msgstr "Soliq stavkasi: {taxRate}%"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:58
+msgid "Please add products and complete the shipping address to run the test."
+msgstr "Sinov uchun mahsulot qo'shing va yetkazib berish manzilini to'ldiring."
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:206
+msgid "Toggle header row"
+msgstr "Sarlavha qatorini almashtirish"
+
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:65
+msgid "Select address"
+msgstr "Manzilni tanlang"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:179
+msgid "Payment eligibility checker"
+msgstr "To'lov muvofiqligi tekshiruvchisi"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:214
+msgid "Default tax zone"
+msgstr "Standart soliq hududi"
+
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:36
+msgid "Order draft is ready to be completed"
+msgstr "Buyurtma qoralamasi yakunlashga tayyor"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:201
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:245
+msgid "Metadata"
+msgstr "Metama'lumotlar"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:251
+msgid "Failed to set shipping method for order: {0}"
+msgstr "Yetkazib berish usulini o'rnatib bo'lmadi: {0}"
+
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:48
+#: src/lib/components/data-table/data-table.tsx:378
+msgid "Filter..."
+msgstr "Filtrlash..."
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:40
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:102
+msgid "New facet value"
+msgstr "Yangi faset qiymati"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:83
+msgid "Successfully updated channel"
+msgstr "Kanal yangilandi"
+
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:124
+msgid "Show less"
+msgstr "Kamroq ko'rsatish"
+
+#: src/lib/components/layout/language-dialog.tsx:130
+msgid "Short date"
+msgstr "Qisqa sana"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:172
+msgid "Available currencies"
+msgstr "Mavjud valyutalar"
+
+#. placeholder {0}: selectedItems.length
+#: src/lib/components/data-input/product-multi-selector-input.tsx:373
+msgid "Select {0} Items"
+msgstr "{0} ta element tanlang"
+
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:108
+msgid "Placed At"
+msgstr "Joylashtirilgan sana"
+
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:53
+msgid "Rotating this key will immediately invalidate the current key. Any integrations using it will stop working until updated with the new key."
+msgstr "Bu kalitni almashtirish joriy kalitni darhol bekor qiladi. Undan foydalanayotgan integratsiyalar yangi kalit bilan yangilanmaguncha ishlamaydi."
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:163
+msgid "The data that has been passed to the job"
+msgstr "Vazifaga uzatilgan ma'lumotlar"
+
+#: src/lib/components/shared/navigation-confirmation.tsx:44
+msgid "Confirm navigation"
+msgstr "Navigatsiyani tasdiqlash"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:118
+msgid "Link target"
+msgstr "Havola maqsadi"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:365
+msgid "Complete draft"
+msgstr "Qoralamani yakunlash"
+
+#: src/app/routes/_authenticated/_administrators/administrators.tsx:45
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:165
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:152
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:169
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:104
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:103
+#: src/app/routes/_authenticated/_customers/customers.tsx:70
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:131
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:120
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:202
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:170
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:158
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:286
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:348
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:165
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:89
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:148
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:105
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:106
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:113
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:93
+#: src/lib/components/shared/asset/asset-gallery.tsx:743
+msgid "Name"
+msgstr "Nomi"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:81
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:87
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:189
+msgid "Failed to fulfill order"
+msgstr "Buyurtmani bajarib bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:158
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:88
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx:106
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:228
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:121
+msgid "Total"
+msgstr "Jami"
+
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:52
+msgid "Enter the transaction ID for this refund settlement"
+msgstr "Ushbu pul qaytarish uchun tranzaksiya ID raqamini kiriting"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:67
+msgid "Your API Key"
+msgstr "Sizning API kalitingiz"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:349
+msgid "Are you sure you want to delete this draft order?"
+msgstr "Ushbu qoralama buyurtma o'chirilsinmi?"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:101
+msgid "Fulfillment created"
+msgstr "Bajarish yaratildi"
+
+#. placeholder {0}: testResult.length
+#. placeholder {1}: testResult.length !== 1 ? 's' : ''
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:62
+msgid "Found {0} eligible shipping method{1}"
+msgstr "{0} ta mos yetkazib berish usuli{1} topildi"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:746
+msgid "Dimensions"
+msgstr "O'lchamlar"
+
+#: src/lib/components/ui/password-input.tsx:20
+msgid "Show password"
+msgstr "Parolni ko'rsatish"
+
+#. placeholder {0}: formatCurrency(refund.totalRefundableAmount, order.currencyCode)
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:282
+msgid "(max: {0})"
+msgstr "(maksimal: {0})"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:165
+#: src/lib/components/shared/customer-address-form.tsx:111
+msgid "Company"
+msgstr "Kompaniya"
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:149
+msgid "Add column after"
+msgstr "Keyin ustun qo'shish"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:241
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:193
+#: src/lib/components/data-table/data-table-bulk-actions.tsx:82
+#: src/lib/components/data-table/use-generated-columns.tsx:251
+msgid "Actions"
+msgstr "Amallar"
+
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx:120
+msgid "Discounts"
+msgstr "Chegirmalar"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:307
+msgid "Enter refund note"
+msgstr "Pul qaytarish izohini kiriting"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:151
+msgid "Order line removed"
+msgstr "Buyurtma qatori olib tashlandi"
+
+#: src/lib/components/layout/channel-switcher.tsx:158
+msgid "Content:"
+msgstr "Tarkib:"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:260
+msgid "Key"
+msgstr "Kalit"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:360
+#: src/lib/components/shared/navigation-confirmation.tsx:58
+msgid "Confirm"
+msgstr "Tasdiqlash"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:303
+msgid "Failed to complete draft order: {0}"
+msgstr "Qoralama buyurtmani yakunlab bo'lmadi: {0}"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+msgid "Failed to create collection"
+msgstr "To'plamni yaratib bo'lmadi"
+
+#: src/lib/components/data-table/data-table-pagination.tsx:57
+msgid "Go to first page"
+msgstr "Birinchi sahifaga o'tish"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:168
+msgid "Failed to create product"
+msgstr "Mahsulotni yaratib bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:276
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:233
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:457
+#: src/lib/components/shared/role-code-label.tsx:8
+msgid "Customer"
+msgstr "Mijoz"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:46
+msgid "Error loading order history: {0}"
+msgstr "Buyurtma tarixini yuklashda xatolik: {0}"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:195
+msgid "Shipping address set for order"
+msgstr "Buyurtma uchun yetkazib berish manzili o'rnatildi"
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:173
+msgid "Focal Point"
+msgstr "Fokus nuqtasi"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:99
+msgid "Single variant, no options"
+msgstr "Yagona variant, optsiyalarsiz"
+
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:107
+msgid "Select the next state for the order"
+msgstr "Buyurtma uchun keyingi holatni tanlang"
+
+#: src/lib/components/layout/language-dialog.tsx:80
+msgid "Locale"
+msgstr "Til"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:30
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:232
+msgid "Scheduled Tasks"
+msgstr "Rejalashtirilgan vazifalar"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:163
+msgid "Enter transaction ID"
+msgstr "Tranzaksiya ID raqamini kiriting"
+
+#: src/lib/components/data-table/refresh-button.tsx:43
+msgid "Refresh data"
+msgstr "Ma'lumotlarni yangilash"
+
+#. placeholder {0}: entityIds.length
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:162
+msgid "Add or remove facet values for {0} {entityType}"
+msgstr "{0} {entityType} uchun faset qiymatlarini qo'shing yoki olib tashlang"
+
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:34
+msgid "These are the facet values for the <0>{facetName}</0> facet."
+msgstr "Bular <0>{facetName}</0> faseti qiymatlari."
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:49
+msgid "Successfully added payment to order"
+msgstr "Buyurtmaga to'lov qo'shildi"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:206
+msgid "Billing address set for order"
+msgstr "Buyurtma uchun hisob-kitob manzili o'rnatildi"
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+msgid "Failed to update zone"
+msgstr "Hududni yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:133
+#: src/app/routes/_authenticated/_profile/profile.tsx:120
+#: src/app/routes/_authenticated/_profile/profile.tsx:137
+#: src/lib/components/login/login-form.tsx:93
+msgid "Password"
+msgstr "Parol"
+
+#: src/lib/components/data-table/use-generated-columns.tsx:389
+#: src/lib/components/data-table/use-generated-columns.tsx:395
+msgid "Failed to delete"
+msgstr "O'chirib bo'lmadi"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:88
+msgid "Scheduled task will be executed"
+msgstr "Rejalashtirilgan vazifa bajariladi"
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:37
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:88
+msgid "New stock location"
+msgstr "Yangi zaxira joylashuvi"
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:129
+msgid "Permissions"
+msgstr "Ruxsatlar"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:131
+msgid "Shipping address changed"
+msgstr "Yetkazib berish manzili o'zgartirildi"
+
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:63
+msgid "No products found"
+msgstr "Mahsulotlar topilmadi"
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:193
+msgid "Add row before"
+msgstr "Oldin qator qo'shish"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:94
+msgid "Transition to {suggestedState}"
+msgstr "{suggestedState} holatiga o'tkazish"
+
+#: src/lib/components/date-range-picker.tsx:71
+msgctxt "date-range"
+msgid "This month"
+msgstr "Bu oy"
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+msgid "Failed to create facet"
+msgstr "Fasetni yaratib bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:259
+msgid "Failed to cancel order items"
+msgstr "Buyurtma elementlarini bekor qilib bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:160
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:178
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:239
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:58
+msgid "Transaction ID"
+msgstr "Tranzaksiya ID"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:476
+msgid "Allocated"
+msgstr "Ajratilgan"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:270
+msgid "Failed to set coupon code for order: {0}"
+msgstr "Buyurtma uchun kupon kodini o'rnatib bo'lmadi: {0}"
+
+#: src/lib/components/layout/nav-user.tsx:102
+msgid "Explore Platform & Cloud"
+msgstr "Platforma va Cloudni o'rganing"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:115
+msgid "Every 5 seconds"
+msgstr "Har 5 soniyada"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+msgid "Successfully created collection"
+msgstr "To'plam yaratildi"
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:88
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:49
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:324
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:298
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:290
+#: src/lib/components/layout/language-dialog.tsx:136
+msgid "Price"
+msgstr "Narx"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:343
+#: src/app/routes/_authenticated/_orders/orders.tsx:115
+msgid "Draft order"
+msgstr "Qoralama buyurtma"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:281
+#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+msgid "Scope"
+msgstr "Qamrov"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:58
+msgid "Shipping method is eligible for this order"
+msgstr "Yetkazib berish usuli ushbu buyurtmaga mos"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:195
+msgid "Administrators"
+msgstr "Administratorlar"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:49
+msgid "Removed from group"
+msgstr "Guruhdan olib tashlandi"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:182
+msgid "Width"
+msgstr "Eni"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:334
+msgid "No payment or refund required"
+msgstr "To'lov yoki pul qaytarish talab qilinmaydi"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:108
+msgid "Download as .env file"
+msgstr ".env fayli sifatida yuklab olish"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:154
+msgid "When enabled, a promotion is available in the shop"
+msgstr "Yoqilganda, aksiya do'konda mavjud bo'ladi"
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:146
+msgid "When tracked, product variant stock levels will be automatically adjusted when sold. This setting can be overridden by individual product variants."
+msgstr "Kuzatilganda, mahsulot varianti zaxira darajalari sotuvda avtomatik o'zgaradi. Bu sozlamani alohida mahsulot variantlari bekor qilishi mumkin."
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:242
+msgid "Shipping method set for order"
+msgstr "Buyurtma uchun yetkazib berish usuli o'rnatildi"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+msgid "Failed to update promotion"
+msgstr "Aksiyani yangilab bo'lmadi"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:368
+#: src/lib/components/shared/asset/asset-gallery.tsx:380
+msgid "Images"
+msgstr "Rasmlar"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:158
+msgid "API Keys"
+msgstr "API kalitlari"
+
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:64
+msgid "Search {name}..."
+msgstr "{name} qidirish..."
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:110
+msgid "Edit asset"
+msgstr "Assetni tahrirlash"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:153
+msgid "Cancel payment"
+msgstr "To'lovni bekor qilish"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:77
+#: src/app/routes/_authenticated/_system/job-queue.tsx:147
+msgid "Job Queue"
+msgstr "Vazifalar navbati"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:66
+msgid "Assets"
+msgstr "Assetlar"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:188
+msgid "Email address"
+msgstr "Elektron pochta manzili"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:281
+msgid "Failed to remove coupon code from order: {0}"
+msgstr "Buyurtmadan kupon kodini olib tashlab bo'lmadi: {0}"
+
+#: src/lib/components/data-input/slug-input.tsx:266
+#: src/lib/components/data-input/slug-input.tsx:267
+msgid "Regenerate slug from source field"
+msgstr "Manba maydonidan Slugni qayta yaratish"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:387
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:403
+msgid "Inherit from global settings"
+msgstr "Global sozlamalardan meros olish"
+
+#: src/lib/components/data-input/relation-selector.tsx:430
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:190
+#: src/lib/components/shared/facet-value-selector.tsx:163
+msgid "No results found"
+msgstr "Natijalar topilmadi"
+
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:27
+msgid "Set a shipping address and select a shipping method"
+msgstr "Yetkazib berish manzilini o'rnating va usulini tanlang"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:114
+msgid "Off"
+msgstr "O'chirilgan"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:37
+#: src/app/routes/_authenticated/_system/settings-store.tsx:304
+msgid "Settings Store"
+msgstr "Sozlamalar do'koni"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:257
+msgid "Queue"
+msgstr "Navbat"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:37
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:86
+msgid "New tax rate"
+msgstr "Yangi soliq stavkasi"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:69
+msgid "Payment transitioned"
+msgstr "To'lov o'tkazildi"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:290
+msgid "Remaining:"
+msgstr "Qolgan:"
+
+#: src/app/common/duplicate-entity-dialog.tsx:104
+msgid "No duplicator found with code \"{duplicatorCode}\" for {entityName}s"
+msgstr "{entityName}lar uchun \"{duplicatorCode}\" kodli dublikator topilmadi"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:230
+msgid "Prices include tax for default tax zone"
+msgstr "Narxlar standart soliq hududi uchun soliqni o'z ichiga oladi"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:276
+msgid "Total refund:"
+msgstr "Jami pul qaytarish:"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:180
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:176
+msgid "View job result"
+msgstr "Ish natijasini ko'rish"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:30
+msgid "Test your shipping methods by simulating a new order."
+msgstr "Yangi buyurtmani simulyatsiya qilib yetkazib berish usullarini sinab ko'ring."
+
+#: src/lib/components/data-input/product-multi-selector-input.tsx:337
+msgid "No items selected"
+msgstr "Hech qanday element tanlanmagan"
+
+#. placeholder {0}: selected.length
+#: src/lib/components/shared/asset/asset-gallery.tsx:469
+msgid ", {0} selected"
+msgstr ", {0} ta tanlangan"
+
+#: src/lib/components/shared/country-selector.tsx:86
+msgid "No countries found"
+msgstr "Mamlakatlar topilmadi"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:181
+msgid "Successfully created variants"
+msgstr "Variantlar muvaffaqiyatli yaratildi"
+
+#: src/lib/components/data-input/slug-input.tsx:280
+#: src/lib/components/data-input/slug-input.tsx:282
+msgid "Generate slug automatically"
+msgstr "Slugni avtomatik yaratish"
+
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:22
+msgid "Surcharge"
+msgstr "Qo'shimcha to'lov"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:41
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:19
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:29
+msgid "Payment Methods"
+msgstr "To'lov usullari"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:377
+msgid "Stock"
+msgstr "Zaxira"
+
+#: src/lib/components/shared/customer-selector.tsx:88
+msgid "No customers found"
+msgstr "Mijozlar topilmadi"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:436
+msgid "Use global out-of-stock threshold"
+msgstr "Global zaxira tugashi chegarasidan foydalanish"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:60
+msgid "Payment state updated successfully"
+msgstr "To'lov holati yangilandi"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:161
+msgid "Create new"
+msgstr "Yangi yaratish"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:249
+msgid "Refund total"
+msgstr "Pul qaytarish jami"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:55
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:104
+msgid "Address deleted"
+msgstr "Manzil o'chirildi"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:195
+msgid "Only roles assigned to your account are available."
+msgstr "Faqat hisobingizga biriktirilgan rollar mavjud."
+
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:63
+msgid "{cancellableCount, plural, one {Cancel {cancellableCount} job} other {Cancel {cancellableCount} jobs}}"
+msgstr "{cancellableCount, plural, one {{cancellableCount} ta ishni bekor qilish} other {{cancellableCount} ta ishni bekor qilish}}"
+
+#: src/lib/components/data-input/product-multi-selector-input.tsx:399
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:265
+#: src/lib/components/shared/configurable-operation-selector.tsx:140
+msgid "{buttonText}"
+msgstr "{buttonText}"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:111
+msgid "Item added to order"
+msgstr "Element buyurtmaga qo'shildi"
+
+#: src/app/routes/_authenticated/_products/components/shared-option-group-warning.tsx:13
+msgid "{productCount, plural, one {This option group is used by one other product. Changes will affect it too.} other {This option group is shared across # products. Changes will affect all of them.}}"
+msgstr "{productCount, plural, one {Ushbu optsiya guruhidan yana bitta mahsulot foydalanadi. O'zgartirishlar unga ham ta'sir qiladi.} other {Ushbu optsiya guruhi # ta mahsulotda umumiy. O'zgartirishlar barchasiga ta'sir qiladi.}}"
+
+#: src/lib/components/data-table/views-sheet.tsx:125
+msgid "My Saved Views"
+msgstr "Saqlangan ko'rinishlarim"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:39
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:111
+msgid "New channel"
+msgstr "Yangi kanal"
+
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+msgid "Failed to create seller"
+msgstr "Sotuvchini yaratib bo'lmadi"
+
+#. placeholder {0}: entityName.toLowerCase()
+#: src/app/common/duplicate-entity-dialog.tsx:88
+msgid "Configure duplication settings for {0}s"
+msgstr "{0}lar uchun nusxalash sozlamalari"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:304
+msgid "No variants match the current filter."
+msgstr "Joriy filtrga mos variant yo'q."
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:203
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:245
+msgid "Addresses"
+msgstr "Manzillar"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:143
+msgid "Add a new option value to the {groupName} option group"
+msgstr "{groupName} guruhiga yangi optsiya qiymatini qo'shish"
+
+#. placeholder {0}: entry.data.modificationId
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:76
+msgid "Order modification #{0}"
+msgstr "Buyurtma o'zgartirishi #{0}"
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:143
+msgid "Add column before"
+msgstr "Oldidan ustun qo'shish"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:306
+msgid "Channel Languages"
+msgstr "Kanal tillari"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:137
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:119
+msgid "Failed to create option group"
+msgstr "Optsiya guruhini yaratib bo'lmadi"
+
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:54
+msgid "True"
+msgstr "To'g'ri"
+
+#: src/lib/components/shared/customer-selector.tsx:77
+msgid "Select customer"
+msgstr "Mijozni tanlash"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:90
+msgid "Order transitioned"
+msgstr "Buyurtma o'tkazildi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:28
+msgid "is before"
+msgstr "oldin"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:348
+msgid "Delete draft order"
+msgstr "Qoralama buyurtmani o'chirish"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:24
+msgid "Catalog"
+msgstr "Katalog"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:42
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:124
+msgid "New payment method"
+msgstr "Yangi to'lov usuli"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+msgid "Successfully updated promotion"
+msgstr "Aksiya muvaffaqiyatli yangilandi"
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx:111
+#: src/lib/components/shared/channel-selector.tsx:47
+msgid "Select a channel"
+msgstr "Kanalni tanlang"
+
+#: src/lib/components/layout/language-dialog.tsx:58
+msgid "Display language"
+msgstr "Ko'rsatish tili"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:309
+msgid "Fulfillment details"
+msgstr "Bajarish tafsilotlari"
+
+#: src/lib/components/data-input/datetime-input.tsx:181
+msgid "Now"
+msgstr "Hozir"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:181
+msgid "Channels"
+msgstr "Kanallar"
+
+#: src/lib/components/data-table/views-sheet.tsx:118
+msgid "View converted to global successfully"
+msgstr "Ko'rinish global qilib o'zgartirildi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:28
+msgid "before"
+msgstr "oldin"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:188
+msgid "Failed to set customer for order: {0}"
+msgstr "Buyurtmaga mijozni o'rnatib bo'lmadi: {0}"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:745
+msgid "Size"
+msgstr "O'lcham"
+
+#. placeholder {0}: formatLanguageName(contentLanguage)
+#: src/lib/components/shared/translatable-form-field.tsx:68
+msgid "No translation found for {0}"
+msgstr "{0} uchun tarjima topilmadi"
+
+#: src/app/routes/_authenticated/_customers/customers.tsx:92
+msgid "New Customer"
+msgstr "Yangi mijoz"
+
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+msgid "Latest Orders"
+msgstr "So'nggi buyurtmalar"
+
+#: src/app/routes/_authenticated/_collections/collections.tsx:427
+msgid "+ {leftOver} more"
+msgstr "+ yana {leftOver} ta"
+
+#: src/lib/components/shared/customer-address-form.tsx:241
+msgid "Use as the default billing address"
+msgstr "Standart hisob-kitob manzili sifatida ishlatish"
+
+#: src/app/common/delete-bulk-action.tsx:139
+#: src/app/routes/_authenticated/_assets/components/asset-bulk-actions.tsx:41
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:357
+#: src/lib/components/data-table/use-generated-columns.tsx:405
+#: src/lib/components/data-table/use-generated-columns.tsx:435
+#: src/lib/components/data-table/views-sheet.tsx:270
+#: src/lib/components/data-table/views-sheet.tsx:296
+msgid "Delete"
+msgstr "O'chirish"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+msgid "Disable"
+msgstr "O'chirib qo'yish"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:59
+msgid "Collections"
+msgstr "To'plamlar"
+
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:225
+msgid "Add variant"
+msgstr "Variant qo'shish"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:69
+msgid "Failed to create country"
+msgstr "Mamlakatni yaratib bo'lmadi"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:237
+msgid "Countries"
+msgstr "Mamlakatlar"
+
+#: src/lib/components/data-table/views-sheet.tsx:68
+msgid "Failed to rename view"
+msgstr "Ko'rinish nomini o'zgartirib bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:306
+msgid "Available"
+msgstr "Mavjud"
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:95
+msgid "Normal"
+msgstr "Oddiy"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:195
+msgid "Filters"
+msgstr "Filtrlar"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:105
+msgid "Customer Groups"
+msgstr "Mijozlar guruhlari"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:91
+#: src/lib/framework/defaults.ts:98
+msgid "Customers"
+msgstr "Mijozlar"
+
+#: src/lib/components/layout/language-dialog.tsx:103
+msgid "Sample Formatting"
+msgstr "Namuna formatlash"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:83
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:92
+msgid "New option"
+msgstr "Yangi parametr"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:220
+msgid "Usage limit"
+msgstr "Foydalanish chegarasi"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:267
+msgid "Loading global settings..."
+msgstr "Global sozlamalar yuklanmoqda..."
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:56
+msgid "Address updated successfully"
+msgstr "Manzil yangilandi"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:226
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:124
+#: src/lib/components/shared/asset/asset-gallery.tsx:747
+#: src/lib/framework/layout-engine/page-layout.tsx:733
+msgid "Created"
+msgstr "Yaratilgan"
+
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:76
+msgid "Loading addresses..."
+msgstr "Manzillar yuklanmoqda..."
+
+#. placeholder {0}: collectionsToMove.length === 1 ? 'this collection' : `${collectionsToMove.length} collections`
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:343
+msgid "Select a target collection to move {0} to."
+msgstr "{0}ni ko'chirish uchun maqsadli to'plamni tanlang."
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:232
+msgid "Failed to unset billing address for order: {0}"
+msgstr "Buyurtma hisob-kitob manzilini bekor qilib bo'lmadi: {0}"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:45
+msgid "Customer details updated"
+msgstr "Mijoz tafsilotlari yangilandi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:38
+msgid "not in"
+msgstr "ichida emas"
+
+#: src/lib/components/data-table/views-sheet.tsx:227
+msgid "Apply"
+msgstr "Qo'llash"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:163
+msgid "New product option"
+msgstr "Yangi mahsulot parametri"
+
+#: src/lib/components/data-table/data-table-pagination.tsx:94
+msgid "Go to last page"
+msgstr "Oxirgi sahifaga o'tish"
+
+#: src/app/common/duplicate-entity-dialog.tsx:113
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:61
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:203
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:418
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:168
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:311
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:352
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:358
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:71
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:273
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:493
+#: src/app/routes/_authenticated/_system/settings-store.tsx:140
+#: src/lib/components/data-input/product-multi-selector-input.tsx:370
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx:122
+#: src/lib/components/data-table/use-generated-columns.tsx:421
+#: src/lib/components/data-table/views-sheet.tsx:217
+#: src/lib/components/data-table/views-sheet.tsx:293
+#: src/lib/components/layout/manage-languages-dialog.tsx:379
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:88
+#: src/lib/components/shared/assign-to-channel-dialog.tsx:126
+#: src/lib/components/shared/confirmation-dialog.tsx:42
+#: src/lib/components/shared/customer-address-form.tsx:253
+#: src/lib/components/shared/navigation-confirmation.tsx:55
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:208
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:146
+msgid "Cancel"
+msgstr "Bekor qilish"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:95
+msgid "Failed to update order custom fields: {0}"
+msgstr "Buyurtmaning maxsus maydonlarini yangilab bo'lmadi: {0}"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:146
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:160
+msgid "Successfully created product variant"
+msgstr "Mahsulot varianti muvaffaqiyatli yaratildi"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:236
+msgid "Refund from this method"
+msgstr "Ushbu usuldan pul qaytarish"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:208
+#: src/lib/components/shared/customer-address-form.tsx:163
+msgid "Postal Code"
+msgstr "Pochta indeksi"
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:37
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:88
+msgid "New tax category"
+msgstr "Yangi soliq toifasi"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:285
+msgid "Partial refund completed"
+msgstr "Qisman pul qaytarish bajarildi"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:452
+msgid "Set custom fields"
+msgstr "Maxsus maydonlarni o'rnatish"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:46
+#: src/app/routes/_authenticated/_collections/collections.tsx:51
+#: src/app/routes/_authenticated/_collections/collections.tsx:339
+msgid "Collections"
+msgstr "To'plamlar"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:453
+msgid "Delete variant"
+msgstr "Variantni o'chirish"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:249
+msgid "No modifications made"
+msgstr "Hech qanday o'zgartirish kiritilmadi"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:222
+msgid "Default shipping zone"
+msgstr "Standart yetkazib berish hududi"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:127
+msgid "Reason:"
+msgstr "Sabab:"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:291
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:248
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:470
+msgid "Shipping address"
+msgstr "Yetkazib berish manzili"
+
+#. placeholder {0}: getTranslatedFulfillmentState(state)
+#. placeholder {0}: getTranslatedOrderState(state)
+#. placeholder {0}: getTranslatedPaymentState(state)
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:102
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:125
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:154
+msgid "Transition to {0}"
+msgstr "{0}ga o'tkazish"
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:36
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:14
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:23
+msgid "Tax Categories"
+msgstr "Soliq toifalari"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:158
+msgid "Private collections are not visible in the shop"
+msgstr "Maxfiy to'plamlar do'konda ko'rinmaydi"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:262
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:229
+msgid "When enabled, a product is available in the shop"
+msgstr "Yoqilganda mahsulot do'konda mavjud bo'ladi"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:91
+msgid "Scheduled task could not be executed"
+msgstr "Rejalashtirilgan vazifani bajarib bo'lmadi"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:35
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:14
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:21
+msgid "Customer Groups"
+msgstr "Mijozlar guruhlari"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:123
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:58
+#: src/lib/components/layout/nav-user.tsx:155
+msgid "Disabled"
+msgstr "O'chirilgan"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:44
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:131
+msgid "New promotion"
+msgstr "Yangi aksiya"
+
+#: src/lib/components/shared/customer-address-form.tsx:220
+msgid "Default Shipping Address"
+msgstr "Standart yetkazib berish manzili"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:63
+msgid "{operator}"
+msgstr "{operator}"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:177
+msgid "Refund required"
+msgstr "Pul qaytarish talab qilinadi"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:222
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:228
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:317
+msgid "Fulfill order"
+msgstr "Buyurtmani bajarish"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:316
+msgid "You don't have permission to view channel settings"
+msgstr "Sizda kanal sozlamalarini ko'rish uchun ruxsat yo'q"
+
+#: src/lib/components/date-range-picker.tsx:55
+msgctxt "date-range"
+msgid "Last 30 days"
+msgstr "So'nggi 30 kun"
+
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:238
+msgid "No facet values"
+msgstr "Faset qiymatlari yo'q"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:214
+msgid "A reason for the refund is required"
+msgstr "Pul qaytarish uchun sabab talab qilinadi"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:194
+msgid "Could not remove option group"
+msgstr "Optsiya guruhini olib tashlab bo'lmadi"
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+msgid "Failed to update tax category"
+msgstr "Soliq toifasini yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:90
+msgid "Refund settled successfully"
+msgstr "Pul qaytarish muvaffaqiyatli hisoblashildi"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:105
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:115
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:122
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:159
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:102
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:51
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:279
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:219
+#: src/app/routes/_authenticated/_profile/profile.tsx:92
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+#: src/lib/framework/page/detail-page.tsx:189
+msgid "Update"
+msgstr "Yangilash"
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:97
+msgid "Heading 2"
+msgstr "2-sarlavha"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:79
+msgid "Order placed"
+msgstr "Buyurtma berildi"
+
+#: src/app/routes/_authenticated/_profile/profile.tsx:71
+msgid "Successfully updated profile"
+msgstr "Profil muvaffaqiyatli yangilandi"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:146
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:168
+msgid "Payment method"
+msgstr "To'lov usuli"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:263
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:292
+#: src/lib/components/shared/history-timeline/history-note-entry.tsx:46
+msgid "Edit"
+msgstr "Tahrirlash"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:183
+msgid "Variant updated successfully"
+msgstr "Variant muvaffaqiyatli yangilandi"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:370
+msgid "Filter by collection name"
+msgstr "To'plam nomi bo'yicha filtrlash"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:43
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:76
+msgid "Note added"
+msgstr "Eslatma qo'shildi"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:231
+msgid "Select quantities to fulfill and configure the fulfillment handler"
+msgstr "Bajarish uchun miqdorlarni tanlang va bajarish ishlovchisini sozlang"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:228
+msgid "Billing address unset for order"
+msgstr "Buyurtma hisob-kitob manzili bekor qilindi"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:182
+msgid "Starts at"
+msgstr "Boshlanadi"
+
+#: src/app/common/duplicate-bulk-action.tsx:131
+#: src/app/common/duplicate-entity-dialog.tsx:116
+#: src/lib/components/data-table/views-sheet.tsx:244
+msgid "Duplicate"
+msgstr "Nusxalash"
+
+#: src/lib/components/data-table/data-table.tsx:588
+#: src/lib/components/shared/customer-group-selector.tsx:56
+msgid "No results"
+msgstr "Natijalar yo'q"
+
+#: src/lib/components/data-table/data-table-view-options.tsx:89
+msgid "Column settings"
+msgstr "Ustun sozlamalari"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:132
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:110
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:137
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:126
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:208
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:176
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:164
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:100
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:154
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:61
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:98
+msgid "Code"
+msgstr "Kod"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:203
+msgid "Failed to remove option groups"
+msgstr "Optsiya guruhlarini olib tashlab bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:97
+msgid "Order delivered"
+msgstr "Buyurtma yetkazib berildi"
+
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:49
+msgid "Remove from zone"
+msgstr "Hududdan olib tashlash"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:341
+msgid "Select from globally available languages for this channel"
+msgstr "Ushbu kanal uchun global mavjud tillardan tanlang"
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:142
+msgid "Are you sure you want to delete this address?"
+msgstr "Ushbu manzilni o'chirishni xohlaysizmi?"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:77
+msgid "Failed to assign option group"
+msgstr "Optsiya guruhini biriktirib bo'lmadi"
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:89
+msgid "Failed to update asset"
+msgstr "Assetni yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:68
+msgid "Successfully updated stock location"
+msgstr "Zaxira joylashuvi yangilandi"
+
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx:116
+msgid "Confirm Action"
+msgstr "Amalni tasdiqlash"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+msgid "Successfully updated country"
+msgstr "Mamlakat yangilandi"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:52
+msgid "Facets"
+msgstr "Fasetlar"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:103
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:108
+msgid "Failed to add note"
+msgstr "Eslatma qo'shib bo'lmadi"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:144
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:150
+msgid "Failed to delete note"
+msgstr "Eslatmani o'chirib bo'lmadi"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-list-query.ts:41
+msgid "Failed to extend query document"
+msgstr "So'rov hujjatini kengaytirib bo'lmadi"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:124
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:129
+msgid "Failed to update note"
+msgstr "Eslatmani yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:201
+msgid "Refund shipping"
+msgstr "Yetkazib berish uchun pul qaytarish"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:289
+#: src/app/routes/_authenticated/_system/settings-store.tsx:293
+#: src/app/routes/_authenticated/_system/settings-store.tsx:324
+msgid "Readonly"
+msgstr "Faqat o'qish uchun"
+
+#: src/lib/components/data-table/views-sheet.tsx:100
+msgid "Failed to duplicate global view"
+msgstr "Global ko'rinishni nusxalab bo'lmadi"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:254
+msgid "Showing {shown} of {total} • {selected} selected"
+msgstr "{total} dan {shown} ko'rsatilmoqda • {selected} tanlangan"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:37
+msgid "Test Shipping Method"
+msgstr "Yetkazib berish usulini sinash"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:491
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:333
+msgid "Facet Values"
+msgstr "Faset qiymatlari"
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:85
+msgid "Successfully updated asset"
+msgstr "Asset yangilandi"
+
+#: src/lib/components/layout/nav-user.tsx:118
+msgid "Theme"
+msgstr "Mavzu"
+
+#. placeholder {0}: value.totalItems
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:40
+msgid "{0} customers"
+msgstr "{0} mijoz"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:48
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:14
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:25
+msgid "API Keys"
+msgstr "API kalitlari"
+
+#: src/lib/components/shared/language-selector.tsx:52
+msgid "Select a language"
+msgstr "Tilni tanlang"
+
+#: src/lib/components/layout/nav-user.tsx:164
+msgid "Log out"
+msgstr "Chiqish"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:50
+msgid "fieldName.attempts"
+msgstr "Urinishlar"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:51
+msgid "fieldName.availableCurrencyCodes"
+msgstr "Mavjud valyuta kodlari"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:52
+msgid "fieldName.availableLanguageCodes"
+msgstr "Mavjud til kodlari"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:53
+msgid "fieldName.breadcrumbs"
+msgstr "Yo'l ko'rsatkichlari"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:54
+msgid "fieldName.category"
+msgstr "Toifa"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:55
+msgid "fieldName.channels"
+msgstr "Kanallar"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:56
+msgid "fieldName.children"
+msgstr "Quyi elementlar"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:57
+msgid "fieldName.code"
+msgstr "Kod"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:58
+msgid "fieldName.couponCode"
+msgstr "Kupon kodi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:59
+msgid "fieldName.createdAt"
+msgstr "Yaratilgan sana"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:60
+msgid "fieldName.currencyCode"
+msgstr "Valyuta kodi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:61
+msgid "fieldName.customer"
+msgstr "Mijoz"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:62
+msgid "fieldName.customerGroup"
+msgstr "Mijozlar guruhi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:63
+msgid "fieldName.customers"
+msgstr "Mijozlar"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:64
+msgid "fieldName.customFields"
+msgstr "Maxsus maydonlar"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:65
+msgid "fieldName.data"
+msgstr "Ma'lumotlar"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:66
+msgid "fieldName.defaultCurrencyCode"
+msgstr "Standart valyuta kodi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:67
+msgid "fieldName.defaultLanguageCode"
+msgstr "Standart til kodi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:68
+msgid "fieldName.defaultShippingZone"
+msgstr "Standart yetkazib berish hududi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:69
+msgid "fieldName.defaultTaxZone"
+msgstr "Standart soliq hududi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:70
+msgid "fieldName.description"
+msgstr "Tavsif"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:71
+msgid "fieldName.duration"
+msgstr "Davomiyligi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:72
+msgid "fieldName.emailAddress"
+msgstr "Elektron pochta manzili"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:73
+msgid "fieldName.enabled"
+msgstr "Yoqilgan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:74
+msgid "fieldName.endsAt"
+msgstr "Tugash vaqti"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:75
+msgid "fieldName.error"
+msgstr "Xato"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:76
+msgid "fieldName.featuredAsset"
+msgstr "Asosiy asset"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:77
+msgid "fieldName.firstName"
+msgstr "Ism"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:78
+msgid "fieldName.fulfillmentHandlerCode"
+msgstr "Bajarish ishlovchisi kodi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:79
+msgid "fieldName.id"
+msgstr "ID"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:80
+msgid "fieldName.isDefault"
+msgstr "Standartmi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:81
+msgid "fieldName.isPrivate"
+msgstr "Maxfiymi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:82
+msgid "fieldName.isSettled"
+msgstr "Hisob-kitob qilinganmi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:83
+msgid "fieldName.lastName"
+msgstr "Familiya"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:84
+msgid "fieldName.name"
+msgstr "Nomi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:85
+msgid "fieldName.orderPlacedAt"
+msgstr "Buyurtma berilgan vaqt"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:86
+msgid "fieldName.parentId"
+msgstr "Asosiy ID"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:87
+msgid "fieldName.perCustomerUsageLimit"
+msgstr "Har bir mijoz uchun foydalanish chegarasi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:88
+msgid "fieldName.permissions"
+msgstr "Ruxsatlar"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:89
+msgid "fieldName.position"
+msgstr "Joylashuv"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:90
+msgid "fieldName.price"
+msgstr "Narx"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:92
+msgid "fieldName.pricesIncludeTax"
+msgstr "Narxlar soliqni o'z ichiga oladi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:91
+msgid "fieldName.priceWithTax"
+msgstr "Soliqli narx"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:93
+msgid "fieldName.productVariants"
+msgstr "Mahsulot variantlari"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:94
+msgid "fieldName.progress"
+msgstr "Jarayon"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:95
+msgid "fieldName.queueName"
+msgstr "Navbat nomi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:96
+msgid "fieldName.result"
+msgstr "Natija"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:97
+msgid "fieldName.retries"
+msgstr "Qayta urinishlar"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:98
+msgid "fieldName.seller"
+msgstr "Sotuvchi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:99
+msgid "fieldName.settledAt"
+msgstr "Hisob-kitob qilingan vaqt"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:100
+msgid "fieldName.shippingLines"
+msgstr "Yetkazib berish qatorlari"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:101
+msgid "fieldName.sku"
+msgstr "SKU"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:102
+msgid "fieldName.slug"
+msgstr "Slug"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:103
+msgid "fieldName.startedAt"
+msgstr "Boshlangan vaqt"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:104
+msgid "fieldName.startsAt"
+msgstr "Boshlanish vaqti"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:105
+msgid "fieldName.state"
+msgstr "Holat"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:106
+msgid "fieldName.stockLevels"
+msgstr "Zaxira darajalari"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:107
+msgid "fieldName.token"
+msgstr "Token"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:108
+msgid "fieldName.total"
+msgstr "Jami"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:109
+msgid "fieldName.totalWithTax"
+msgstr "Soliqli jami"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:110
+msgid "fieldName.type"
+msgstr "Turi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:111
+msgid "fieldName.updatedAt"
+msgstr "Yangilangan sana"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:112
+msgid "fieldName.usageLimit"
+msgstr "Foydalanish chegarasi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:113
+msgid "fieldName.user"
+msgstr "Foydalanuvchi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:114
+msgid "fieldName.value"
+msgstr "Qiymat"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:115
+msgid "fieldName.valueList"
+msgstr "Qiymatlar ro'yxati"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:116
+msgid "fieldName.zone"
+msgstr "Hudud"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:116
+msgid "Method"
+msgstr "Usul"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:232
+msgid "Tax summary"
+msgstr "Soliq xulosasi"
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:114
+msgid "Sets the languages that are available for all channels. Individual channels can then support a subset of these languages."
+msgstr "Barcha kanallar uchun mavjud tillarni belgilaydi. Alohida kanallar bu tillarning bir qismini qo'llab-quvvatlashi mumkin."
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:284
+msgid "Collections moved successfully"
+msgstr "To'plamlar ko'chirildi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:23
+msgid "Registered"
+msgstr "Ro'yxatdan o'tgan"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:199
+msgid "Failed to set shipping address for order: {0}"
+msgstr "Buyurtma uchun yetkazib berish manzilini o'rnatib bo'lmadi: {0}"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:231
+msgid "Cancel Job"
+msgstr "Ishni bekor qilish"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:194
+msgid "Ends at"
+msgstr "Tugaydi"
+
+#. placeholder {0}: table.getState().pagination.pageIndex + 1
+#. placeholder {1}: table.getPageCount() || 1
+#: src/lib/components/data-table/data-table-pagination.tsx:43
+msgid "Page {0} of {1}"
+msgstr "{1} dan {0} sahifa"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:119
+msgid "Rate"
+msgstr "Stavka"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:114
+msgid "Size, colour, etc."
+msgstr "O'lcham, rang va h.k."
+
+#: src/lib/components/shared/facet-value-selector.tsx:155
+#: src/lib/components/shared/facet-value-selector.tsx:172
+msgid "Browse facets"
+msgstr "Fasetlarni ko'rib chiqish"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:72
+msgid "Zone"
+msgstr "Hudud"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:9
+#: src/i18n/common-strings.ts:12
+msgid "fulfillmentState.Cancelled"
+msgstr "Bekor qilingan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:7
+msgid "fulfillmentState.Created"
+msgstr "Yaratilgan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:11
+msgid "fulfillmentState.Delivered"
+msgstr "Yetkazilgan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:8
+msgid "fulfillmentState.Pending"
+msgstr "Kutilmoqda"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:10
+msgid "fulfillmentState.Shipped"
+msgstr "Jo'natilgan"
+
+#: src/lib/components/data-table/save-view-button.tsx:35
+msgid "Save View"
+msgstr "Ko'rinishni saqlash"
+
+#. placeholder {0}: selection.length
+#: src/lib/components/data-table/data-table-bulk-actions.tsx:78
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx:80
+msgid "{0} selected"
+msgstr "{0} tanlangan"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:239
+msgid "Search option groups..."
+msgstr "Optsiya guruhlarini qidirish..."
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:168
+msgid "Modify order"
+msgstr "Buyurtmani o'zgartirish"
+
+#: src/lib/components/data-input/product-multi-selector-input.tsx:322
+msgid "Selected Items"
+msgstr "Tanlangan elementlar"
+
+#: src/app/routes/_authenticated/_facets/facets.tsx:50
+msgid "Values"
+msgstr "Qiymatlar"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:170
+msgid "Customer set for order"
+msgstr "Buyurtma uchun mijoz o'rnatildi"
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:38
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:35
+#: src/app/routes/_authenticated/_facets/facets.tsx:21
+#: src/app/routes/_authenticated/_facets/facets.tsx:28
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:233
+#: src/lib/components/shared/facet-value-selector.tsx:222
+msgid "Facets"
+msgstr "Fasetlar"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:293
+msgid "Stock on Hand"
+msgstr "Mavjud zaxira"
+
+#: src/app/routes/_authenticated/_products/products.tsx:35
+msgid "Search index rebuild could not be started"
+msgstr "Qidiruv indeksini qayta qurish boshlanmadi"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:143
+msgid "Shipping Address"
+msgstr "Yetkazib berish manzili"
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:34
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:76
+msgid "New zone"
+msgstr "Yangi hudud"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:49
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:136
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:79
+msgid "New API Key"
+msgstr "Yangi API kaliti"
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:164
+msgid "Delete column"
+msgstr "Ustunni oʻchirish"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:157
+msgid "Assign existing"
+msgstr "Mavjudini biriktirish"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:34
+msgid "is null"
+msgstr "boʻsh"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:37
+msgid "These are the customers in the <0>{customerGroupName}</0> customer group."
+msgstr "Bular <0>{customerGroupName}</0> guruhidagi mijozlar."
+
+#: src/lib/components/data-table/manage-global-views-button.tsx:18
+msgid "Manage global views"
+msgstr "Global koʻrinishlarni boshqarish"
+
+#: src/lib/components/shared/channel-code-label.tsx:5
+msgid "Default channel"
+msgstr "Standart kanal"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+msgid "Insert a new image with source, title, and dimensions"
+msgstr "Manba, sarlavha va oʻlchamlar bilan yangi rasm qoʻshish"
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+msgid "Failed to create facet value"
+msgstr "Faset qiymatini yaratib boʻlmadi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:24
+msgid "="
+msgstr "="
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:151
+msgid "Failed to update product option"
+msgstr "Mahsulot opsiyasini yangilab boʻlmadi"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:206
+msgid "Coupon code"
+msgstr "Kupon kodi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:41
+msgid "Customer verified"
+msgstr "Mijoz tasdiqlandi"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:251
+msgid "Global Settings"
+msgstr "Global sozlamalar"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:132
+msgid "Schedule"
+msgstr "Jadval"
+
+#: src/app/routes/_authenticated/_collections/collections.tsx:288
+msgid "Cannot move a collection into its own descendant"
+msgstr "Toʻplamni oʻzining avlodiga koʻchirib boʻlmaydi"
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:58
+msgid "New Tax Category"
+msgstr "Yangi soliq toifasi"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:83
+msgid "Successfully created channel"
+msgstr "Kanal yaratildi"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:98
+msgid "Successfully updated customer"
+msgstr "Mijoz yangilandi"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:166
+msgid "View data"
+msgstr "Maʼlumotlarni koʻrish"
+
+#: src/lib/components/data-table/views-sheet.tsx:163
+msgid "Delete View"
+msgstr "Koʻrinishni oʻchirish"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:231
+msgid "Add a new address to the customer."
+msgstr "Mijozga yangi manzil qoʻshish."
+
+#: src/lib/components/data-table/global-views-bar.tsx:75
+msgid "More views"
+msgstr "Koʻproq koʻrinishlar"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:109
+msgid "Edit the selected image properties"
+msgstr "Tanlangan rasm xususiyatlarini tahrirlash"
+
+#: src/lib/components/data-table/views-sheet.tsx:49
+msgid "Applied view \"{viewName}\""
+msgstr "\"{viewName}\" ko'rinishi qo'llanildi"
+
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:80
+msgid "Successfully removed {successCount} facets from channel"
+msgstr "Kanaldan {successCount} faset olib tashlandi"
+
+#: src/app/routes/_authenticated/_products/products.tsx:117
+msgid "New Product"
+msgstr "Yangi mahsulot"
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:40
+msgid "New asset"
+msgstr "Yangi asset"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:262
+msgid "Recalculate shipping"
+msgstr "Yetkazib berishni qayta hisoblash"
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:39
+#: src/app/routes/_authenticated/_assets/assets.tsx:17
+#: src/app/routes/_authenticated/_assets/assets.tsx:40
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:225
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:508
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:366
+msgid "Assets"
+msgstr "Assetlar"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:307
+msgid "This will remove all option groups from this product and return to the variant setup choice."
+msgstr "Bu mahsulotdagi barcha optsiya guruhlarini olib tashlaydi va variant sozlash tanloviga qaytaradi."
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:299
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:277
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:502
+msgid "Billing address"
+msgstr "Hisob-faktura manzili"
+
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:131
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:172
+msgid "Add facet value"
+msgstr "Faset qiymatini qoʻshish"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:312
+msgid "Please select a target collection"
+msgstr "Maqsadli toʻplamni tanlang"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:159
+msgid "Review the changes before applying them to the order."
+msgstr "Buyurtmaga qoʻllashdan oldin oʻzgarishlarni koʻrib chiqing."
+
+#: src/lib/components/shared/role-selector.tsx:52
+msgid "Select a role"
+msgstr "Rolni tanlang"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:132
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:85
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:112
+msgid "Order cancelled"
+msgstr "Buyurtma bekor qilindi"
+
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:38
+msgid "Discount"
+msgstr "Chegirma"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:367
+#: src/lib/components/shared/asset/asset-gallery.tsx:379
+msgid "All types"
+msgstr "Barcha turlar"
+
+#: src/app/routes/_authenticated/_orders/components/draft-order-status.tsx:29
+msgid "Only draft orders can be completed"
+msgstr "Faqat qoralama buyurtmalarni yakunlash mumkin"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:168
+msgid "Failed to update product"
+msgstr "Mahsulotni yangilab boʻlmadi"
+
+#. placeholder {0}: adjustedLines.length
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:152
+msgid "Adjusting {0} lines"
+msgstr "{0} qator sozlanmoqda"
+
+#: src/lib/components/shared/facet-value-selector.tsx:118
+msgid "Add facet values"
+msgstr "Faset qiymatlarini qoʻshish"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:30
+msgid "after"
+msgstr "keyin"
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx:103
+msgid "Channel"
+msgstr "Kanal"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:170
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:317
+msgid "Amount"
+msgstr "Miqdor"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:242
+#: src/lib/components/shared/customer-address-form.tsx:201
+msgid "Phone Number"
+msgstr "Telefon raqami"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:62
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:152
+msgid "New customer"
+msgstr "Yangi mijoz"
+
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx:33
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:90
+msgid "Image"
+msgstr "Rasm"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:77
+msgid "Successfully created administrator"
+msgstr "Administrator yaratildi"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:198
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:315
+msgid "Product Options"
+msgstr "Mahsulot opsiyalari"
+
+#: src/lib/components/shared/country-selector.tsx:72
+msgid "Select country"
+msgstr "Mamlakatni tanlang"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:427
+msgid "Creating..."
+msgstr "Yaratilmoqda..."
+
+#: src/lib/components/data-table/views-sheet.tsx:168
+msgid "Are you sure you want to delete this global view? This action cannot be undone and will affect all users."
+msgstr "Ushbu global koʻrinishni oʻchirasizmi? Bu amalni bekor qilib boʻlmaydi va barcha foydalanuvchilarga taʼsir qiladi."
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:486
+msgid "Force remove option group"
+msgstr "Optsiya guruhini majburan olib tashlash"
+
+#: src/app/routes/_authenticated/_profile/profile.tsx:140
+msgid "Added"
+msgstr "Qoʻshildi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:30
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:250
+msgid "Customer history"
+msgstr "Mijoz tarixi"
+
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:75
+msgid "Successfully updated facet values for {entityIdsLength} {entityType}"
+msgstr "{entityIdsLength} {entityType} uchun faset qiymatlari yangilandi"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:144
+msgid "Failed to remove customer from group"
+msgstr "Mijozni guruhdan olib tashlab boʻlmadi"
+
+#: src/lib/components/layout/nav-user.tsx:135
+msgctxt "theme"
+msgid "System"
+msgstr "Tizim"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:212
+msgid "Per customer usage limit"
+msgstr "Har bir mijoz uchun foydalanish chegarasi"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:138
+msgid "Billing address changed"
+msgstr "Hisob-faktura manzili oʻzgartirildi"
+
+#: src/lib/components/data-input/select-with-options.tsx:107
+msgid "Select an option"
+msgstr "Opsiyani tanlang"
+
+#: src/lib/components/data-table/views-sheet.tsx:251
+msgid "Copy to Personal"
+msgstr "Shaxsiyga nusxalash"
+
+#. placeholder {0}: formatCurrency(totalRefundableAmount, order.currencyCode)
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:205
+msgid "Refund total exceeds maximum refundable amount of {0}"
+msgstr "Pul qaytarish jami {0} maksimal qaytariladigan miqdordan oshib ketadi"
+
+#: src/lib/components/data-table/views-sheet.tsx:163
+msgid "Delete Global View"
+msgstr "Global koʻrinishni oʻchirish"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:105
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:155
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:122
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:148
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:84
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:93
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:159
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:110
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:99
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:177
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:160
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:138
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:252
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:219
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:144
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:84
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:78
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:138
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:96
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:96
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:93
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:83
+msgid "Create"
+msgstr "Yaratish"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:117
+msgid "Every 30 seconds"
+msgstr "Har 30 soniyada"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:33
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:77
+msgid "New country"
+msgstr "Yangi mamlakat"
+
+#. placeholder {0}: entry.data.from
+#. placeholder {1}: entry.data.to
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:13
+msgid "From {0} to {1}"
+msgstr "{0} dan {1} gacha"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:105
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:111
+msgid "Failed to create customer"
+msgstr "Mijozni yaratib boʻlmadi"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:298
+msgid "Option values"
+msgstr "Optsiya qiymatlari"
+
+#: src/lib/components/shared/customer-address-form.tsx:238
+msgid "Default Billing Address"
+msgstr "Standart hisob-faktura manzili"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:284
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:241
+msgid "No customer"
+msgstr "Mijoz yoʻq"
+
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:36
+msgid "Failed to remove countries from zone"
+msgstr "Hududdan mamlakatlarni olib tashlab boʻlmadi"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:112
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:120
+msgid "Failed to create promotion"
+msgstr "Aksiyani yaratib boʻlmadi"
+
+#: src/lib/components/date-range-picker.tsx:23
+msgctxt "date-range"
+msgid "Today"
+msgstr "Bugun"
+
+#: src/lib/components/date-range-picker.tsx:31
+msgctxt "date-range"
+msgid "Yesterday"
+msgstr "Kecha"
+
+#. placeholder {0}: selection.length
+#. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:51
+msgid "Are you sure you want to remove {0} {1} from this zone?"
+msgstr "Ushbu hududdan {0} {1} ni olib tashlaysizmi?"
+
+#. placeholder {0}: addedSurcharges.length
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:233
+msgid "Adding {0} surcharge(s)"
+msgstr "{0} ustama qoʻshilmoqda"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:93
+msgid "Link href"
+msgstr "Havola href"
+
+#: src/lib/utils/get-locale-fallback-placeholder.ts:31
+msgid "Fallback: {value}"
+msgstr "Zaxira: {value}"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:260
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:30
+msgid "Order history"
+msgstr "Buyurtma tarixi"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:263
+msgid "Override"
+msgstr "Bekor qilish"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:161
+msgid "Transaction ID is required"
+msgstr "Tranzaksiya ID talab qilinadi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:60
+msgid "matches regex"
+msgstr "regex bilan mos keladi"
+
+#: src/lib/components/data-table/views-sheet.tsx:63
+msgid "Global view renamed successfully"
+msgstr "Global koʻrinish nomi oʻzgartirildi"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:111
+msgid "No tags selected"
+msgstr "Hech qanday teg tanlanmagan"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:408
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:417
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:205
+msgid "Back"
+msgstr "Orqaga"
+
+#: src/lib/components/data-table/views-sheet.tsx:63
+msgid "View renamed successfully"
+msgstr "Koʻrinish nomi oʻzgartirildi"
+
+#: src/lib/components/data-table/data-table-filter-dialog.tsx:89
+msgid "Apply filter"
+msgstr "Filtrni qoʻllash"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:171
+msgid "Last Result"
+msgstr "Oxirgi natija"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:47
+msgid "Added to group"
+msgstr "Guruhga qoʻshildi"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:16
+msgid "Insights"
+msgstr "Tahlillar"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:31
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:46
+msgid "Testing shipping method..."
+msgstr "Yetkazib berish usuli sinovdan oʻtkazilmoqda..."
+
+#: src/lib/components/layout/nav-user.tsx:131
+msgctxt "theme"
+msgid "Dark"
+msgstr "Qorongʻi"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:39
+msgid "Test Results"
+msgstr "Sinov natijalari"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:127
+msgid "Add customer"
+msgstr "Mijoz qoʻshish"
+
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
+#: src/lib/components/layout/manage-languages-dialog.tsx:382
+msgid "Save Changes"
+msgstr "Oʻzgarishlarni saqlash"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:53
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:78
+msgid "Address updated"
+msgstr "Manzil yangilandi"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:299
+msgid "Refund processed successfully"
+msgstr "Pul qaytarish amalga oshirildi"
+
+#. placeholder {0}: action.label
+#. placeholder {0}: entityType === 'products' ? 'Product' : 'Variant'
+#. placeholder {0}: entry.type.replace(/_/g, ' ').toLowerCase()
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:67
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:115
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:37
+#: src/app/routes/_authenticated/_orders/components/shipping-method-selector.tsx:44
+#: src/app/routes/_authenticated/_orders/components/state-transition-control.tsx:77
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:192
+#: src/app/routes/_authenticated/_tax-categories/tax-categories.tsx:44
+#: src/lib/components/data-input/product-multi-selector-input.tsx:281
+#: src/lib/components/data-input/product-multi-selector-input.tsx:284
+#: src/lib/components/data-input/relation-selector.tsx:404
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:439
+msgid "{0}"
+msgstr "{0}"
+
+#: src/app/routes/_authenticated/_zones/zones.tsx:53
+msgid "New Zone"
+msgstr "Yangi hudud"
+
+#: src/app/routes/_authenticated/_collections/collections.tsx:330
+msgid "Failed to update collection position"
+msgstr "Toʻplam holatini yangilab boʻlmadi"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:102
+msgid "Refund"
+msgstr "Pul qaytarish"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:160
+#: src/app/routes/_authenticated/_orders/utils/order-detail-loaders.tsx:78
+msgid "Modify"
+msgstr "Oʻzgartirish"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:337
+msgid "No global languages configured"
+msgstr "Hech qanday global til sozlanmagan"
+
+#. placeholder {0}: removedLines.length
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:197
+msgid "Removing {0} item(s)"
+msgstr "{0} element olib tashlanmoqda"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:388
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:406
+msgid "Track"
+msgstr "Kuzatish"
+
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:322
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:429
+msgid "Create variant"
+msgstr "Variant yaratish"
+
+#: src/app/routes/_authenticated/_facets/components/facet-values-sheet.tsx:31
+msgid "Facet values for {facetName}"
+msgstr "{facetName} uchun faset qiymatlari"
+
+#: src/app/routes/_authenticated/index.tsx:199
+msgid "Save Layout"
+msgstr "Maketni saqlash"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:61
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:138
+msgid "Password reset verified"
+msgstr "Parolni tiklash tasdiqlandi"
+
+#: src/lib/components/data-table/views-sheet.tsx:87
+msgid "Failed to delete view"
+msgstr "Koʻrinishni oʻchirib boʻlmadi"
+
+#: src/lib/components/shared/navigation-confirmation.tsx:47
+msgid "Are you sure you want to navigate away from this page? Any unsaved changes will be lost."
+msgstr "Ushbu sahifadan chiqasizmi? Saqlanmagan oʻzgarishlar yoʻqoladi."
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:156
+msgid "Toggle header column"
+msgstr "Sarlavha ustunini almashtirish"
+
+#: src/app/routes/_authenticated/_promotions/promotions.tsx:90
+msgid "New Promotion"
+msgstr "Yangi aksiya"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:151
+msgid "Option value name"
+msgstr "Optsiya qiymati nomi"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:214
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:46
+msgid "Last used"
+msgstr "Oxirgi ishlatilgan"
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:112
+msgid "Is default tax category"
+msgstr "Standart soliq toifasimi"
+
+#: src/lib/components/data-input/slug-input.tsx:238
+msgid "Slug is set"
+msgstr "Slug oʻrnatilgan"
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+msgid "Successfully updated zone"
+msgstr "Hudud yangilandi"
+
+#: src/lib/components/shared/customer-address-form.tsx:149
+msgid "State/Province"
+msgstr "Shtat/Viloyat"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:138
+msgid "Failed to update option group"
+msgstr "Optsiya guruhini yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:183
+msgid "Channel defaults"
+msgstr "Kanal standartlari"
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:77
+msgid "Failed to create tax category"
+msgstr "Soliq toifasini yaratib bo'lmadi"
+
+#: src/lib/components/data-table/data-table-filter-dialog.tsx:55
+msgid "Set filter criteria for the {columnId} column"
+msgstr "{columnId} ustuni uchun filtr mezonlarini belgilang"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:217
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:53
+#: src/lib/components/shared/customer-address-form.tsx:173
+msgid "Country"
+msgstr "Mamlakat"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:97
+msgid "Simple product"
+msgstr "Oddiy mahsulot"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:137
+msgid "Job Queue"
+msgstr "Vazifalar navbati"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:53
+msgid "Please confirm you have saved the API key before closing."
+msgstr "Yopishdan oldin API kalitini saqlaganingizni tasdiqlang."
+
+#: src/lib/components/data-table/use-generated-columns.tsx:411
+msgid "Confirm deletion"
+msgstr "O'chirishni tasdiqlang"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:150
+msgid "Failed to modify order"
+msgstr "Buyurtmani o'zgartirib bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:101
+msgid "Includes tax at {taxRate}%"
+msgstr "{taxRate}% soliqni o'z ichiga oladi"
+
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:75
+msgid "Order metrics"
+msgstr "Buyurtma ko'rsatkichlari"
+
+#: src/lib/components/layout/language-dialog.tsx:49
+msgid "Select display language"
+msgstr "Ko'rsatish tilini tanlang"
+
+#: src/app/routes/_authenticated/_profile/profile.tsx:128
+msgid "Authentication methods"
+msgstr "Autentifikatsiya usullari"
+
+#: src/lib/components/data-table/data-table-filter-badge.tsx:120
+msgid "start"
+msgstr "boshlanish"
+
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:35
+msgid "Failed to rotate API key"
+msgstr "API kalitini almashtirib bo'lmadi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:36
+msgid "in"
+msgstr "ichida"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:188
+#: src/lib/components/shared/role-selector.tsx:53
+msgid "Search roles..."
+msgstr "Rollarni qidirish..."
+
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:35
+msgid "Successfully cancelled {fulfilled} jobs"
+msgstr "{fulfilled} ta vazifa bekor qilindi"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:71
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:19
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:28
+msgid "Product Variants"
+msgstr "Mahsulot variantlari"
+
+#: src/lib/components/data-table/views-sheet.tsx:125
+msgid "Manage Global Views"
+msgstr "Global ko'rinishlarni boshqarish"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:365
+msgid "Processing..."
+msgstr "Qayta ishlanmoqda..."
+
+#. placeholder {0}: totalItems === 1 ? 'asset' : 'assets'
+#: src/lib/components/shared/asset/asset-gallery.tsx:465
+msgid "{totalItems} {0} found"
+msgstr "{totalItems} {0} topildi"
+
+#: src/lib/components/date-range-picker.tsx:126
+msgid "Select date range"
+msgstr "Sana oralig'ini tanlang"
+
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:87
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx:44
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:93
+msgid "Product"
+msgstr "Mahsulot"
+
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:51
+msgid "Rotate API Key"
+msgstr "API kalitini almashtirish"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:62
+msgid "Category"
+msgstr "Toifa"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:425
+msgid "Moving..."
+msgstr "Ko'chirilmoqda..."
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx:129
+msgid "Assign"
+msgstr "Tayinlash"
+
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+msgid "Successfully created seller"
+msgstr "Sotuvchi yaratildi"
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:91
+msgid "Successfully updated shipping method"
+msgstr "Yetkazib berish usuli yangilandi"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+msgid "Failed to update product variant"
+msgstr "Mahsulot variantini yangilab bo'lmadi"
+
+#: src/lib/components/data-input/custom-field-list-input.tsx:72
+msgid "Drag to reorder"
+msgstr "Qayta tartiblash uchun torting"
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:33
+#: src/app/routes/_authenticated/_zones/zones.tsx:14
+#: src/app/routes/_authenticated/_zones/zones.tsx:24
+msgid "Zones"
+msgstr "Hududlar"
+
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:170
+#: src/lib/components/shared/facet-value-selector.tsx:123
+msgid "Search facet values..."
+msgstr "Faset qiymatlarini qidirish..."
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:267
+msgid "Note"
+msgstr "Eslatma"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:160
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:112
+msgid "Available languages"
+msgstr "Mavjud tillar"
+
+#. placeholder {0}: Math.min(remaining, CHILDREN_PAGE_SIZE)
+#: src/app/routes/_authenticated/_collections/collections.tsx:478
+msgid "Load {0} more ({remaining} remaining)"
+msgstr "Yana {0} ta yuklash ({remaining} ta qoldi)"
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:141
+#: src/app/routes/_authenticated/_product-variants/product-variants.tsx:84
+#: src/app/routes/_authenticated/_products/products.tsx:76
+msgid "Facet values"
+msgstr "Faset qiymatlari"
+
+#: src/lib/components/data-table/data-table.tsx:237
+msgid "Failed to reorder items"
+msgstr "Elementlarni qayta tartiblab bo'lmadi"
+
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:90
+msgid "Total Orders"
+msgstr "Jami buyurtmalar"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:52
+msgid "No eligible shipping methods found for this order."
+msgstr "Bu buyurtma uchun mos yetkazib berish usullari topilmadi."
+
+#: src/app/routes/_authenticated/_products/components/product-options-table.tsx:118
+msgid "Add product option"
+msgstr "Mahsulot tanlovini qo'shish"
+
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:66
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:189
+#: src/app/routes/_authenticated/_orders/orders.tsx:85
+msgid "Shipping"
+msgstr "Yetkazib berish"
+
+#: src/lib/hooks/use-widget-dimensions.ts:9
+msgid "useWidgetDimensions must be used within a DashboardBaseWidget"
+msgstr "useWidgetDimensions DashboardBaseWidget ichida ishlatilishi kerak"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:488
+msgid "This option group is in use by existing variants. Force removing it may affect those variants. Are you sure?"
+msgstr "Bu optsiya guruhi mavjud variantlarda ishlatilmoqda. Majburiy olib tashlash ularga ta'sir qilishi mumkin. Ishonchingiz komilmi?"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:63
+msgid "Email update requested"
+msgstr "Elektron pochtani yangilash so'raldi"
+
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:124
+msgid "Error transitioning to state"
+msgstr "Holatga o'tishda xatolik"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:64
+msgid "Successfully created customer group"
+msgstr "Mijozlar guruhi yaratildi"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:133
+msgid "New window"
+msgstr "Yangi oyna"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:64
+msgid "Payment authorized"
+msgstr "To'lov tasdiqlandi"
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:62
+msgid "Successfully updated role"
+msgstr "Rol yangilandi"
+
+#: src/lib/components/shared/customer-address-form.tsx:184
+msgid "Select a country"
+msgstr "Mamlakatni tanlang"
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+msgid "Failed to update shipping method"
+msgstr "Yetkazib berish usulini yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:42
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:19
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:28
+msgid "Shipping Methods"
+msgstr "Yetkazib berish usullari"
+
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:71
+msgid "Select an address"
+msgstr "Manzilni tanlang"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:326
+msgid "Yes"
+msgstr "Ha"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:175
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:246
+msgid "Slug"
+msgstr "Slug"
+
+#: src/lib/components/shared/asset/asset-focal-point-editor.tsx:97
+msgid "Set Focal Point"
+msgstr "Fokal nuqtani belgilash"
+
+#: src/lib/components/data-table/data-table-filter-badge.tsx:122
+msgid "end"
+msgstr "tugash"
+
+#: src/lib/components/shared/currency-selector.tsx:29
+msgid "Select a currency"
+msgstr "Valyutani tanlang"
+
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx:47
+msgid "Update the note content or visibility"
+msgstr "Eslatma mazmuni yoki ko'rinishini yangilang"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:272
+msgid "Latest Orders Widget"
+msgstr "So'nggi buyurtmalar vidjeti"
+
+#: src/app/routes/_authenticated/_collections/components/collection-contents-sheet.tsx:34
+msgid "Collection contents for {collectionName}"
+msgstr "{collectionName} uchun to'plam mazmuni"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:145
+msgid "Shipping method changed"
+msgstr "Yetkazib berish usuli o'zgartirildi"
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:123
+msgid "Tax description"
+msgstr "Soliq tavsifi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:53
+msgid "is less than or equal to"
+msgstr "quyidagidan kichik yoki teng"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:26
+msgid "is not equal to"
+msgstr "quyidagiga teng emas"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:142
+msgid "Settle payment"
+msgstr "To'lovni yakunlash"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:38
+#: src/app/routes/_authenticated/_channels/channels.tsx:15
+#: src/app/routes/_authenticated/_channels/channels.tsx:23
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:216
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:343
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
+#: src/lib/components/layout/channel-switcher.tsx:146
+msgid "Channels"
+msgstr "Kanallar"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:122
+msgid "Shipping refunded"
+msgstr "Yetkazib berish puli qaytarildi"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:376
+msgid "Asset type"
+msgstr "Asset turi"
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations.tsx:58
+msgid "New Stock Location"
+msgstr "Yangi zaxira joylashuvi"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:286
+msgid "{successfulRefundCount} payment(s) refunded before failure. Check order history for details."
+msgstr "Nosozlikdan oldin {successfulRefundCount} ta to'lov qaytarildi. Tafsilotlar uchun buyurtma tarixini tekshiring."
+
+#: src/lib/components/data-input/relation-selector.tsx:411
+msgid "Select item"
+msgstr "Elementni tanlash"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:57
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:212
+msgid "New product"
+msgstr "Yangi mahsulot"
+
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:192
+msgid "Manage Tags"
+msgstr "Teglarni boshqarish"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:110
+msgid "Items refunded"
+msgstr "Elementlar qaytarildi"
+
+#. placeholder {0}: entityName.toLowerCase()
+#: src/app/common/duplicate-entity-dialog.tsx:85
+msgid "Duplicate {0}s"
+msgstr "{0} larni nusxalash"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:52
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:56
+msgid "Failed to update fulfillment state"
+msgstr "Bajarish holatini yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:233
+msgid "Create a new product variant with options, pricing, and stock"
+msgstr "Tanlovlar, narx va zaxira bilan yangi mahsulot varianti yarating"
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
+msgid "Private facets are not visible in the shop"
+msgstr "Maxfiy fasetlar do'konda ko'rinmaydi"
+
+#: src/lib/components/shared/tax-category-selector.tsx:50
+msgid "Select a tax category"
+msgstr "Soliq toifasini tanlang"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:165
+msgid "Not Running"
+msgstr "Ishlamayapti"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:267
+msgid "Assigned"
+msgstr "Tayinlangan"
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:96
+msgid "Heading 1"
+msgstr "Sarlavha 1"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:279
+msgid "Select Available Languages"
+msgstr "Mavjud tillarni tanlang"
+
+#. placeholder {0}: addedLines.length
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:183
+msgid "Adding {0} item(s)"
+msgstr "{0} ta element qo'shilmoqda"
+
+#: src/lib/components/shared/rich-text-editor/table-edit-icons.tsx:199
+msgid "Add row after"
+msgstr "Keyin qator qo'shish"
+
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:23
+msgid "Tax total"
+msgstr "Jami soliq"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:374
+msgid "Draft order status"
+msgstr "Qoralama buyurtma holati"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+msgid "Failed to create payment method"
+msgstr "To'lov usulini yaratib bo'lmadi"
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+msgid "Successfully created facet value"
+msgstr "Faset qiymati yaratildi"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:114
+msgid "Marketing"
+msgstr "Marketing"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:311
+msgid "Draft order deleted"
+msgstr "Qoralama buyurtma o'chirildi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:40
+msgid "greater than"
+msgstr "quyidagidan katta"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:263
+msgid "Metrics Widget"
+msgstr "Ko'rsatkichlar vidjeti"
+
+#: src/lib/components/shared/currency-selector.tsx:30
+msgid "Search currencies..."
+msgstr "Valyutalarni qidirish..."
+
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:82
+msgid "Remove from channel"
+msgstr "Kanaldan olib tashlash"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:169
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:157
+msgid "Title"
+msgstr "Sarlavha"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:211
+msgid "Insert image"
+msgstr "Rasm kiritish"
+
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:63
+msgid "Failed to update seller"
+msgstr "Sotuvchini yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:62
+msgid "Successfully created country"
+msgstr "Mamlakat yaratildi"
+
+#: src/lib/components/shared/seller-selector.tsx:39
+msgid "Select seller"
+msgstr "Sotuvchini tanlang"
+
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:91
+msgid "Loading tags..."
+msgstr "Teglar yuklanmoqda..."
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+msgid "Successfully created facet"
+msgstr "Faset yaratildi"
+
+#. placeholder {0}: row.original.productVariantCount
+#: src/app/routes/_authenticated/_collections/collections.tsx:409
+msgid "{0} variants"
+msgstr "{0} ta variant"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:48
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:52
+msgid "Failed to settle payment"
+msgstr "To'lovni yakunlab bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:300
+msgid "No billing address"
+msgstr "Hisob-kitob manzili yo'q"
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:119
+msgid "Facet"
+msgstr "Faset"
+
+#. placeholder {0}: import { DataTableBulkActionItem } from '@/vdb/components/data-table/data-table-bulk-action-item.js'; import { BulkActionComponent } from '@/vdb/framework/extension-api/types/data-table.js'; import { api } from '@/vdb/graphql/api.js'; import { usePaginatedList } from '@/vdb/hooks/use-paginated-list.js'; import { plural } from '@lingui/core/macro'; import { Plural, useLingui } from '@lingui/react/macro'; import { useMutation } from '@tanstack/react-query'; import { Ban } from 'lucide-react'; import { toast } from 'sonner'; import { cancelJobDocument } from '../job-queue.graphql.js'; export const CancelJobsBulkAction: BulkActionComponent<any> = ({ selection, table }) => { const { refetchPaginatedList } = usePaginatedList(); const { t } = useLingui(); const cancellableJobs = selection.filter(job => job.state === 'RUNNING' || job.state === 'PENDING'); const cancellableCount = cancellableJobs.length; const { mutate, isPending } = useMutation({ mutationFn: async () => { const results = await Promise.allSettled( cancellableJobs.map(job => api.mutate(cancelJobDocument, { jobId: job.id })), ); const fulfilled = results.filter(r => r.status === 'fulfilled').length; const rejected = results.filter(r => r.status === 'rejected').length; return { fulfilled, rejected }; }, onSuccess: ({ fulfilled, rejected }) => { if (fulfilled > 0) { toast.success( plural(fulfilled, { one: t`Successfully cancelled ${fulfilled} job`, other: t`Successfully cancelled ${fulfilled} jobs`, }), ); } if (rejected > 0) { toast.error( plural(rejected, { one: t`Failed to cancel ${rejected} job`, other: t`Failed to cancel ${rejected} jobs`, }), ); } refetchPaginatedList(); table.resetRowSelection(); }, }); if (cancellableCount === 0) { return null; } return ( <DataTableBulkActionItem requiresPermission={['DeleteSettings', 'DeleteSystem']} onClick={() => mutate()} disabled={isPending} label={ <Plural value={cancellableCount} one={`Cancel ${cancellableCount} job`} other={`Cancel ${cancellableCount} jobs`} /> } confirmationText={ <Plural value={cancellableCount} one={`Are you sure you want to cancel ${cancellableCount} job? This action cannot be undone.`} other={`Are you sure you want to cancel ${cancellableCount} jobs? This action cannot be undone.`} /> } icon={Ban} className="text-destructive" /> ); }; 
+#. placeholder {1}: import { DataTableBulkActionItem } from '@/vdb/components/data-table/data-table-bulk-action-item.js'; import { BulkActionComponent } from '@/vdb/framework/extension-api/types/data-table.js'; import { api } from '@/vdb/graphql/api.js'; import { usePaginatedList } from '@/vdb/hooks/use-paginated-list.js'; import { plural } from '@lingui/core/macro'; import { Plural, useLingui } from '@lingui/react/macro'; import { useMutation } from '@tanstack/react-query'; import { Ban } from 'lucide-react'; import { toast } from 'sonner'; import { cancelJobDocument } from '../job-queue.graphql.js'; export const CancelJobsBulkAction: BulkActionComponent<any> = ({ selection, table }) => { const { refetchPaginatedList } = usePaginatedList(); const { t } = useLingui(); const cancellableJobs = selection.filter(job => job.state === 'RUNNING' || job.state === 'PENDING'); const cancellableCount = cancellableJobs.length; const { mutate, isPending } = useMutation({ mutationFn: async () => { const results = await Promise.allSettled( cancellableJobs.map(job => api.mutate(cancelJobDocument, { jobId: job.id })), ); const fulfilled = results.filter(r => r.status === 'fulfilled').length; const rejected = results.filter(r => r.status === 'rejected').length; return { fulfilled, rejected }; }, onSuccess: ({ fulfilled, rejected }) => { if (fulfilled > 0) { toast.success( plural(fulfilled, { one: t`Successfully cancelled ${fulfilled} job`, other: t`Successfully cancelled ${fulfilled} jobs`, }), ); } if (rejected > 0) { toast.error( plural(rejected, { one: t`Failed to cancel ${rejected} job`, other: t`Failed to cancel ${rejected} jobs`, }), ); } refetchPaginatedList(); table.resetRowSelection(); }, }); if (cancellableCount === 0) { return null; } return ( <DataTableBulkActionItem requiresPermission={['DeleteSettings', 'DeleteSystem']} onClick={() => mutate()} disabled={isPending} label={ <Plural value={cancellableCount} one={`Cancel ${cancellableCount} job`} other={`Cancel ${cancellableCount} jobs`} /> } confirmationText={ <Plural value={cancellableCount} one={`Are you sure you want to cancel ${cancellableCount} job? This action cannot be undone.`} other={`Are you sure you want to cancel ${cancellableCount} jobs? This action cannot be undone.`} /> } icon={Ban} className="text-destructive" /> ); }; 
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:41
+msgid "{rejected, plural, one {{0}} other {{1}}}"
+msgstr "{rejected, plural, one {{0}} other {{1}}}"
+
+#: src/lib/components/shared/assigned-channels.tsx:58
+msgid "Cannot remove from active channel"
+msgstr "Faol kanaldan olib tashlab bo'lmaydi"
+
+#: src/app/routes/_authenticated/_assets/assets_.$id.tsx:179
+msgid "Not set"
+msgstr "Belgilanmagan"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:504
+msgid "Force remove"
+msgstr "Majburiy olib tashlash"
+
+#: src/app/routes/_authenticated/_channels/channels.tsx:70
+msgid "New Channel"
+msgstr "Yangi kanal"
+
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:65
+msgid "Option Group Name"
+msgstr "Optsiya guruhi nomi"
+
+#: src/lib/components/data-input/combination-mode-input.tsx:46
+msgid "AND"
+msgstr "VA"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+msgid "Failed to create customer group"
+msgstr "Mijozlar guruhini yaratib bo'lmadi"
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+msgid "Failed to create role"
+msgstr "Rolni yaratib bo'lmadi"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:240
+msgid "Product name"
+msgstr "Mahsulot nomi"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:49
+msgid "Fulfillment state updated successfully"
+msgstr "Bajarish holati yangilandi"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:79
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:71
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:211
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:38
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:66
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:66
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:56
+#: src/app/routes/_authenticated/_products/products.tsx:24
+#: src/app/routes/_authenticated/_products/products.tsx:47
+msgid "Products"
+msgstr "Mahsulotlar"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:51
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:62
+msgid "Address created"
+msgstr "Manzil yaratildi"
+
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:32
+msgid "API key rotated successfully"
+msgstr "API kaliti almashtirildi"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:141
+msgid "Add option group"
+msgstr "Optsiya guruhi qo'shish"
+
+#. placeholder {0}: formatCurrency(refund.amountToRefundTotal, order.currencyCode)
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:367
+msgid "Refund {0}"
+msgstr "{0} pul qaytarish"
+
+#: src/lib/components/data-input/slug-input.tsx:240
+msgid "Enter slug manually"
+msgstr "Slug'ni qo'lda kiriting"
+
+#: src/app/routes/_authenticated/index.tsx:230
+msgid "No widgets available"
+msgstr "Mavjud vidjetlar yo'q"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:78
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:82
+msgid "Failed to cancel payment"
+msgstr "To'lovni bekor qilib bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:75
+msgid "Payment cancelled successfully"
+msgstr "To'lov bekor qilindi"
+
+#: src/lib/components/data-table/views-sheet.tsx:96
+msgid "Global view duplicated successfully"
+msgstr "Global ko'rinish nusxalandi"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:210
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:66
+msgid "Created by"
+msgstr "Yaratgan"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:240
+msgid "Filter variants..."
+msgstr "Variantlarni filtrlash..."
+
+#: src/app/routes/_authenticated/_product-variants/components/add-currency-dropdown.tsx:35
+msgid "Add a price in another currency"
+msgstr "Boshqa valyutada narx qo'shish"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:127
+#: src/app/routes/_authenticated/_profile/profile.tsx:114
+msgid "Email Address or identifier"
+msgstr "Email manzili yoki identifikator"
+
+#. placeholder {0}: entry.data.refundId
+#. placeholder {1}: entry.data.to
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:39
+msgid "Refund #{0} transitioned to {1}"
+msgstr "Pul qaytarish #{0} {1} holatiga o'tdi"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:110
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:61
+#: src/app/routes/_authenticated/_customers/customers.tsx:15
+#: src/app/routes/_authenticated/_customers/customers.tsx:21
+msgid "Customers"
+msgstr "Mijozlar"
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:99
+msgid "Heading 4"
+msgstr "Sarlavha 4"
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+msgid "Failed to update stock location"
+msgstr "Zaxira joylashuvini yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:88
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:94
+msgid "Order shipped"
+msgstr "Buyurtma jo'natildi"
+
+#: src/lib/components/shared/customer-address-form.tsx:257
+msgid "Save Address"
+msgstr "Manzilni saqlash"
+
+#: src/lib/components/data-table/views-sheet.tsx:261
+msgid "Make Global"
+msgstr "Global qilish"
+
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:103
+msgid "Select next state"
+msgstr "Keyingi holatni tanlang"
+
+#: src/lib/components/shared/alerts.tsx:46
+msgid "No alerts"
+msgstr "Ogohlantirishlar yo'q"
+
+#. placeholder {0}: collectionsToMove.length
+#. placeholder {1}: collectionsToMove.length === 1 ? '' : 's'
+#. placeholder {2}: selectedCollectionId === topLevelCollectionId ? 'top level' : collectionNameCache.current.get(selectedCollectionId) || 'selected collection'
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:75
+msgid "Moving {0} collection{1} into {2}"
+msgstr "{0} ta to'plam{1} {2} ichiga ko'chirilmoqda"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:22
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-shipping-method-sheet.tsx:32
+msgid "Test"
+msgstr "Test"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:32
+msgid "between"
+msgstr "oralig'ida"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:99
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:104
+msgid "Note added successfully"
+msgstr "Eslatma qo'shildi"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:140
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:146
+msgid "Note deleted successfully"
+msgstr "Eslatma o'chirildi"
+
+#. js-lingui-explicit-id
+#: src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts:120
+#: src/app/routes/_authenticated/_orders/components/order-history/use-order-history.ts:125
+msgid "Note updated successfully"
+msgstr "Eslatma yangilandi"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:94
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:98
+msgid "Failed to settle refund"
+msgstr "Pul qaytarishni yakunlab bo'lmadi"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:461
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:311
+msgid "Stock level"
+msgstr "Zaxira darajasi"
+
+#: src/lib/components/data-input/custom-field-list-input.tsx:289
+msgid "Add item"
+msgstr "Element qo'shish"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:108
+msgid "Successfully created API key"
+msgstr "API kaliti yaratildi"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:165
+msgid "Loading preview…"
+msgstr "Ko'rib chiqish yuklanmoqda…"
+
+#: src/lib/components/shared/facet-value-selector.tsx:189
+msgid "Back to search"
+msgstr "Qidiruvga qaytish"
+
+#: src/lib/components/data-table/views-sheet.tsx:97
+msgid "View duplicated successfully"
+msgstr "Ko'rinish nusxalandi"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:315
+msgid "Remove option group"
+msgstr "Optsiya guruhini olib tashlash"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:190
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:76
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:14
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:171
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:262
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:174
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:94
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:162
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:114
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:112
+msgid "Description"
+msgstr "Tavsif"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:32
+#: src/app/routes/_authenticated/_countries/countries.tsx:13
+#: src/app/routes/_authenticated/_countries/countries.tsx:22
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:100
+msgid "Countries"
+msgstr "Mamlakatlar"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:160
+msgid "Failed to remove order line: {0}"
+msgstr "Buyurtma qatorini olib tashlab bo'lmadi: {0}"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:182
+msgid "Street Address 2"
+msgstr "Ko'cha manzili 2"
+
+#: src/lib/components/data-table/views-sheet.tsx:83
+msgid "Global view deleted successfully"
+msgstr "Global ko'rinish o'chirildi"
+
+#: src/app/routes/_authenticated/index.tsx:199
+msgid "Edit Layout"
+msgstr "Tartibni tahrirlash"
+
+#: src/lib/components/shared/assign-to-channel-bulk-action.tsx:55
+#: src/lib/components/shared/assigned-channels.tsx:98
+msgid "Assign to channel"
+msgstr "Kanalga biriktirish"
+
+#: src/lib/components/date-range-picker.tsx:47
+msgctxt "date-range"
+msgid "This week"
+msgstr "Bu hafta"
+
+#. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:130
+msgid "Add a manual payment of {0}"
+msgstr "{0} miqdorida qo'lda to'lov qo'shish"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:36
+msgid "is in"
+msgstr "ichida"
+
+#: src/lib/components/login/login-form.tsx:83
+msgid "Email"
+msgstr "Email"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:86
+msgid "Failed to update administrator"
+msgstr "Administratorni yangilab bo'lmadi"
+
+#: src/lib/components/data-table/views-sheet.tsx:132
+msgid "Manage your personal saved views for this table"
+msgstr "Ushbu jadval uchun shaxsiy ko'rinishlaringizni boshqaring"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:103
+msgid "Filter by tags"
+msgstr "Teglar bo'yicha filtrlash"
+
+#: src/lib/components/login/login-form.tsx:73
+msgid "Sign in to access the admin dashboard"
+msgstr "Admin dashboard'ga kirish uchun tizimga kiring"
+
+#: src/lib/components/data-table/filters/data-table-boolean-filter.tsx:57
+msgid "False"
+msgstr "Yolg'on"
+
+#: src/lib/components/layout/nav-user.tsx:127
+msgctxt "theme"
+msgid "Light"
+msgstr "Yorug'"
+
+#: src/lib/components/data-table/data-table-view-options.tsx:120
+msgid "Reset"
+msgstr "Tiklash"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:24
+msgid "is equal to"
+msgstr "ga teng"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:57
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:118
+msgid "Password updated"
+msgstr "Parol yangilandi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:58
+msgid "does not contain"
+msgstr "o'z ichiga olmaydi"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:186
+msgid "Option Group"
+msgstr "Optsiya guruhi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:132
+msgid "Edit the address details below."
+msgstr "Quyida manzil tafsilotlarini tahrirlang."
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:67
+msgid "Successfully created tax category"
+msgstr "Soliq toifasi yaratildi"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:294
+msgid "Failed to move collections"
+msgstr "To'plamlarni ko'chirib bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:63
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:67
+msgid "Failed to update payment state"
+msgstr "To'lov holatini yangilab bo'lmadi"
+
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:85
+msgid "Your orders summary"
+msgstr "Buyurtmalaringiz xulosasi"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:406
+msgid "Upload"
+msgstr "Yuklash"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:112
+msgid "Product with options"
+msgstr "Variantli mahsulot"
+
+#. placeholder {0}: filteredTags.length
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:165
+msgid "Showing all {0} results"
+msgstr "Barcha {0} ta natija ko'rsatilmoqda"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:204
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:60
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:95
+msgid "Lookup ID"
+msgstr "Qidiruv ID'si"
+
+#. placeholder {0}: list.totalItems - 3
+#: src/app/routes/_authenticated/_facets/facets.tsx:65
+msgid "+ {0} more"
+msgstr "+ yana {0} ta"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:45
+msgid "Option Groups"
+msgstr "Optsiya guruhlari"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:431
+msgid "Custom fields"
+msgstr "Maxsus maydonlar"
+
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:85
+msgid "All possible order states and their transitions. The current state is highlighted."
+msgstr "Barcha mumkin bo'lgan buyurtma holatlari va ularning o'tishlari. Joriy holat ajratilgan."
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:82
+msgid "Orders"
+msgstr "Buyurtmalar"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:280
+msgid "Orders Summary Widget"
+msgstr "Buyurtmalar xulosasi vidjeti"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:30
+msgid "orderState.AddingItems"
+msgstr "Elementlar qo'shilmoqda"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:40
+msgid "orderState.ArrangingAdditionalPayment"
+msgstr "Qo'shimcha to'lovni tayyorlash"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:32
+msgid "orderState.ArrangingPayment"
+msgstr "To'lovni tayyorlash"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:31
+msgid "orderState.Cancelled"
+msgstr "Bekor qilingan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:28
+msgid "orderState.Created"
+msgstr "Yaratilgan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:38
+msgid "orderState.Delivered"
+msgstr "Yetkazilgan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:29
+msgid "orderState.Draft"
+msgstr "Qoralama"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:39
+msgid "orderState.Modifying"
+msgstr "O'zgartirilmoqda"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:37
+msgid "orderState.PartiallyDelivered"
+msgstr "Qisman yetkazilgan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:35
+msgid "orderState.PartiallyShipped"
+msgstr "Qisman jo'natilgan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:33
+msgid "orderState.PaymentAuthorized"
+msgstr "To'lov tasdiqlangan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:34
+msgid "orderState.PaymentSettled"
+msgstr "To'lov yakunlangan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:36
+msgid "orderState.Shipped"
+msgstr "Jo'natilgan"
+
+#: src/lib/framework/layout-engine/page-layout.tsx:705
+msgid "Entity Information"
+msgstr "Obyekt ma'lumotlari"
+
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:34
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:81
+msgid "Order Total"
+msgstr "Buyurtma jami"
+
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+msgid "Visible to admins only"
+msgstr "Faqat adminlarga ko'rinadi"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:99
+msgid "Qty"
+msgstr "Miqdor"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:104
+msgid "Tags"
+msgstr "Teglar"
+
+#: src/lib/components/shared/role-code-label.tsx:6
+msgid "Super Admin"
+msgstr "Super Admin"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:141
+msgid "Failed to update order line: {0}"
+msgstr "Buyurtma qatorini yangilab bo'lmadi: {0}"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:84
+msgid "Insert link"
+msgstr "Havola qo'shish"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:201
+msgid "If enabled, the filters will be inherited from the parent collection and combined with the filters set on this collection."
+msgstr "Yoqilgan bo'lsa, filtrlar asosiy to'plamdan meros qilinadi va ushbu to'plamdagi filtrlar bilan birlashtiriladi."
+
+#: src/lib/components/shared/zone-selector.tsx:50
+msgid "Select a zone"
+msgstr "Hududni tanlang"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-sheet.tsx:27
+msgid "Test shipping methods"
+msgstr "Yetkazib berish usullarini sinash"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:45
+msgid "Payment settled successfully"
+msgstr "To'lov yakunlandi"
+
+#. placeholder {0}: selection.length
+#. placeholder {1}: selection.length === 1 ? 'country' : 'countries'
+#: src/app/routes/_authenticated/_zones/components/zone-bulk-actions.tsx:31
+msgid "Removed {0} {1} from zone"
+msgstr "Hududdan {0} {1} olib tashlandi"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:220
+msgid "Enable"
+msgstr "Yoqish"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:216
+msgid "Payment Methods"
+msgstr "To'lov usullari"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:16
+msgid "paymentState.Authorized"
+msgstr "Tasdiqlangan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:20
+msgid "paymentState.Cancelled"
+msgstr "Bekor qilingan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:15
+msgid "paymentState.Created"
+msgstr "Yaratilgan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:18
+msgid "paymentState.Declined"
+msgstr "Rad etilgan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:19
+msgid "paymentState.Error"
+msgstr "Xatolik"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:25
+msgid "paymentState.Failed"
+msgstr "Muvaffaqiyatsiz"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:23
+msgid "paymentState.Pending"
+msgstr "Kutilmoqda"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:17
+#: src/i18n/common-strings.ts:24
+msgid "paymentState.Settled"
+msgstr "Yakunlangan"
+
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:36
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:83
+msgid "Average Order Value"
+msgstr "O'rtacha buyurtma qiymati"
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:68
+msgid "Failed to create zone"
+msgstr "Hududni yaratib bo'lmadi"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:382
+msgid "Stock levels"
+msgstr "Zaxira darajalari"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+msgid "Failed to update API key"
+msgstr "API kalitini yangilab bo'lmadi"
+
+#: src/lib/framework/dashboard-widget/base-widget.tsx:76
+msgid "{title}"
+msgstr "{title}"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:244
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:83
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:178
+msgid "Order lines"
+msgstr "Buyurtma qatorlari"
+
+#: src/lib/components/data-table/views-sheet.tsx:68
+msgid "Failed to rename global view"
+msgstr "Global ko'rinish nomini o'zgartirib bo'lmadi"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+msgid "Insert a new hyperlink with URL and target options"
+msgstr "URL va maqsad parametrlari bilan yangi havola qo'shish"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:194
+msgid "Height"
+msgstr "Balandlik"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:180
+msgid "A refund of {formattedDiff} is required. Select payment amounts and enter a note to proceed."
+msgstr "{formattedDiff} miqdorida pul qaytarish talab qilinadi. To'lov summalarini tanlang va davom etish uchun eslatma kiriting."
+
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:100
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx:57
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:96
+msgid "Unit price"
+msgstr "Birlik narxi"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:129
+msgid "Schedule Pattern"
+msgstr "Reja andozasi"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:67
+msgid "Payment failed"
+msgstr "To'lov muvaffaqiyatsiz tugadi"
+
+#: src/lib/components/layout/channel-switcher.tsx:212
+msgid "Add channel"
+msgstr "Kanal qo'shish"
+
+#: src/lib/components/shared/channel-selector.tsx:48
+msgid "Search channels..."
+msgstr "Kanallarni qidirish..."
+
+#: src/lib/components/shared/customer-group-selector.tsx:45
+msgid "Add customer groups"
+msgstr "Mijozlar guruhlarini qo'shish"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:323
+msgid "Available Languages"
+msgstr "Mavjud tillar"
+
+#: src/lib/components/data-table/data-table-bulk-actions.tsx:119
+msgid "Reset selection"
+msgstr "Tanlovni tiklash"
+
+#: src/app/routes/_authenticated/_orders/components/order-address.tsx:30
+msgid "No address"
+msgstr "Manzil yo'q"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:100
+msgid "Successfully created payment method"
+msgstr "To'lov usuli yaratildi"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:86
+msgid "Customer information updated"
+msgstr "Mijoz ma'lumotlari yangilandi"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:318
+msgid "Failed to delete draft order: {0}"
+msgstr "Qoralama buyurtmani o'chirib bo'lmadi: {0}"
+
+#: src/lib/components/data-table/views-sheet.tsx:120
+msgid "Failed to convert view to global"
+msgstr "Ko'rinishni globalga o'tkazib bo'lmadi"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:38
+msgid "Product Variants"
+msgstr "Mahsulot variantlari"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:31
+msgid "Products"
+msgstr "Mahsulotlar"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:121
+msgid "Promotions"
+msgstr "Aksiyalar"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:150
+msgid "Failed to create product option"
+msgstr "Mahsulot opsiyasini yaratib bo'lmadi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:159
+msgid "Old email:"
+msgstr "Eski email:"
+
+#: src/lib/components/data-table/views-sheet.tsx:144
+msgid "Save a view as \"Global\" to make it available to all users."
+msgstr "Ko'rinishni barcha foydalanuvchilarga ochish uchun uni \"Global\" qilib saqlang."
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:184
+msgid "Failed to create variants"
+msgstr "Variantlarni yaratib bo'lmadi"
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:133
+msgid "Sets the stock level at which this a variant is considered to be out of stock. Using a negative value enables backorder support. Can be overridden by product variants."
+msgstr "Variant zaxirasi tugagan deb hisoblanadigan darajani belgilaydi. Manfiy qiymat oldindan buyurtma imkonini yoqadi. Mahsulot variantlari buni bekor qilishi mumkin."
+
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:45
+#: src/app/routes/_authenticated/_api-keys/components/rotate-api-key-button.tsx:68
+msgid "Rotate Key"
+msgstr "Kalitni almashtirish"
+
+#: src/lib/components/ui/password-input.tsx:20
+msgid "Hide password"
+msgstr "Parolni yashirish"
+
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:30
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:71
+msgid "New seller"
+msgstr "Yangi sotuvchi"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:153
+msgid "e.g., Red, Large, Cotton"
+msgstr "masalan, Qizil, Katta, Paxta"
+
+#: src/app/routes/_authenticated/_profile/profile.tsx:75
+msgid "Failed to update profile"
+msgstr "Profilni yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:221
+msgid "Removed coupon codes"
+msgstr "Kupon kodlari olib tashlandi"
+
+#: src/lib/components/data-table/data-table-filter-dialog.tsx:78
+msgid "Clear filter"
+msgstr "Filtrni tozalash"
+
+#: src/app/routes/_authenticated/_zones/zones.tsx:36
+msgid "Regions"
+msgstr "Hududlar"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:438
+msgid "Drop files here to upload"
+msgstr "Yuklash uchun fayllarni shu yerga tashlang"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:276
+msgid "Toggle all visible variants"
+msgstr "Barcha ko'rinadigan variantlarni almashtirish"
+
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:18
+msgid "Verified"
+msgstr "Tasdiqlangan"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:74
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:82
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:149
+msgid "New option group"
+msgstr "Yangi optsiya guruhi"
+
+#: src/lib/components/data-table/views-sheet.tsx:141
+msgid "No global views have been created yet."
+msgstr "Hali birorta global ko'rinish yaratilmagan."
+
+#: src/app/routes/_authenticated/_roles/roles_.$id.tsx:69
+msgid "Failed to update role"
+msgstr "Rolni yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:77
+msgid "This is the only time the full API key will be displayed. Copy or download it now — it cannot be retrieved later."
+msgstr "To'liq API kaliti faqat hozir ko'rsatiladi. Hozir nusxalang yoki yuklab oling — keyin uni qayta olib bo'lmaydi."
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:104
+msgid "Successfully updated collection"
+msgstr "To'plam yangilandi"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:101
+msgid "Successfully updated payment method"
+msgstr "To'lov usuli yangilandi"
+
+#: src/lib/components/data-table/views-sheet.tsx:83
+msgid "View deleted successfully"
+msgstr "Ko'rinish o'chirildi"
+
+#: src/lib/components/data-input/combination-mode-input.tsx:59
+msgid "OR"
+msgstr "YOKI"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:213
+msgid "Manage tags"
+msgstr "Teglarni boshqarish"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:277
+msgid "Coupon code removed from order"
+msgstr "Buyurtmadan kupon kodi olib tashlandi"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:221
+#: src/app/routes/_authenticated/_api-keys/api-keys.tsx:50
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:142
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:152
+msgid "Never"
+msgstr "Hech qachon"
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:93
+msgid "Failed to update facet value"
+msgstr "Faset qiymatini yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:82
+msgid "Order fulfilled"
+msgstr "Buyurtma bajarildi"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:210
+msgid "Failed to set billing address for order: {0}"
+msgstr "Buyurtma uchun hisob-kitob manzilini o'rnatib bo'lmadi: {0}"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:271
+msgid "No shipping address"
+msgstr "Yetkazib berish manzili yo'q"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-list-query.ts:49
+msgid "Query extension contains invalid GraphQL syntax"
+msgstr "So'rov kengaytmasi yaroqsiz GraphQL sintaksisini o'z ichiga oladi"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-detail-query.ts:23
+#: src/lib/hooks/use-extended-list-query.ts:64
+msgid "Query extension error"
+msgstr "So'rov kengaytmasi xatosi"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-list-query.ts:51
+msgid "Query extension error: "
+msgstr "So'rov kengaytmasi xatosi:"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-list-query.ts:43
+msgid "Query extension is invalid: must have at least one top-level field"
+msgstr "So'rov kengaytmasi yaroqsiz: kamida bitta yuqori darajadagi maydon bo'lishi kerak"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-list-query.ts:47
+msgid "Query extension mismatch: "
+msgstr "So'rov kengaytmasi mos kelmadi:"
+
+#: src/app/routes/_authenticated/_facets/facets.tsx:44
+msgid "public"
+msgstr "public"
+
+#: src/app/routes/_authenticated/_tax-categories/tax-categories_.$id.tsx:68
+msgid "Successfully updated tax category"
+msgstr "Soliq toifasi yangilandi"
+
+#: src/app/routes/_authenticated/_collections/components/collection-bulk-actions.tsx:116
+msgid "Move"
+msgstr "Ko'chirish"
+
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:195
+msgid "Edit or delete existing tags"
+msgstr "Mavjud teglarni tahrirlash yoki o'chirish"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:79
+msgid "This shipping method's eligibility checker conditions are not met for the current order and shipping address."
+msgstr "Bu yetkazib berish usulining muvofiqlik shartlari joriy buyurtma va manzil uchun bajarilmagan."
+
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:273
+msgid "Add coupon code"
+msgstr "Kupon kodini qo'shish"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:261
+msgid "Coupon code set for order"
+msgstr "Buyurtma uchun kupon kodi o'rnatildi"
+
+#: src/app/routes/_authenticated/_orders/components/order-line-custom-fields-form.tsx:47
+msgid "Custom Fields"
+msgstr "Maxsus maydonlar"
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods.tsx:71
+msgid "New Shipping Method"
+msgstr "Yangi yetkazib berish usuli"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:45
+msgid "is greater than or equal to"
+msgstr "katta yoki teng"
+
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:77
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:88
+msgid "Preview"
+msgstr "Oldindan ko'rish"
+
+#. placeholder {0}: quantity.max
+#. placeholder {1}: line.quantity
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:261
+msgid "{0} of {1} available to fulfill"
+msgstr "{1} dan {0} ta bajarish uchun mavjud"
+
+#: src/lib/components/date-range-picker.tsx:63
+msgctxt "date-range"
+msgid "Month to date"
+msgstr "Oy boshidan hozirgacha"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:43
+msgid "refundReason.CustomerRequest"
+msgstr "Mijoz so'rovi"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:45
+msgid "refundReason.DamagedInShipping"
+msgstr "Yetkazishda shikastlangan"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:44
+msgid "refundReason.NotAvailable"
+msgstr "Mavjud emas"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:47
+msgid "refundReason.Other"
+msgstr "Boshqa"
+
+#. js-lingui-explicit-id
+#: src/i18n/common-strings.ts:46
+msgid "refundReason.WrongItem"
+msgstr "Noto'g'ri mahsulot"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:201
+msgid "Summary of modifications"
+msgstr "O'zgartirishlar xulosasi"
+
+#. placeholder {0}: payment.refunds.length
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:208
+msgid "Refunds ({0})"
+msgstr "Pul qaytarishlar ({0})"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:135
+msgid "Last Executed"
+msgstr "Oxirgi bajarilgan"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:248
+msgid "Payment details"
+msgstr "To'lov tafsilotlari"
+
+#: src/app/routes/_authenticated/_products/products.tsx:111
+msgid "Rebuild search index"
+msgstr "Qidiruv indeksini qayta qurish"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:157
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:161
+msgid "Running"
+msgstr "Ishlamoqda"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:118
+msgid "Every 60 seconds"
+msgstr "Har 60 soniyada"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups_.$id.tsx:74
+msgid "Failed to update customer group"
+msgstr "Mijozlar guruhini yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:191
+msgid "Payment metadata"
+msgstr "To'lov metama'lumotlari"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:173
+msgid "Cancel modification"
+msgstr "O'zgartirishni bekor qilish"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:130
+msgid "Same window"
+msgstr "Xuddi shu oyna"
+
+#: src/lib/components/data-table/views-sheet.tsx:155
+msgid "Apply filters to the table and click \"Save View\" to get started."
+msgstr "Boshlash uchun jadvalga filtrlarni qo'llang va \"Ko'rinishni saqlash\" tugmasini bosing."
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:202
+msgid "Roles"
+msgstr "Rollar"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:322
+msgid "Additional payment required"
+msgstr "Qo'shimcha to'lov talab qilinadi"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:96
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:63
+msgid "Failed to update order"
+msgstr "Buyurtmani yangilab bo'lmadi"
+
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx:84
+msgid "With selected..."
+msgstr "Tanlangan bilan..."
+
+#: src/app/routes/_authenticated/_stock-locations/stock-locations_.$id.tsx:77
+msgid "Failed to create stock location"
+msgstr "Zaxira joyini yaratib bo'lmadi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:51
+msgid "less than or equal"
+msgstr "kichik yoki teng"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-sheet.tsx:34
+msgid "Customer group members for {customerGroupName}"
+msgstr "{customerGroupName} uchun mijozlar guruhi a'zolari"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:118
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:217
+#: src/app/routes/_authenticated/_orders/orders.tsx:101
+#: src/app/routes/_authenticated/_system/job-queue.tsx:268
+msgid "State"
+msgstr "Holat"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:389
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:409
+msgid "Do not track"
+msgstr "Kuzatmaslik"
+
+#. placeholder {0}: entry.data.fulfillmentId
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:65
+msgid "Fulfillment #{0} created"
+msgstr "Bajarish #{0} yaratildi"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/alert/search-index-buffer-alert/search-index-buffer-alert.ts:35
+msgid "Running pending search index updates"
+msgstr "Kutilayotgan qidiruv indeksi yangilanishlari ishga tushirilmoqda"
+
+#: src/app/routes/_authenticated/_roles/roles.tsx:53
+msgid "This is a default Role and cannot be modified"
+msgstr "Bu standart Rol va uni o'zgartirib bo'lmaydi"
+
+#: src/lib/components/data-table/my-views-button.tsx:37
+msgid "My saved views"
+msgstr "Mening saqlangan ko'rinishlarim"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:202
+msgid "State / Province"
+msgstr "Shtat / Viloyat"
+
+#: src/app/routes/_authenticated/_countries/countries_.$id.tsx:92
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:147
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:42
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:261
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:228
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:153
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:115
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:119
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:102
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:55
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:57
+#: src/app/routes/_authenticated/_zones/components/zone-countries-table.tsx:57
+#: src/lib/components/layout/nav-user.tsx:152
+msgid "Enabled"
+msgstr "Yoqilgan"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:476
+msgid "Items per page"
+msgstr "Sahifaga elementlar"
+
+#: src/app/routes/_authenticated/_zones/zones.tsx:39
+msgid "Edit members"
+msgstr "A'zolarni tahrirlash"
+
+#: src/lib/components/shared/stock-level-label.tsx:18
+msgid "Stock on hand"
+msgstr "Mavjud zaxira"
+
+#: src/lib/components/data-table/data-table-filter-dialog.tsx:52
+msgid "Filter by {columnId}"
+msgstr "{columnId} bo'yicha filtrlash"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:108
+msgid "ID"
+msgstr "ID"
+
+#: src/lib/components/shared/alerts.tsx:33
+msgid "Alerts"
+msgstr "Ogohlantirishlar"
+
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:74
+msgid "Option Values"
+msgstr "Optsiya qiymatlari"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:222
+msgid "Preview changes"
+msgstr "O'zgartirishlarni oldindan ko'rish"
+
+#: src/lib/components/shared/assigned-channels.tsx:52
+msgid "Failed to remove {entityType} from channel"
+msgstr "{entityType} kanaldan olib tashlab bo'lmadi"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:191
+msgid "Variant deleted successfully"
+msgstr "Variant o'chirildi"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:87
+msgid "Edit the selected link properties"
+msgstr "Tanlangan havola xususiyatlarini tahrirlash"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:75
+msgid "Sales"
+msgstr "Sotuvlar"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:83
+msgid "Select a destination collection"
+msgstr "Manzil to'plamini tanlang"
+
+#: src/lib/framework/dashboard-widget/latest-orders-widget/index.tsx:78
+msgid "Your latest orders"
+msgstr "So'nggi buyurtmalaringiz"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:144
+msgid "Scheduled Tasks"
+msgstr "Rejalashtirilgan vazifalar"
+
+#: src/lib/components/data-table/use-generated-columns.tsx:414
+msgid "Are you sure you want to delete this item? This action cannot be undone."
+msgstr "Bu elementni o'chirmoqchimisiz? Bu amalni bekor qilib bo'lmaydi."
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:342
+msgid "Variants"
+msgstr "Variantlar"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:174
+msgid "Sellers"
+msgstr "Sotuvchilar"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:167
+msgid "Settings"
+msgstr "Sozlamalar"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:151
+msgid "Settings Store"
+msgstr "Sozlamalar do'koni"
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:98
+msgid "Heading 3"
+msgstr "3-sarlavha"
+
+#: src/lib/components/login/login-form.tsx:70
+msgid "Welcome to Vendure"
+msgstr "Vendure'ga xush kelibsiz"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:209
+msgid "Shipping Methods"
+msgstr "Yetkazib berish usullari"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:144
+msgid "({maxRefundable} refundable)"
+msgstr "({maxRefundable} qaytarilishi mumkin)"
+
+#: src/app/routes/_authenticated/_administrators/administrators.tsx:73
+msgid "Identifier"
+msgstr "Identifikator"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:118
+msgid "Failed to update collection"
+msgstr "To'plamni yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:304
+msgid "Price and tax"
+msgstr "Narx va soliq"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:56
+msgid "Order not found"
+msgstr "Buyurtma topilmadi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:26
+msgid "!="
+msgstr "!="
+
+#: src/lib/components/shared/error-page.tsx:18
+msgid "Error"
+msgstr "Xato"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:103
+msgid "Order modified"
+msgstr "Buyurtma o'zgartirildi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:59
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:128
+msgid "Password reset requested"
+msgstr "Parolni tiklash so'raldi"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:210
+msgid "Allocated payment amount must equal refund total"
+msgstr "Ajratilgan to'lov summasi pul qaytarish jamiga teng bo'lishi kerak"
+
+#. placeholder {0}: selection.length
+#: src/lib/components/shared/remove-from-channel-bulk-action.tsx:84
+msgid "Are you sure you want to remove {0} {entityType} from the current channel?"
+msgstr "Joriy kanaldan {0} {entityType} olib tashlamoqchimisiz?"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:140
+msgid "Add tags..."
+msgstr "Teglar qo'shish..."
+
+#. placeholder {0}: selectedIds.length
+#: src/lib/components/data-input/product-multi-selector-input.tsx:404
+msgid "{0} items selected"
+msgstr "{0} ta element tanlandi"
+
+#: src/lib/components/shared/language-selector.tsx:53
+msgid "Search languages..."
+msgstr "Tillarni qidirish..."
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:188
+msgid "Stock Locations"
+msgstr "Zaxira joylashuvlari"
+
+#: src/lib/components/data-table/data-table-pagination.tsx:69
+msgid "Go to previous page"
+msgstr "Oldingi sahifaga o'tish"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:245
+#: src/app/routes/_authenticated/_collections/collections.tsx:402
+msgid "Contents"
+msgstr "Tarkib"
+
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:43
+msgid "Failed to cancel {rejected} jobs"
+msgstr "{rejected} ta vazifani bekor qilib bo'lmadi"
+
+#: src/lib/components/data-table/views-sheet.tsx:110
+msgid "Failed to convert global view to personal view"
+msgstr "Global ko'rinishni shaxsiyga aylantirib bo'lmadi"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:182
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:177
+msgid "The result of the job"
+msgstr "Vazifa natijasi"
+
+#. placeholder {0}: formatCurrency(outstandingAmount, currencyCode)
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:177
+msgid "Add payment ({0})"
+msgstr "To'lov qo'shish ({0})"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:130
+msgid "System"
+msgstr "Tizim"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:290
+msgid "Variant name"
+msgstr "Variant nomi"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:543
+msgid "Remove"
+msgstr "Olib tashlash"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:105
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:111
+msgid "Failed to update customer"
+msgstr "Mijozni yangilab bo'lmadi"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:306
+msgid "Remove option groups?"
+msgstr "Optsiya guruhlari olib tashlansinmi?"
+
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:91
+msgid "This is a preview of the collection contents based on the current filter settings. Once you save the collection, the contents will be updated to reflect the new filter settings."
+msgstr "Bu joriy filtr sozlamalariga asoslangan to'plam tarkibi. To'plamni saqlagach, tarkib yangi sozlamalar bo'yicha yangilanadi."
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:223
+msgid "Tax Categories"
+msgstr "Soliq toifalari"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:230
+msgid "Tax Rates"
+msgstr "Soliq stavkalari"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:273
+msgid "Failed to load global settings"
+msgstr "Global sozlamalarni yuklab bo'lmadi"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:75
+msgid "Select items to refund and optionally return to stock"
+msgstr "Pul qaytarish va zaxiraga qaytarish uchun elementlarni tanlang"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:243
+#: src/app/routes/_authenticated/_system/settings-store.tsx:143
+#: src/lib/components/data-table/views-sheet.tsx:210
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx:54
+msgid "Save"
+msgstr "Saqlash"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:156
+msgid "Preview order modifications"
+msgstr "Buyurtma o'zgartirishlarini oldindan ko'rish"
+
+#. js-lingui-explicit-id
+#: src/lib/hooks/use-extended-detail-query.ts:25
+#: src/lib/hooks/use-extended-list-query.ts:66
+msgid "The page will continue with the default query."
+msgstr "Sahifa standart so'rov bilan davom etadi."
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-address-form.tsx:175
+#: src/lib/components/shared/customer-address-form.tsx:121
+msgid "Street Address"
+msgstr "Ko'cha manzili"
+
+#: src/lib/components/shared/facet-value-selector.tsx:242
+msgid "No more facets"
+msgstr "Boshqa fasetlar yo'q"
+
+#: src/app/routes/_authenticated/_products/products.tsx:32
+msgid "Search index rebuild started"
+msgstr "Qidiruv indeksini qayta qurish boshlandi"
+
+#: src/app/routes/_authenticated/_collections/collections.tsx:323
+msgid "Collection position updated"
+msgstr "To'plam pozitsiyasi yangilandi"
+
+#: src/app/routes/_authenticated/_products/components/product-option-select.tsx:79
+msgid "Add \"{newOptionInput}\""
+msgstr "\"{newOptionInput}\" qo'shish"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:244
+msgid "New product variant"
+msgstr "Yangi mahsulot varianti"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:74
+msgid "Refund transitioned"
+msgstr "Pul qaytarish o'tkazildi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:13
+msgid "Using native authentication strategy"
+msgstr "Mahalliy autentifikatsiya strategiyasidan foydalanilmoqda"
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx:73
+msgid "Failed to assign {entityIdsLength} {entityType} to channel"
+msgstr "{entityIdsLength} ta {entityType} kanalga biriktirib bo'lmadi"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:351
+msgid "Default Language"
+msgstr "Standart til"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:141
+msgid "Token"
+msgstr "Token"
+
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:315
+msgid "Fulfilling..."
+msgstr "Bajarilmoqda..."
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:147
+msgid "Add option group to product"
+msgstr "Mahsulotga optsiya guruhi qo'shish"
+
+#: src/app/routes/_authenticated/_sellers/sellers_.$id.tsx:56
+msgid "Successfully updated seller"
+msgstr "Sotuvchi muvaffaqiyatli yangilandi"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:130
+msgid "Failed to transition order to state"
+msgstr "Buyurtmani holatga o'tkazib bo'lmadi"
+
+#. placeholder {0}: group.entries.length - 2
+#: src/lib/components/shared/history-timeline/history-timeline-with-grouping.tsx:129
+msgid "Show all ({0})"
+msgstr "Hammasini ko'rsatish ({0})"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:78
+msgid "Failed to create tax rate"
+msgstr "Soliq stavkasini yaratib bo'lmadi"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:118
+msgid "I have saved this API key"
+msgstr "Men bu API kalitini saqladim"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:244
+msgid "Configure available languages for your store and channels"
+msgstr "Do'kon va kanallaringiz uchun mavjud tillarni sozlang"
+
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:160
+msgid "Successfully created product"
+msgstr "Mahsulot muvaffaqiyatli yaratildi"
+
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:230
+msgid "Add product variant"
+msgstr "Mahsulot varianti qo'shish"
+
+#. js-lingui-explicit-id
+#: src/lib/components/data-input/string-list-input.tsx:237
+msgid "Type and press Enter or comma to add..."
+msgstr "Yozing va qo'shish uchun Enter yoki vergul bosing..."
+
+#: src/lib/components/shared/history-timeline/history-note-editor.tsx:44
+msgid "Edit Note"
+msgstr "Eslatmani tahrirlash"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:628
+msgid "No assets found. Try adjusting your filters."
+msgstr "Asset topilmadi. Filtrlarni o'zgartirib ko'ring."
+
+#: src/app/routes/_authenticated/_products/components/option-groups-editor.tsx:161
+msgid "Add Option"
+msgstr "Variant qo'shish"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:190
+msgid "Save option group"
+msgstr "Optsiya guruhini saqlash"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-single-method-result.tsx:43
+msgid "Click \"Run Test\" to test this shipping method."
+msgstr "Bu yetkazib berish usulini sinash uchun \"Testni ishga tushirish\" tugmasini bosing."
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:78
+msgid "Successfully updated administrator"
+msgstr "Administrator muvaffaqiyatli yangilandi"
+
+#: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:282
+#: src/lib/components/data-table/data-table-faceted-filter.tsx:185
+#: src/lib/components/shared/asset/asset-gallery.tsx:361
+msgid "Clear filters"
+msgstr "Filtrlarni tozalash"
+
+#. placeholder {0}: entry.data.fulfillmentId
+#. placeholder {1}: entry.data.from
+#. placeholder {2}: entry.data.to
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:52
+msgid "Fulfillment #{0} from {1} to {2}"
+msgstr "{1} dan {2} ga bajarish #{0}"
+
+#: src/lib/components/data-table/views-sheet.tsx:87
+msgid "Failed to delete global view"
+msgstr "Global ko'rinishni o'chirib bo'lmadi"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:188
+msgid "Default language"
+msgstr "Standart til"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:253
+#: src/app/routes/_authenticated/_customers/customers.tsx:44
+msgid "Status"
+msgstr "Holat"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:370
+#: src/lib/components/shared/asset/asset-gallery.tsx:382
+msgid "Binary"
+msgstr "Ikkilik"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:127
+msgid "Successfully updated option group"
+msgstr "Optsiya guruhi muvaffaqiyatli yangilandi"
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:43
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:117
+msgid "New shipping method"
+msgstr "Yangi yetkazib berish usuli"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:116
+msgid "Every 10 seconds"
+msgstr "Har 10 soniyada"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/price-display.tsx:17
+msgid "ex. tax:"
+msgstr "soliqsiz:"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:105
+msgid "Successfully added option value"
+msgstr "Optsiya qiymati muvaffaqiyatli qo'shildi"
+
+#: src/app/routes/_authenticated/_collections/collections.tsx:325
+msgid "Collection moved to new parent"
+msgstr "To'plam yangi ota-elementga ko'chirildi"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:206
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:215
+msgid "Option group removed"
+msgstr "Optsiya guruhi olib tashlandi"
+
+#: src/app/routes/_authenticated/_orders/components/use-transition-order-to-state.tsx:130
+msgid "Transition to selected state"
+msgstr "Tanlangan holatga o'tkazish"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:325
+msgid "An additional payment of {formattedDiff} will be required."
+msgstr "{formattedDiff} miqdorida qo'shimcha to'lov talab qilinadi."
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:144
+msgid "Track inventory by default"
+msgstr "Standart bo'yicha omborni kuzatish"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:258
+msgid "{selected} of {total} selected"
+msgstr "{total} tadan {selected} tasi tanlandi"
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:90
+msgid "Successfully created shipping method"
+msgstr "Yetkazib berish usuli muvaffaqiyatli yaratildi"
+
+#: src/app/routes/_authenticated/_customer-groups/customer-groups.tsx:61
+msgid "New Customer Group"
+msgstr "Yangi mijozlar guruhi"
+
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:24
+msgid "Visible to customer"
+msgstr "Mijozga ko'rinadigan"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:126
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:115
+msgid "Successfully created option group"
+msgstr "Optsiya guruhi muvaffaqiyatli yaratildi"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:36
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:18
+#: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:28
+msgid "Tax Rates"
+msgstr "Soliq stavkalari"
+
+#: src/lib/components/data-input/slug-input.tsx:239
+msgid "Slug will be generated automatically..."
+msgstr "Slug avtomatik yaratiladi..."
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:56
+msgid "Customer not found"
+msgstr "Mijoz topilmadi"
+
+#. placeholder {0}: entityName.toLowerCase()
+#: src/lib/components/data-input/default-relation-input.tsx:663
+msgid "Select {0}s"
+msgstr "{0} larni tanlang"
+
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:256
+msgid "New facet values to add:"
+msgstr "Qo'shish uchun yangi faset qiymatlari:"
+
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:289
+#: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts:302
+msgid "Failed to process refund"
+msgstr "Pul qaytarishni qayta ishlab bo'lmadi"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:115
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:176
+#: src/app/routes/_authenticated/_profile/profile.tsx:102
+msgid "First name"
+msgstr "Ismi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:56
+msgid "contains"
+msgstr "o'z ichiga oladi"
+
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+msgid "No option groups found"
+msgstr "Optsiya guruhi topilmadi"
+
+#: src/lib/components/data-input/product-multi-selector-input.tsx:91
+msgid "No items found"
+msgstr "Element topilmadi"
+
+#: src/app/routes/_authenticated/_orders/components/order-table-totals.tsx:52
+msgid "Sub total"
+msgstr "Oraliq jami"
+
+#. placeholder {0}: fulfillment.lines.reduce((acc, line) => acc + line.quantity, 0)
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:131
+msgid "Fulfilled items ({0})"
+msgstr "Bajarilgan elementlar ({0})"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:236
+msgid "Value updated"
+msgstr "Qiymat yangilandi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-status-badge.tsx:28
+msgid "Unverified"
+msgstr "Tasdiqlanmagan"
+
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:111
+#: src/app/routes/_authenticated/_orders/components/fulfill-order-dialog.tsx:268
+#: src/app/routes/_authenticated/_orders/components/order-table.tsx:78
+msgid "Quantity"
+msgstr "Miqdor"
+
+#: src/lib/components/data-table/add-filter-menu.tsx:35
+msgid "Add filter"
+msgstr "Filtr qo'shish"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:309
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:127
+msgid "Tax category"
+msgstr "Soliq toifasi"
+
+#: src/app/routes/_authenticated/_profile/profile.tsx:38
+#: src/app/routes/_authenticated/_profile/profile.tsx:84
+#: src/lib/components/layout/nav-user.tsx:108
+msgid "Profile"
+msgstr "Profil"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/shipping-method-test-result-wrapper.tsx:68
+msgid "Test data has been updated. Click \"Run Test\" to see updated results."
+msgstr "Test ma'lumotlari yangilandi. Yangilangan natijalarni ko'rish uchun \"Testni ishga tushirish\" tugmasini bosing."
+
+#: src/lib/components/data-table/human-readable-operator.tsx:38
+msgid "is not in"
+msgstr "ichida emas"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:132
+msgid "Order line updated"
+msgstr "Buyurtma satri yangilandi"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods.tsx:81
+msgid "New Payment Method"
+msgstr "Yangi to'lov usuli"
+
+#: src/app/routes/_authenticated/_products/components/option-value-input.tsx:35
+msgid "Duplicate value \"{trimmed}\" already exists"
+msgstr "\"{trimmed}\" takroriy qiymati allaqachon mavjud"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:233
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:217
+msgid "Reason"
+msgstr "Sabab"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:256
+msgid "Customer groups"
+msgstr "Mijozlar guruhlari"
+
+#: src/lib/components/shared/assigned-channels.tsx:48
+msgid "Successfully removed {entityType} from channel"
+msgstr "{entityType} kanaldan muvaffaqiyatli olib tashlandi"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:81
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$groupId.options_.$id.tsx:90
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:73
+#: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:81
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:17
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:24
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:278
+msgid "Option Groups"
+msgstr "Optsiya guruhlari"
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:133
+#: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx:194
+msgid "Add surcharge"
+msgstr "Qo'shimcha to'lov qo'shish"
+
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:202
+msgid "Current facet values"
+msgstr "Joriy faset qiymatlari"
+
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:80
+msgid "Page {page} of {totalPages}"
+msgstr "{totalPages} dan {page}-sahifa"
+
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:42
+msgid "Failed to cancel {rejected} job"
+msgstr "{rejected} ta vazifani bekor qilib bo'lmadi"
+
+#: src/lib/components/date-range-picker.tsx:79
+msgctxt "date-range"
+msgid "Last month"
+msgstr "O'tgan oy"
+
+#: src/app/routes/_authenticated/_countries/countries.tsx:59
+msgid "Add Country"
+msgstr "Mamlakat qo'shish"
+
+#: src/lib/components/data-input/custom-field-list-input.tsx:85
+msgid "Remove item"
+msgstr "Elementni olib tashlash"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:369
+#: src/lib/components/shared/asset/asset-gallery.tsx:381
+msgid "Video"
+msgstr "Video"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:48
+msgid "less than"
+msgstr "dan kichik"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:121
+msgid "The variant could not be added. Ensure the parent product is enabled."
+msgstr "Variantni qo'shib bo'lmadi. Ota-mahsulot yoqilganiga ishonch hosil qiling."
+
+#: src/lib/framework/dashboard-widget/metrics-widget/index.tsx:74
+msgid "Metrics"
+msgstr "Metrikalar"
+
+#: src/lib/components/layout/nav-user.tsx:112
+msgid "Language"
+msgstr "Til"
+
+#: src/app/routes/_authenticated/_collections/collections.tsx:520
+msgid "New Collection"
+msgstr "Yangi to'plam"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:72
+msgid "Refund and cancel order"
+msgstr "Pul qaytarish va buyurtmani bekor qilish"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:65
+msgid "Email update verified"
+msgstr "Elektron pochta yangilanishi tasdiqlandi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:32
+msgid "is between"
+msgstr "oralig'ida"
+
+#: src/app/routes/_authenticated/_orders/components/order-detail-shared.tsx:171
+msgid "Refund & Cancel"
+msgstr "Pul qaytarish va bekor qilish"
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-shipping-methods-result.tsx:56
+msgid "Testing shipping methods..."
+msgstr "Yetkazib berish usullari sinovdan o'tkazilmoqda..."
+
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx:110
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx:137
+msgid "{label}"
+msgstr "{label}"
+
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:100
+msgid "Failed to create shipping method"
+msgstr "Yetkazib berish usulini yaratib bo'lmadi"
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx:68
+msgid "Successfully assigned {entityIdsLength} {entityType} to channel"
+msgstr "{entityIdsLength} ta {entityType} kanalga muvaffaqiyatli biriktirildi"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:253
+msgid "Global Languages"
+msgstr "Global tillar"
+
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:38
+#: src/app/routes/_authenticated/_administrators/administrators_.$id.tsx:97
+msgid "New administrator"
+msgstr "Yangi administrator"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:355
+msgid "Delete draft"
+msgstr "Qoralamani o'chirish"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:141
+msgid "Source"
+msgstr "Manba"
+
+#: src/lib/components/data-table/data-table-bulk-actions.tsx:107
+#: src/lib/components/shared/asset/asset-bulk-actions.tsx:98
+msgid "No actions available"
+msgstr "Mavjud amallar yo'q"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:90
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:96
+msgid "Failed to update channel"
+msgstr "Kanalni yangilab bo'lmadi"
+
+#: src/lib/components/shared/custom-fields-form.tsx:101
+msgid "General"
+msgstr "Umumiy"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:223
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:228
+msgid "Add new address"
+msgstr "Yangi manzil qo'shish"
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:77
+msgid "Successfully updated facet"
+msgstr "Faset muvaffaqiyatli yangilandi"
+
+#: src/app/routes/_authenticated/_zones/zones_.$id.tsx:61
+msgid "Successfully created zone"
+msgstr "Hudud muvaffaqiyatli yaratildi"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:268
+msgid "Value"
+msgstr "Qiymat"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:105
+msgid "Customer updated"
+msgstr "Mijoz yangilandi"
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx:146
+msgid "Price conversion factor"
+msgstr "Narx konversiya koeffitsienti"
+
+#: src/app/routes/_authenticated/_orders/orders_.$aggregateOrderId_.seller-orders.$sellerOrderId.tsx:34
+msgid "Seller order"
+msgstr "Sotuvchi buyurtmasi"
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:36
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:92
+msgid "New facet"
+msgstr "Yangi faset"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:316
+msgid "Are you sure you want to remove this option group from the product?"
+msgstr "Ushbu optsiya guruhini mahsulotdan olib tashlamoqchimisiz?"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:169
+msgid "Description (alt)"
+msgstr "Tavsif (muqobil)"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:126
+#: src/app/routes/_authenticated/_assets/components/asset-tags-editor.tsx:164
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:99
+msgid "No tags found"
+msgstr "Teglar topilmadi"
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:201
+msgid "Default currency"
+msgstr "Standart valyuta"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:337
+msgid "No payment or refund is required for these changes."
+msgstr "Bu o'zgartirishlar uchun to'lov yoki pul qaytarish talab qilinmaydi."
+
+#: src/app/routes/_authenticated/_system/components/cancel-jobs-bulk-action.tsx:70
+msgid "{cancellableCount, plural, one {Are you sure you want to cancel {cancellableCount} job? This action cannot be undone.} other {Are you sure you want to cancel {cancellableCount} jobs? This action cannot be undone.}}"
+msgstr "{cancellableCount, plural, one {{cancellableCount} ta vazifani bekor qilmoqchimisiz? Bu amalni qaytarib bo'lmaydi.} other {{cancellableCount} ta vazifani bekor qilmoqchimisiz? Bu amalni qaytarib bo'lmaydi.}}"
+
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:100
+msgid "Total Revenue"
+msgstr "Jami daromad"
+
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:147
+msgid "Next Execution"
+msgstr "Keyingi bajarilish"
+
+#: src/lib/components/shared/history-timeline/history-note-checkbox.tsx:21
+msgid "Note is private"
+msgstr "Eslatma maxfiy"
+
+#: src/lib/components/layout/language-dialog.tsx:124
+msgid "Medium date"
+msgstr "O'rta sana"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:169
+msgid "Invalid number"
+msgstr "Noto'g'ri raqam"
+
+#: src/lib/components/data-table/views-sheet.tsx:152
+msgid "You haven't saved any views yet."
+msgstr "Hali hech qanday ko'rinishni saqlamadingiz."
+
+#: src/lib/components/data-table/views-sheet.tsx:173
+msgid "Are you sure you want to delete this view? This action cannot be undone."
+msgstr "Ushbu ko'rinishni o'chirmoqchimisiz? Bu amalni qaytarib bo'lmaydi."
+
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:73
+msgid "View order process"
+msgstr "Buyurtma jarayonini ko'rish"
+
+#: src/lib/components/data-table/views-sheet.tsx:100
+msgid "Failed to duplicate view"
+msgstr "Ko'rinishni nusxalash amalga oshmadi"
+
+#: src/lib/components/shared/customer-address-form.tsx:223
+msgid "Use as the default shipping address"
+msgstr "Standart yetkazib berish manzili sifatida ishlatish"
+
+#: src/lib/components/data-input/slug-input.tsx:280
+#: src/lib/components/data-input/slug-input.tsx:282
+msgid "Edit slug manually"
+msgstr "Slug'ni qo'lda tahrirlash"
+
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:80
+msgid "Add filters to preview the collection contents."
+msgstr "To'plam tarkibini ko'rish uchun filtrlar qo'shing."
+
+#: src/app/routes/_authenticated/_shipping-methods/components/test-order-builder.tsx:220
+msgid "Subtotal"
+msgstr "Oraliq jami"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:48
+msgid "is less than"
+msgstr "dan kichik"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:215
+msgid "Refund ID"
+msgstr "Pul qaytarish ID"
+
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:91
+msgid "Order custom fields updated"
+msgstr "Buyurtmaning maxsus maydonlari yangilandi"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:193
+#: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx:191
+msgid "Calculator"
+msgstr "Kalkulyator"
+
+#: src/app/routes/_authenticated/_option-groups/components/option-group-bulk-actions.tsx:78
+msgid "Failed to remove option group from channel: {message}"
+msgstr "Optsiya guruhini kanaldan olib tashlash amalga oshmadi: {message}"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:161
+msgid "View job data"
+msgstr "Vazifa ma'lumotlarini ko'rish"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:107
+msgid "Move to the top level"
+msgstr "Eng yuqori darajaga ko'chirish"
+
+#: src/lib/components/data-input/product-multi-selector-input.tsx:329
+msgid "Clear"
+msgstr "Tozalash"
+
+#: src/lib/framework/dashboard-widget/orders-summary/index.tsx:84
+msgid "Orders Summary"
+msgstr "Buyurtmalar xulosasi"
+
+#: src/lib/components/shared/asset/asset-gallery.tsx:349
+msgid "Search assets..."
+msgstr "Assetlarni qidirish..."
+
+#: src/app/routes/_authenticated/_facets/facets.tsx:114
+msgid "New Facet"
+msgstr "Yangi faset"
+
+#: src/lib/components/shared/assign-to-channel-dialog.tsx:92
+msgid "Assign {entityType} to channel"
+msgstr "{entityType} ni kanalga biriktirish"
+
+#: src/lib/components/data-table/data-table-bulk-action-item.tsx:125
+#: src/lib/components/shared/confirmation-dialog.tsx:51
+msgid "Continue"
+msgstr "Davom etish"
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:43
+#: src/app/routes/_authenticated/_promotions/promotions.tsx:20
+#: src/app/routes/_authenticated/_promotions/promotions.tsx:29
+msgid "Promotions"
+msgstr "Aksiyalar"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:183
+msgid "Error message"
+msgstr "Xatolik xabari"
+
+#: src/app/routes/_authenticated/_product-variants/components/add-stock-location-dropdown.tsx:40
+msgid "Add stock level for another location"
+msgstr "Boshqa joy uchun zaxira darajasini qo'shish"
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:141
+msgid "Delete Address"
+msgstr "Manzilni o'chirish"
+
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:84
+msgid "Failed to update facet"
+msgstr "Fasetni yangilash amalga oshmadi"
+
+#: src/lib/hooks/use-widget-filters.ts:17
+msgid "useWidgetFilters must be used within a WidgetFiltersProvider"
+msgstr "useWidgetFilters WidgetFiltersProvider ichida ishlatilishi kerak"
+
+#: src/app/routes/_authenticated/_customers/components/customer-address-card.tsx:129
+msgid "Edit Address"
+msgstr "Manzilni tahrirlash"
+
+#: src/app/routes/_authenticated/_facets/components/facet-bulk-actions.tsx:73
+msgid "Failed to remove facet from channel: {message}"
+msgstr "Fasetni kanaldan olib tashlash amalga oshmadi: {message}"
+
+#: src/lib/components/shared/rich-text-editor/link-dialog.tsx:149
+msgid "Set link"
+msgstr "Havolani o'rnatish"
+
+#: src/app/routes/_authenticated/_sellers/sellers.tsx:45
+msgid "New Seller"
+msgstr "Yangi sotuvchi"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:106
+msgid "Edit image"
+msgstr "Rasmni tahrirlash"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:68
+msgid "Manage Variants"
+msgstr "Variantlarni boshqarish"
+
+#: src/lib/components/shared/stock-level-label.tsx:18
+msgid "Stock allocated"
+msgstr "Zaxira ajratildi"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:43
+msgid "greater than or equal"
+msgstr "dan katta yoki teng"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:420
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:438
+msgid "Sets the stock level at which this variant is considered to be out of stock. Using a negative value enables backorder support."
+msgstr "Ushbu variant zaxirada tugagan deb hisoblanadigan zaxira darajasini belgilaydi. Manfiy qiymat oldindan buyurtmani yoqadi."
+
+#: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx:206
+#: src/lib/components/layout/manage-languages-dialog.tsx:382
+msgid "Saving..."
+msgstr "Saqlanmoqda..."
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:185
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:180
+msgid "View result"
+msgstr "Natijani ko'rish"
+
+#: src/lib/components/data-table/data-table-pagination.tsx:20
+msgid "Rows per page"
+msgstr "Sahifadagi qatorlar"
+
+#: src/app/routes/_authenticated/_collections/components/move-collections-dialog.tsx:379
+msgid "Loading collections..."
+msgstr "To'plamlar yuklanmoqda..."
+
+#: src/app/routes/_authenticated/_facets/facets_.$facetId.values_.$id.tsx:84
+msgid "Successfully updated facet value"
+msgstr "Faset qiymati muvaffaqiyatli yangilandi"
+
+#: src/lib/components/shared/rich-text-editor/image-dialog.tsx:135
+msgid "Add asset"
+msgstr "Asset qo'shish"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:55
+msgid "Customer added to group"
+msgstr "Mijoz guruhga qo'shildi"
+
+#: src/app/routes/_authenticated/_orders/orders_.$id.tsx:23
+msgid "Seller orders"
+msgstr "Sotuvchi buyurtmalari"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:111
+msgid "Failed to add option value"
+msgstr "Optsiya qiymatini qo'shish amalga oshmadi"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:140
+msgid "Add option value to {groupName}"
+msgstr "{groupName} ga optsiya qiymatini qo'shish"
+
+#. placeholder {0}: error.message
+#: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:221
+msgid "Failed to unset shipping address for order: {0}"
+msgstr "Buyurtma uchun yetkazib berish manzilini bekor qilish amalga oshmadi: {0}"
+
+#: src/app/routes/_authenticated/_orders/components/add-surcharge-form.tsx:82
+#: src/app/routes/_authenticated/_orders/components/edit-order-table.tsx:96
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:297
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:292
+#: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:198
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:351
+msgid "SKU"
+msgstr "SKU"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/default-order-history-components.tsx:117
+msgid "{totalQuantity} item(s) refunded"
+msgstr "{totalQuantity} ta mahsulot uchun pul qaytarildi"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:282
+msgid "No option groups defined yet. Add option groups to create different variants of your product (e.g., Size, Color, Material)"
+msgstr "Hali optsiya guruhi belgilanmagan. Mahsulotingizning turli variantlarini yaratish uchun optsiya guruhlarini qo'shing (masalan, O'lcham, Rang, Material)"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/default-customer-history-components.tsx:167
+msgid "New email:"
+msgstr "Yangi email:"
+
+#: src/app/routes/_authenticated/_payment-methods/payment-methods_.$id.tsx:110
+msgid "Failed to update payment method"
+msgstr "To'lov usulini yangilash amalga oshmadi"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-preview-dialog.tsx:242
+msgid "Available:"
+msgstr "Mavjud:"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:174
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:221
+msgid "Created at"
+msgstr "Yaratilgan sana"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:156
+#: src/app/routes/_authenticated/_products/components/add-product-variant-dialog.tsx:165
+msgid "Failed to create product variant"
+msgstr "Mahsulot variantini yaratish amalga oshmadi"
+
+#. placeholder {0}: formatLanguageName(contentLanguage)
+#: src/lib/components/layout/channel-switcher.tsx:130
+msgid "Language: {0}"
+msgstr "Til: {0}"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:262
+msgid "You don't have permission to view global language settings"
+msgstr "Sizda global til sozlamalarini ko'rish ruxsati yo'q"
+
+#: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:70
+msgid "Successfully created tax rate"
+msgstr "Soliq stavkasi muvaffaqiyatli yaratildi"
+
+#: src/lib/components/shared/rich-text-editor/responsive-toolbar.tsx:101
+msgid "Heading 6"
+msgstr "Sarlavha 6"
+
+#: src/app/routes/_authenticated/_orders/components/order-modification-summary.tsx:209
+msgid "Added coupon codes"
+msgstr "Kupon kodlari qo'shildi"
+
+#: src/lib/components/layout/channel-switcher.tsx:180
+msgctxt "active language"
+msgid "Active"
+msgstr "Faol"
+
+#: src/app/routes/_authenticated/_orders/components/order-tax-summary.tsx:20
+msgid "Tax base"
+msgstr "Soliq asosi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-container.tsx:73
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-container.tsx:75
+msgid "Load more"
+msgstr "Ko'proq yuklash"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:72
+msgid "Refund settled"
+msgstr "Pul qaytarish hisoblashildi"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:85
+msgid "API Key"
+msgstr "API kaliti"
+
+#: src/app/common/duplicate-bulk-action.tsx:97
+msgid "Successfully duplicated {count} {entityName}"
+msgstr "{count} ta {entityName} muvaffaqiyatli nusxalandi"
+
+#: src/app/routes/_authenticated/_option-groups/option-groups.tsx:71
+msgid "New Option Group"
+msgstr "Yangi optsiya guruhi"
+
+#: src/app/routes/_authenticated/_system/job-queue.tsx:191
+#: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:186
+msgid "No result yet"
+msgstr "Hali natija yo'q"
+
+#: src/app/routes/_authenticated/_orders/components/order-history/order-history-utils.tsx:61
+msgid "Payment settled"
+msgstr "To'lov hisoblashildi"
+
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx:27
+msgid "Active filters"
+msgstr "Faol filtrlar"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:178
+#: src/lib/components/data-table/data-table-active-filters-popover.tsx:54
+#: src/lib/components/data-table/data-table.tsx:434
+msgid "Clear all"
+msgstr "Hammasini tozalash"
+
+#: src/lib/components/data-table/human-readable-operator.tsx:40
+msgid "is greater than"
+msgstr "dan katta"
+
+#: src/app/routes/_authenticated/_api-keys/components/api-key-secret-dialog.tsx:125
+msgid "Close"
+msgstr "Yopish"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:127
+msgid "Add payment to order"
+msgstr "Buyurtmaga to'lov qo'shish"
+
+#: src/app/routes/_authenticated/_assets/components/asset-tag-filter.tsx:122
+#: src/app/routes/_authenticated/_option-groups/components/option-group-products-block.tsx:59
+#: src/app/routes/_authenticated/_products/components/add-option-group-dialog.tsx:245
+#: src/lib/components/data-input/product-multi-selector-input.tsx:83
+#: src/lib/components/data-input/relation-selector.tsx:427
+#: src/lib/components/shared/country-selector.tsx:86
+#: src/lib/components/shared/customer-group-selector.tsx:56
+#: src/lib/components/shared/customer-selector.tsx:88
+#: src/lib/components/shared/facet-value-selector.tsx:159
+msgid "Loading..."
+msgstr "Yuklanmoqda..."
+
+#: src/app/routes/_authenticated/_channels/channels_.$id.tsx:143
+msgid "The token is used to specify the channel when making API requests."
+msgstr "Token API so'rovlarini yuborishda kanalni belgilash uchun ishlatiladi."
+
+#: src/app/routes/_authenticated/_orders/components/customer-address-selector.tsx:80
+msgid "No addresses found"
+msgstr "Manzillar topilmadi"
+
+#: src/app/routes/_authenticated/_orders/components/fulfillment-details.tsx:115
+msgid "Fulfillment ID"
+msgstr "Bajarish ID"
+
+#: src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx:290
+msgid "Select payments to refund"
+msgstr "Pul qaytarish uchun to'lovlarni tanlang"
+
+#: src/app/common/delete-bulk-action.tsx:115
+msgid "Failed to delete {failed} {entityName}"
+msgstr "{failed} ta {entityName} ni o'chirish amalga oshmadi"
+
+#: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:418
+msgid "Out-of-stock threshold"
+msgstr "Zaxira tugash chegarasi"
+
+#: src/app/routes/_authenticated/_system/settings-store.tsx:239
+msgid "Failed to update value"
+msgstr "Qiymatni yangilash amalga oshmadi"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:121
+msgid "Failed to create API key"
+msgstr "API kalitini yaratish amalga oshmadi"
+
+#: src/app/routes/_authenticated/_orders/components/payment-details.tsx:264
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:49
+#: src/app/routes/_authenticated/_orders/components/settle-refund-dialog.tsx:74
+msgid "Settle refund"
+msgstr "Pul qaytarishni hisoblash"
+
+#: src/app/routes/_authenticated/_orders/components/add-manual-payment-dialog.tsx:147
+msgid "Payment method is required"
+msgstr "To'lov usuli talab qilinadi"
+
+#: src/app/routes/_authenticated/_customer-groups/components/customer-group-members-table.tsx:61
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:134
+msgid "Failed to add customer to group"
+msgstr "Mijozni guruhga qo'shish amalga oshmadi"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:275
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:279
+msgid "Manage variants"
+msgstr "Variantlarni boshqarish"
+
+#: src/lib/components/data-table/views-sheet.tsx:49
+msgid "Applied global view \"{viewName}\""
+msgstr "\"{viewName}\" global ko'rinishi qo'llanildi"
+
+#: src/app/routes/_authenticated/_customers/components/customer-history/customer-history-utils.tsx:39
+msgid "Customer registered"
+msgstr "Mijoz ro'yxatdan o'tdi"
+
+#. js-lingui-explicit-id
+#: src/lib/framework/defaults.ts:244
+msgid "Zones"
+msgstr "Hududlar"
+
+#: src/lib/components/shared/seller-selector.tsx:37
+msgid "Search sellers..."
+msgstr "Sotuvchilarni qidirish..."
+
+#: src/app/routes/_authenticated/_promotions/promotions_.$id.tsx:104
+msgid "Successfully created promotion"
+msgstr "Aksiya muvaffaqiyatli yaratildi"
+
+#: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:292
+msgid "Option"
+msgstr "Optsiya"
+
+#: src/app/routes/_authenticated/_orders/components/order-process-dialog.tsx:82
+msgid "Order process"
+msgstr "Buyurtma jarayoni"
+
+#: src/app/routes/_authenticated/_customers/customers_.$id.tsx:194
+msgid "Phone number"
+msgstr "Telefon raqami"
+
+#: src/app/routes/_authenticated/_collections/collections_.$id.tsx:157
+#: src/app/routes/_authenticated/_facets/facets_.$id.tsx:108
+msgid "Private"
+msgstr "Maxfiy"
+
+#: src/app/routes/_authenticated/_products/components/generate-variants-panel.tsx:283
+msgid "Variant"
+msgstr "Variant"
+
+#: src/app/routes/_authenticated/_global-settings/global-settings.tsx:71
+msgid "Successfully updated global settings"
+msgstr "Global sozlamalar muvaffaqiyatli yangilandi"
+
+#: src/app/routes/_authenticated/_api-keys/api-keys_.$id.tsx:115
+msgid "Successfully updated API key"
+msgstr "API kaliti muvaffaqiyatli yangilandi"
+
+#: src/lib/components/layout/manage-languages-dialog.tsx:294
+msgid "These languages will be available for all channels to use"
+msgstr "Bu tillar barcha kanallar uchun mavjud bo'ladi"

--- a/packages/dashboard/vite/constants.ts
+++ b/packages/dashboard/vite/constants.ts
@@ -29,6 +29,7 @@ export const defaultAvailableLanguages = [
     LanguageCode.bg,
     LanguageCode.nl,
     LanguageCode.ro,
+    LanguageCode.uz,
 ];
 
 export const defaultAvailableLocales = [


### PR DESCRIPTION
## Summary

Adds full **Uzbek (Latin script)** localization for the Dashboard and registers `uz` as a selectable display language. This follows the same pattern as the prior new-language additions (Romanian #4598, Hungarian #4423, Bulgarian #4001).

## Changes

- `packages/dashboard/lingui.config.js` — add `uz` to the `locales` list (extract/compile registry).
- `packages/dashboard/vite/constants.ts` — add `LanguageCode.uz` to `defaultAvailableLanguages`, so **Uzbek** appears in the "Select display language" dialog.
- `packages/dashboard/src/i18n/locales/uz.po` — new catalog with all ~1,244 UI strings translated.

No other changes are needed: the display label is rendered automatically via `Intl.DisplayNames`, the locale list already includes `UZ`, and the build pipeline compiles `uz.po` to `assets/i18n/uz.js` automatically. `LanguageCode.uz` already exists in `@vendure/core`, so no core changes are required.

## Notes on the translation

- Latin script throughout (Uzbekistan's official script); placeholders and ICU plural/select structures preserved; technical terms (API, GraphQL, SKU, Slug, …) and the Vendure brand kept verbatim.
- Explicit-id entries (`orderState.*`, `paymentState.*`, `fieldName.*`, …) translate only the human-readable part.
- Terminology kept consistent (e.g. order → buyurtma, customer → mijoz, product → mahsulot, option group → optsiya guruhi).

## Verification

- `npm run i18n:check` → `uz: 0 missing`.
- `lingui compile` passes (catalog is well-formed; all placeholders valid).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4837"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784287618&installation_id=128408429&pr_number=4837&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4837&signature=30a68616d584d978f1eafbf2b8731dc85c7b31ad01433c11c1f81d26862c2acb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->