### PR TITLE
fix(dashboard): Guard order list state cells against undefined state

### DIFF
--- a/packages/dashboard/e2e/tests/sales/orders.spec.ts
+++ b/packages/dashboard/e2e/tests/sales/orders.spec.ts
@@ -100,6 +100,46 @@ test.describe('Orders', () => {
         await lp.expectRowCountGreaterThan(0);
     });
 
+    // #4830 — toggling the State column must not crash the order list.
+    // The list query only fetches visible columns; re-enabling State refetches,
+    // but `placeholderData: keepPreviousData` first renders the previous rows
+    // (which no longer carry `state`) into the State column. Pre-fix this threw
+    // `Cannot read properties of undefined (reading 'toLowerCase')` in
+    // OrderStateCell and tripped the router error boundary.
+    test('should not crash when toggling the State column off and on', async ({ page }) => {
+        const client = new VendureAdminClient(page);
+        await client.login();
+        await createPaidOrder(client);
+
+        const lp = listPage(page);
+        await lp.goto();
+        await lp.expectLoaded();
+        await lp.expectRowCountGreaterThan(0);
+
+        const stateHeader = lp.dataTable.locator('thead th').filter({ hasText: 'State' });
+        const stateToggle = page.getByRole('menuitemcheckbox', { name: /^state$/i });
+        await expect(stateHeader).toBeVisible();
+
+        // Hide State → the list refetches without the `state` field.
+        await lp.openColumnSettings();
+        await stateToggle.click();
+        await page.keyboard.press('Escape');
+        await expect(stateHeader).toBeHidden();
+
+        // Re-enable State → triggers the stale-placeholder render that used to crash.
+        await lp.openColumnSettings();
+        await stateToggle.click();
+        await page.keyboard.press('Escape');
+
+        // No crash: a crashed boundary unmounts the table, so the header + rows
+        // staying visible after the refetch is the real signal. The error-text
+        // assertion is belt-and-suspenders.
+        await expect(stateHeader).toBeVisible();
+        await lp.expectRowCountGreaterThan(0);
+        await expect(lp.getRows().first()).toBeVisible();
+        await expect(page.getByText(/An error occurred:/i)).toHaveCount(0);
+    });
+
     test('should create and delete a draft order', async ({ page }) => {
         // Create a new draft
         const lp = listPage(page);

--- a/packages/dashboard/src/app/routes/_authenticated/_customers/components/customer-order-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customers/components/customer-order-table.tsx
@@ -55,7 +55,10 @@ export function CustomerOrderTable({ customerId }: Readonly<CustomerOrderTablePr
                 state: {
                     header: 'State',
                     cell: ({ cell }) => {
-                        const value = cell.getValue() as string;
+                        const value = cell.getValue() as string | undefined;
+                        if (!value) {
+                            return null;
+                        }
                         return <Badge variant={stateTypeToBadgeVariant(getTypeForState(value))}>{value}</Badge>;
                     },
                 },

--- a/packages/dashboard/src/lib/components/shared/table-cell/order-table-cell-components.tsx
+++ b/packages/dashboard/src/lib/components/shared/table-cell/order-table-cell-components.tsx
@@ -31,6 +31,9 @@ export const CustomerCell: DataTableCellComponent<CustomerCellData> = ({ row }) 
 export const OrderStateCell: DataTableCellComponent<{ state: string }> = ({ row }) => {
     const { getTranslatedOrderState } = useDynamicTranslations();
     const value = row.original.state;
+    if (!value) {
+        return null;
+    }
     return <Badge variant={stateTypeToBadgeVariant(getTypeForState(value))}>{getTranslatedOrderState(value)}</Badge>;
 };
 


### PR DESCRIPTION
## Summary
Enabling the **State** column on an order list crashed the whole page with `TypeError: Cannot read properties of undefined (reading 'toLowerCase')`. This guards the affected list cells so the column can be toggled safely.

Fixes #4830

## Root cause
`PaginatedListDataTable` trims the list query to only the visible columns (`includeOnlySelectedListFields`). Enabling **State** changes the query key and triggers a refetch, but with `placeholderData: keepPreviousData` the previous rows — which were fetched **without** `state` — render into the newly-added State column before the refetch returns. `OrderStateCell` passed that `undefined` straight into `getTypeForState(state)`, which calls `state.toLowerCase()` → crash, tripping the router error boundary.

`CustomerCell` in the same file already guards against exactly this transient-empty case (`if (!value) return null`); `OrderStateCell` just missed it.

## Change
- `order-table-cell-components.tsx` — `OrderStateCell` returns `null` when `state` is not yet present (matches the existing `CustomerCell` pattern).
- `customer-order-table.tsx` — the orders table on the customer detail page has the same `getTypeForState(value)` pattern (with an `as string` cast that hid the risk). Guarded it the same way and narrowed the cast to `string | undefined`.
- `getTypeForState` is left strict on purpose — an `undefined` state on a *detail* page is a real bug worth surfacing; the transient-empty contract belongs at the list-cell layer.

## Test plan
**Automated (e2e):** `packages/dashboard/e2e/tests/sales/orders.spec.ts` — *should not crash when toggling the State column off and on*. Hides then re-enables the State column and asserts the table keeps rendering (a crashed boundary unmounts the table). Verified it **fails on master** (table/State header gone after the crash) and **passes on this branch**.

**Manual:** before/after screenshots below (toggle State on the Orders list).

**Note:** the customer-detail orders table received the same guard for consistency, but I could not get a reliable fail-on-master e2e for it — on re-enable React Query appears to serve the cached initial (state-bearing) data rather than the state-less placeholder, so the crash doesn't reproduce there in the tested scenario. Shipped as defensive consistency; the shared mechanism is covered by the orders-list regression.

## Screenshots
| Before (master) | After (this PR) |
| --- | --- |
| _error boundary: "Cannot read properties of undefined (reading 'toLowerCase')"_ | _State column renders the order-state badge_ |

_(images attached below)_

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4839"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784297550&installation_id=128408429&pr_number=4839&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4839&signature=c0d7f397b8d0827ce53881e1715e8d5b8627124d7da3d5f479b77f7b946b3b6f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->