### PR TITLE
docs: Reframe README around edition-neutral positioning

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,27 +39,42 @@ Vendure is an open-source headless commerce platform. Model your catalog, orders
 
 - **Model your business, no forks required**: Extend or override any part of the system through stable plugin contracts and service overrides. Add custom entities, pricing logic, and workflows, and change core behaviour without patching it.
 - **One backend, every channel**: A single extensible core serves any frontend through a GraphQL API, across D2C, B2B, marketplace, and omnichannel. No stitching together separate commerce services.
-- **One TypeScript stack**: Node.js, NestJS, and GraphQL, with strong types across the stack and no proprietary query language. Agent-ready APIs that work with the AI tools your developers already use.
+- **One TypeScript stack**: Node.js, NestJS, and GraphQL, with strong types across the stack and no proprietary query language. The introspectable GraphQL schema makes it straightforward to wire up LLM tool-calling, MCP servers, and agent frameworks.
 - **Commerce building blocks from day one**: Catalog, orders, customers, promotions, channels, tax, shipping, payments, and stock are built in. The same extension model lets you build the workflows specific to your business on top.
 - **Proven in production**: Used in production by enterprise teams and proven at high transaction volume. Stable plugin contracts give you safe extension points without forking.
 
-## Where it runs
-
-Vendure runs anywhere Node.js runs: self-hosted, Docker, Kubernetes, or any cloud. You own the deployment.
-
-Want a managed runtime, or enterprise modules like SSO, B2B pricing, and approval workflows? [Vendure Cloud](https://vendure.io/product/cloud) is a fully managed PaaS with git-push deploys, a modern CLI, and agent-first DevOps workflows. [Vendure Platform](https://vendure.io/product/platform) adds the enterprise capability layer. Start with what's here, and add them when you need them.
-
 ## Getting started
 
-Visit our [Getting Started guide](https://docs.vendure.io/guides/getting-started/installation/) to spin up Vendure locally with a single command.
+Scaffold a new project with the server, admin dashboard, and GraphQL API ready to run:
+
+```bash
+npx @vendure/create my-shop
+```
+
+Requires Node.js (20.19+ or 22.12+) and a SQL database (PostgreSQL, MySQL, MariaDB, or SQLite). Full walkthrough and configuration options are in the [Getting Started guide](https://docs.vendure.io/guides/getting-started/installation/).
 
 Questions? Join [our Discord](https://www.vendure.io/community) for support and discussions.
+
+## What's in this repo
+
+Vendure is a Lerna monorepo. The packages you'll touch most:
+
+- **`@vendure/core`**: the framework itself. Entities, services, GraphQL APIs, the plugin system.
+- **`@vendure/create`**: `npx @vendure/create` scaffolds a new project.
+- **`@vendure/dashboard`**: the React and TanStack admin dashboard.
+- **`@vendure/cli`**: dev tooling for generating plugins, migrations, etc.
+- **Official plugins**: `email-plugin`, `asset-server-plugin`, `job-queue-plugin`, `harden-plugin`, `telemetry-plugin`, `graphiql-plugin`.
+- **`@vendure/testing`**: e2e test harness with a programmable mock server.
+
+## Where it runs
+
+Vendure runs anywhere Node.js runs: self-hosted, Docker, Kubernetes, or any cloud. You own the deployment, the data, and the stack.
+
+If you want git-push deploys and a managed runtime, [Vendure Cloud](https://vendure.io/product/cloud) is a fully managed PaaS with a modern CLI and agent-first DevOps workflows. [Vendure Platform](https://vendure.io/product/platform) adds an optional enterprise capability layer (SSO, approval workflows, and B2B pricing) on the same open-source core.
 
 ## Contribution
 
 Contributions are welcome: bugs, features, or docs. Our **[Contribution Guide](./CONTRIBUTING.md)** covers everything from setting up your development environment to submitting your first pull request.
-
-**Packages in this monorepo:** `@vendure/core` (the framework), `@vendure/dashboard` (the admin dashboard), `@vendure/cli`, `@vendure/create`, the official plugins, and `@vendure/testing`.
 
 Pick up a [labelled issue](https://github.com/vendurehq/vendure/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%F0%9F%91%8B%20contributions%20welcome%22) as a good first contribution.
 
@@ -69,7 +84,7 @@ Patch releases ship regularly. Check our [release notes](https://github.com/vend
 
 ## License
 
-Vendure is open source under the [GPLv3 license](./LICENSE.md). Commercial licensing for Vendure Platform is covered on our [pricing page](https://vendure.io/pricing).
+Vendure is open source under the [GPLv3 license](./LICENSE.md). GPLv3 applies to the Vendure source itself; the storefronts and services you build against the Vendure GraphQL API are separate works and aren't subject to it. Commercial licensing for Vendure Platform is covered on our [pricing page](https://vendure.io/pricing).
 
 ## Professional services
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ Patch releases ship regularly. Check our [release notes](https://github.com/vend
 
 ## License
 
-Vendure is open source under the [GPLv3 license](./LICENSE.md). GPLv3 applies to the Vendure source itself; the storefronts and services you build against the Vendure GraphQL API are separate works and aren't subject to it. Commercial licensing for Vendure Platform is covered on our [pricing page](https://vendure.io/pricing).
+Vendure is open source under the [GPLv3 license](./LICENSE.md). Building against the GraphQL API doesn't make your storefront or services subject to GPLv3, and a [plugin license exception](./license/plugin-exception.txt) lets you release your own Vendure plugins under any license you choose (see the [licensing FAQ](./license/license-faq.md)). Commercial licensing for Vendure Platform is on our [pricing page](https://vendure.io/pricing).
 
 ## Professional services
 

--- a/README.md
+++ b/README.md
@@ -57,14 +57,7 @@ Questions? Join [our Discord](https://www.vendure.io/community) for support and 
 
 ## What's in this repo
 
-Vendure is a Lerna monorepo. The packages you'll touch most:
-
-- **`@vendure/core`**: the framework itself. Entities, services, GraphQL APIs, the plugin system.
-- **`@vendure/create`**: `npx @vendure/create` scaffolds a new project.
-- **`@vendure/dashboard`**: the React and TanStack admin dashboard.
-- **`@vendure/cli`**: dev tooling for generating plugins, migrations, etc.
-- **Official plugins**: `email-plugin`, `asset-server-plugin`, `job-queue-plugin`, `harden-plugin`, `telemetry-plugin`, `graphiql-plugin`.
-- **`@vendure/testing`**: e2e test harness with a programmable mock server.
+This is the Vendure source monorepo: the `@vendure/core` framework, the React and TanStack admin dashboard, the CLI, the official plugins, and an e2e testing harness. To build with Vendure, run `npx @vendure/create` (see [Getting started](#getting-started)) rather than cloning; clone this repo only to contribute to Vendure itself.
 
 ## Where it runs
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Vendure is an open-source headless commerce platform. Model your catalog, orders
 
 Vendure runs anywhere Node.js runs: self-hosted, Docker, Kubernetes, or any cloud. You own the deployment.
 
-Want a managed runtime, or enterprise modules like SSO, B2B pricing, and approval workflows? [Vendure Cloud](https://vendure.io/products/cloud) is a fully managed PaaS with git-push deploys, a modern CLI, and agent-first DevOps workflows. [Vendure Platform](https://vendure.io/product/platform) adds the enterprise capability layer. Start with what's here, and add them when you need them.
+Want a managed runtime, or enterprise modules like SSO, B2B pricing, and approval workflows? [Vendure Cloud](https://vendure.io/product/cloud) is a fully managed PaaS with git-push deploys, a modern CLI, and agent-first DevOps workflows. [Vendure Platform](https://vendure.io/product/platform) adds the enterprise capability layer. Start with what's here, and add them when you need them.
 
 ## Getting started
 
@@ -63,7 +63,7 @@ Contributions are welcome: bugs, features, or docs. Our **[Contribution Guide](.
 
 Pick up a [labelled issue](https://github.com/vendurehq/vendure/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%F0%9F%91%8B%20contributions%20welcome%22) as a good first contribution.
 
-## Upgrades & plugins
+## Releases
 
 Patch releases ship regularly. Check our [release notes](https://github.com/vendurehq/vendure/releases) to keep up to date.
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,14 @@
 </p>
 
 <h1 align="center">
-  Vendure Core
+  Vendure
 </h1>
 <h3 align="center">
-    Headless TypeScript commerce backend on NestJS. GraphQL API, plugin-first, runs anywhere.
+    The open-source headless commerce platform.
 </h3>
+<h4 align="center">
+  Plugin-first, TypeScript end to end: a Node.js, NestJS, and GraphQL backend with a React and TanStack admin dashboard.
+</h4>
 <h4 align="center">
   <a href="https://docs.vendure.io">Documentation</a> |
   <a href="https://vendure.io">Website</a>
@@ -17,7 +20,7 @@
 
 <p align="center">
   <a href="https://github.com/vendurehq/vendure/blob/master/LICENSE.md">
-    <img src="https://img.shields.io/badge/license-GPLv3-blue.svg" alt="Vendure Core is released under the GPLv3 license." />
+    <img src="https://img.shields.io/badge/license-GPLv3-blue.svg" alt="Vendure is released under the GPLv3 license." />
   </a>
   <a href="https://twitter.com/intent/follow?screen_name=vendure_io">
     <img src="https://img.shields.io/twitter/follow/vendure_io" alt="Follow @vendure_io" />
@@ -30,38 +33,33 @@
   </a>
 </p>
 
-## What is Vendure Core
+## What is Vendure
 
-Vendure Core is the open-source TypeScript backend that powers [Vendure](https://vendure.io), the enterprise commerce platform. One coherent, extensible backend for catalog, orders, pricing, promotions, and customers in one place, so teams don't have to choose between rigid SaaS and assembling a DIY stack of services.
+Vendure is an open-source headless commerce platform. Model your catalog, orders, pricing, promotions, and customers on one backend you can change at the core. Run D2C, B2B, marketplace, and omnichannel on it, so teams don't choose between a rigid suite and a DIY composable stack.
 
-- **Plugin architecture, no forks required**: Extend or override any part of the system through stable plugin contracts. Customise the edges without patching the core.
-- **TypeScript, Node.js, NestJS, GraphQL**: A coherent stack with strong types end to end, a large ecosystem, no proprietary query language, and agent-ready APIs that work with your developers' AI tools.
-- **One backend, every channel**: A single extensible core serves any frontend or channel through a GraphQL API, so you avoid stitching together separate commerce services.
-- **Production-tested at scale**: Used in production by enterprise teams. Plugin contracts give you safe extension points without patching core.
-- **Built-in commerce building blocks**: Catalog, orders, customers, promotions, channels, tax, shipping, payments, and stock, with the primitives teams need from day one.
+- **Model your business, no forks required**: Extend or override any part of the system through stable plugin contracts and service overrides. Add custom entities, pricing logic, and workflows, and change core behaviour without patching it.
+- **One backend, every channel**: A single extensible core serves any frontend through a GraphQL API, across D2C, B2B, marketplace, and omnichannel. No stitching together separate commerce services.
+- **One TypeScript stack**: Node.js, NestJS, and GraphQL, with strong types across the stack and no proprietary query language. Agent-ready APIs that work with the AI tools your developers already use.
+- **Commerce building blocks from day one**: Catalog, orders, customers, promotions, channels, tax, shipping, payments, and stock are built in. The same extension model lets you build the workflows specific to your business on top.
+- **Proven in production**: Used in production by enterprise teams and proven at high transaction volume. Stable plugin contracts give you safe extension points without forking.
 
-## What's in this repo
+## Where it runs
 
-Vendure is a Lerna monorepo. The packages you'll touch most:
+Vendure runs anywhere Node.js runs: self-hosted, Docker, Kubernetes, or any cloud. You own the deployment.
 
-- **`@vendure/core`**: the framework itself. Entities, services, GraphQL APIs, the plugin system.
-- **`@vendure/create`**: `npx @vendure/create` scaffolds a new project.
-- **`@vendure/dashboard`**: the React-based admin dashboard.
-- **`@vendure/cli`**: dev tooling for generating plugins, migrations, etc.
-- **Official plugins**: `email-plugin`, `asset-server-plugin`, `job-queue-plugin`, `harden-plugin`, `telemetry-plugin`, `graphiql-plugin`.
-- **`@vendure/testing`**: e2e test harness with a programmable mock server.
-
-Runs on any Node.js host: self-hosted, Docker, Kubernetes, or any cloud. Managed hosting is available via [Vendure Cloud](https://vendure.io/products/cloud).
+Want a managed runtime, or enterprise modules like SSO, B2B pricing, and approval workflows? [Vendure Cloud](https://vendure.io/products/cloud) is a fully managed PaaS with git-push deploys, a modern CLI, and agent-first DevOps workflows. [Vendure Platform](https://vendure.io/product/platform) adds the enterprise capability layer. Start with what's here, and add them when you need them.
 
 ## Getting started
 
-Visit our [Getting Started guide](https://docs.vendure.io/guides/getting-started/installation/) to spin up Vendure Core locally with a single command.
+Visit our [Getting Started guide](https://docs.vendure.io/guides/getting-started/installation/) to spin up Vendure locally with a single command.
 
 Questions? Join [our Discord](https://www.vendure.io/community) for support and discussions.
 
 ## Contribution
 
 Contributions are welcome: bugs, features, or docs. Our **[Contribution Guide](./CONTRIBUTING.md)** covers everything from setting up your development environment to submitting your first pull request.
+
+**Packages in this monorepo:** `@vendure/core` (the framework), `@vendure/dashboard` (the admin dashboard), `@vendure/cli`, `@vendure/create`, the official plugins, and `@vendure/testing`.
 
 Pick up a [labelled issue](https://github.com/vendurehq/vendure/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%F0%9F%91%8B%20contributions%20welcome%22) as a good first contribution.
 
@@ -71,7 +69,7 @@ Patch releases ship regularly. Check our [release notes](https://github.com/vend
 
 ## License
 
-Vendure Core is licensed under the [GPLv3 license](./LICENSE.md). To learn more about the full Vendure platform and cloud offering, see our [pricing page](https://vendure.io/pricing).
+Vendure is open source under the [GPLv3 license](./LICENSE.md). Commercial licensing for Vendure Platform is covered on our [pricing page](https://vendure.io/pricing).
 
 ## Professional services
 


### PR DESCRIPTION
## Why

The README framed the open-source project as **"Vendure Core"** — an edition/SKU — with the H1, section headings, and body all positioning the repo as the free piece of a bigger paid product ("the open-source backend that powers Vendure, the enterprise commerce platform" / "the full Vendure platform"). That reads as a stripped-down edition and is out of step with the now edition-neutral product pages on the website.

This reframes the README so the repo presents as **Vendure**, the open-source headless commerce platform — a complete product that stands on its own — while keeping a light, OSS-first path to the commercial layer.

## What changed

- **De-editioned throughout.** Title is now `Vendure`; the product is "Vendure" everywhere in prose. "Core" survives only as the literal `@vendure/core` package name.
- **Accurate, model-agnostic OSS definition.** "Open-source headless commerce platform." B2B is one supported channel, not the headline. All B2B-specific capability (SSO, B2B pricing, approvals) is attributed to **Vendure Platform**, which is the B2B-focused layer.
- **Stack surfaced in the header**, attributed correctly: a Node.js / NestJS / GraphQL backend with a React / TanStack **admin** dashboard (so it doesn't imply a React storefront — Vendure stays headless).
- **Vendure Cloud described as what it is:** a fully managed PaaS with git-push deploys, a modern CLI, and agent-first DevOps workflows (was "managed hosting").
- **Cleaner evaluator funnel:** the contributor-facing package list moved out of the top flow and into the Contribution section.
- **Renamed** the mislabeled "Upgrades & plugins" section to "Releases" (it only ever covered release notes).
- **Removed** "enterprise commerce platform" (off-category) and "the full Vendure platform" (implied the repo is partial) framing.

## Note for reviewers

The "proven at high transaction volume" proof line is currently a claim without a named reference. Fine as-is, but worth swapping in a named logo/quote once permission is confirmed.