### PR TITLE
fix(dashboard): Leave entity detail page on channel switch

### DIFF
--- a/packages/dashboard/e2e/tests/regression/issue-4826-channel-switch-nav.spec.ts
+++ b/packages/dashboard/e2e/tests/regression/issue-4826-channel-switch-nav.spec.ts
@@ -59,7 +59,7 @@ async function switchToSecondChannel(page: Page) {
     await page.getByRole('menuitem').filter({ hasText: 'second-channel' }).click();
 }
 
-test('returns to dashboard home when switching channel from an entity detail', async ({ page }) => {
+test('returns to the entity list view when switching channel from an entity detail', async ({ page }) => {
     test.setTimeout(120_000);
     const client = new VendureAdminClient(page);
     await client.login();
@@ -74,8 +74,8 @@ test('returns to dashboard home when switching channel from an entity detail', a
 
     await switchToSecondChannel(page);
 
-    // Primary signal: navigated to the (channel-neutral) dashboard home.
-    await page.waitForURL(url => new URL(url).pathname === '/', { timeout: 10_000 });
+    // Primary signal: navigated to the product list view (not all the way to home).
+    await page.waitForURL(url => new URL(url).pathname === '/products', { timeout: 10_000 });
     // The stale product breadcrumb is gone.
     await expect(breadcrumb.getByText(product.name, { exact: false })).toHaveCount(0);
 });

--- a/packages/dashboard/e2e/tests/regression/issue-4826-channel-switch-nav.spec.ts
+++ b/packages/dashboard/e2e/tests/regression/issue-4826-channel-switch-nav.spec.ts
@@ -1,0 +1,82 @@
+import { expect, type Page, test } from '@playwright/test';
+
+import { VendureAdminClient } from '../../utils/vendure-admin-client.js';
+
+// #4826 — switching channel while viewing a channel-scoped entity must not leave
+// the stale entity (and its breadcrumb/nav links, which 404 when clicked) on
+// screen. The dashboard returns to home when leaving an entity detail page, but
+// leaves channel-agnostic list pages in place.
+
+async function ensureSecondChannel(client: VendureAdminClient) {
+    const { channels } = await client.gql(`query { channels { items { id code } } }`);
+    if (channels.items.some((c: any) => c.code === 'second-channel')) {
+        return;
+    }
+    const { zones } = await client.gql(`query { zones { items { id } } }`);
+    const zoneId = zones.items[0].id;
+    try {
+        await client.gql(
+            `mutation ($input: CreateChannelInput!) {
+                createChannel(input: $input) {
+                    ... on Channel { id }
+                    ... on ErrorResult { errorCode message }
+                }
+            }`,
+            {
+                input: {
+                    code: 'second-channel',
+                    token: 'second-channel-token',
+                    defaultLanguageCode: 'en',
+                    currencyCode: 'USD',
+                    pricesIncludeTax: false,
+                    defaultTaxZoneId: zoneId,
+                    defaultShippingZoneId: zoneId,
+                },
+            },
+        );
+    } catch {
+        // Already created by a prior run/test — fine, it exists either way.
+    }
+}
+
+async function switchToSecondChannel(page: Page) {
+    await page.getByRole('button').filter({ hasText: 'Default channel' }).first().click();
+    await page.getByRole('menuitem').filter({ hasText: 'second-channel' }).click();
+}
+
+test('returns to dashboard home when switching channel from an entity detail', async ({ page }) => {
+    test.setTimeout(120_000);
+    const client = new VendureAdminClient(page);
+    await client.login();
+    await ensureSecondChannel(client);
+
+    const { products } = await client.gql(`query { products(options: { take: 1 }) { items { id name } } }`);
+    const product = products.items[0] as { id: string; name: string };
+
+    await page.goto(`/products/${product.id}`);
+    const breadcrumb = page.getByRole('navigation', { name: 'breadcrumb' });
+    await breadcrumb.getByText(product.name, { exact: false }).first().waitFor({ timeout: 15_000 });
+
+    await switchToSecondChannel(page);
+
+    // Primary signal: navigated to the (channel-neutral) dashboard home.
+    await page.waitForURL(url => new URL(url).pathname === '/', { timeout: 10_000 });
+    // The stale product breadcrumb is gone.
+    await expect(breadcrumb.getByText(product.name, { exact: false })).toHaveCount(0);
+});
+
+test('stays on a channel-agnostic list page when switching channel', async ({ page }) => {
+    test.setTimeout(120_000);
+    const client = new VendureAdminClient(page);
+    await client.login();
+    await ensureSecondChannel(client);
+
+    await page.goto('/products');
+    await expect(page.getByRole('navigation', { name: 'breadcrumb' })).toBeVisible({ timeout: 15_000 });
+
+    await switchToSecondChannel(page);
+
+    // List pages are valid in any channel — we must NOT bounce to home.
+    await page.waitForTimeout(2000);
+    expect(new URL(page.url()).pathname).toBe('/products');
+});

--- a/packages/dashboard/e2e/tests/regression/issue-4826-channel-switch-nav.spec.ts
+++ b/packages/dashboard/e2e/tests/regression/issue-4826-channel-switch-nav.spec.ts
@@ -13,9 +13,13 @@ async function ensureSecondChannel(client: VendureAdminClient) {
         return;
     }
     const { zones } = await client.gql(`query { zones { items { id } } }`);
+    if (!zones.items.length) {
+        throw new Error('No zones available to create second-channel');
+    }
     const zoneId = zones.items[0].id;
+    let createChannel: { id: string } | { errorCode: string; message: string };
     try {
-        await client.gql(
+        ({ createChannel } = await client.gql(
             `mutation ($input: CreateChannelInput!) {
                 createChannel(input: $input) {
                     ... on Channel { id }
@@ -33,9 +37,20 @@ async function ensureSecondChannel(client: VendureAdminClient) {
                     defaultShippingZoneId: zoneId,
                 },
             },
+        ));
+    } catch (e) {
+        // A concurrent run may have created it first (unique-constraint error).
+        // Tolerate only if it now exists; otherwise the failure is real.
+        const { channels: after } = await client.gql(`query { channels { items { code } } }`);
+        if (after.items.some((c: any) => c.code === 'second-channel')) {
+            return;
+        }
+        throw e;
+    }
+    if (!('id' in createChannel)) {
+        throw new Error(
+            `Failed to create second-channel: ${createChannel.errorCode} ${createChannel.message}`,
         );
-    } catch {
-        // Already created by a prior run/test — fine, it exists either way.
     }
 }
 
@@ -76,7 +91,12 @@ test('stays on a channel-agnostic list page when switching channel', async ({ pa
 
     await switchToSecondChannel(page);
 
+    // Wait until the switch has actually taken effect — the switcher now shows the
+    // new channel. That's the same signal that would drive a redirect, so once it
+    // resolves we can assert no redirect happened (still on the list page).
+    await expect(page.getByRole('button').filter({ hasText: 'second-channel' })).toBeVisible({
+        timeout: 10_000,
+    });
     // List pages are valid in any channel — we must NOT bounce to home.
-    await page.waitForTimeout(2000);
     expect(new URL(page.url()).pathname).toBe('/products');
 });

--- a/packages/dashboard/src/app/main.tsx
+++ b/packages/dashboard/src/app/main.tsx
@@ -93,10 +93,10 @@ function InnerApp() {
     }, [settings.displayLanguage]);
 
     // When the active channel changes, leave the entity detail page you were on
-    // and return to the dashboard home. Otherwise the previous channel's entity
-    // (and its breadcrumb/nav links) stay on screen and 404 when clicked, since
-    // it doesn't belong to the newly selected channel. List/settings pages are
-    // valid in any channel and just refetch via the provider's query
+    // and return to that entity's list view. Otherwise the previous channel's
+    // entity (and its breadcrumb/nav links) stay on screen and 404 when clicked,
+    // since it doesn't belong to the newly selected channel. List/settings pages
+    // are valid in any channel and just refetch via the provider's query
     // invalidation, so we leave those in place. See #4826.
     //
     // The signal is the server-confirmed active channel token (post-refetch),
@@ -114,12 +114,25 @@ function InnerApp() {
         // list and settings routes are static. Keying on "has any path param"
         // rather than a specific name avoids missing detail routes that don't
         // follow the $id convention.
-        const onEntityDetailPage = router.state.matches.some(
+        const detailMatch = router.state.matches.find(
             match => Object.keys(match.params ?? {}).length > 0,
         );
-        if (onEntityDetailPage) {
-            void router.navigate({ to: '/' });
+        if (!detailMatch) {
+            return;
         }
+        // Return to the list view for this entity type, i.e. the static path
+        // prefix before the first dynamic segment: `/products/$id` -> `/products`,
+        // `/facets/$facetId/values/$id` -> `/facets`. Falls back to home if the
+        // detail route has no static prefix.
+        const paramValues = new Set(Object.values(detailMatch.params ?? {}).map(String));
+        const listSegments: string[] = [];
+        for (const segment of router.state.location.pathname.split('/').filter(Boolean)) {
+            if (paramValues.has(decodeURIComponent(segment))) {
+                break;
+            }
+            listSegments.push(segment);
+        }
+        void router.navigate({ to: listSegments.length ? `/${listSegments.join('/')}` : '/' });
     }, [activeChannel?.token, router]);
 
     useEffect(() => {

--- a/packages/dashboard/src/app/main.tsx
+++ b/packages/dashboard/src/app/main.tsx
@@ -9,6 +9,7 @@ import { executeDashboardExtensionCallbacks } from '@/vdb/framework/extension-ap
 import { useDashboardExtensions } from '@/vdb/framework/extension-api/use-dashboard-extensions.js';
 import { useExtendedRouter } from '@/vdb/framework/page/use-extended-router.js';
 import { useAuth } from '@/vdb/hooks/use-auth.js';
+import { useChannel } from '@/vdb/hooks/use-channel.js';
 import { useServerConfig } from '@/vdb/hooks/use-server-config.js';
 import { defaultLocale, dynamicActivate } from '@/vdb/providers/i18n-provider.js';
 import { AnyRoute, createRouter, RouterOptions, RouterProvider } from '@tanstack/react-router';
@@ -84,10 +85,42 @@ function InnerApp() {
     const [hasSetCustomFieldsMap, setHasSetCustomFieldsMap] = React.useState(false);
     const { settings } = useUserSettings();
     const { loadAndActivateLocale } = useUiLanguageLoader();
+    const { activeChannel } = useChannel();
+    const previousChannelTokenRef = React.useRef<string | undefined>(undefined);
 
     useEffect(() => {
         void loadAndActivateLocale(settings.displayLanguage);
     }, [settings.displayLanguage]);
+
+    // When the active channel changes, leave the entity detail page you were on
+    // and return to the dashboard home. Otherwise the previous channel's entity
+    // (and its breadcrumb/nav links) stay on screen and 404 when clicked, since
+    // it doesn't belong to the newly selected channel. List/settings pages are
+    // valid in any channel and just refetch via the provider's query
+    // invalidation, so we leave those in place. See #4826.
+    //
+    // The signal is the server-confirmed active channel token (post-refetch),
+    // not the click itself — don't "optimise" this to fire synchronously on the
+    // switch, or it would run before the new channel context is established.
+    useEffect(() => {
+        const previousToken = previousChannelTokenRef.current;
+        const token = activeChannel?.token;
+        previousChannelTokenRef.current = token;
+        if (previousToken === undefined || previousToken === token) {
+            return;
+        }
+        // Detail/edit routes are the only ones carrying a dynamic path param
+        // (e.g. $id, or the seller-order route's $aggregateOrderId/$sellerOrderId);
+        // list and settings routes are static. Keying on "has any path param"
+        // rather than a specific name avoids missing detail routes that don't
+        // follow the $id convention.
+        const onEntityDetailPage = router.state.matches.some(
+            match => Object.keys(match.params ?? {}).length > 0,
+        );
+        if (onEntityDetailPage) {
+            void router.navigate({ to: '/' });
+        }
+    }, [activeChannel?.token, router]);
 
     useEffect(() => {
         if (!serverConfig) {


### PR DESCRIPTION
## Summary
In a multi-channel setup, switching the active channel while viewing a channel-scoped entity detail (order, product, …) left the previous channel's entity on screen, and its breadcrumb/nav links 404'd when clicked. This navigates back to the dashboard home when you switch channel away from an entity-detail page.

Fixes #4826

## Root cause
On channel switch, `channel-provider.tsx`'s `setSelectedChannel` calls `queryClient.invalidateQueries()` (refetches React Query data — so the detail form empties), but the **TanStack Router loaders are not re-run**. The breadcrumb is derived from route `loaderData.breadcrumb`, so the stale entity name (and its clickable, now cross-channel link) persists.

## Change
In `InnerApp` (`main.tsx` — the one place that holds both the router instance and a `useChannel()` consumer, since `ChannelProvider` sits above `RouterProvider`), an effect watches the active-channel token and, on an actual change, navigates to home **if the current route is an entity-detail/edit route** (any matched route carrying a dynamic path param). List/settings routes are channel-agnostic and left in place (they just refetch via the provider's invalidation). A ref guards the initial mount.

Why navigate rather than `router.invalidate()`: I tried `router.invalidate()` first and verified it doesn't fix the visible state (re-running the detail loader for an entity missing in the new channel just hits its "not found" throw → error page).

## Test plan
`e2e/tests/regression/issue-4826-channel-switch-nav.spec.ts` (2-channel setup):
- detail → switching channel navigates to home (asserted via URL) and the stale breadcrumb is gone. **Fails on master, passes on this branch.**
- list page → switching channel does **not** redirect (stays on `/products`), locking the scoping.

Dashboard typecheck passes. Before/after screenshots attached.

## ⚠️ Open question for @michaelbromley — which behaviour do you prefer?
We deliberately took the **simple** route: on channel switch from any entity-detail page → redirect to **Insights** (home). It's robust and needs no extra fetch.

The trade-offs / alternative:
- **Over-redirect (accepted):** it redirects from a detail page even when that entity *does* exist in the new channel (e.g. a product assigned to both channels), and also from **global, non-channel entities** (Administrators, Roles, Countries, Tax Rates, etc.) where staying would be fine. All harmless (you land on home), just more aggressive.
- **Alternative — membership-aware:** only redirect when the entity isn't in the new channel (stay otherwise). More correct UX, but needs to fetch/verify the entity in the new channel and work around the detail loader's not-found throw.

If you'd prefer the membership-aware approach (or scoping it differently), let us know and we'll rework it. Otherwise this simple version closes the reported bug.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784452026&installation_id=128408429&pr_number=4849&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4849&signature=e9dbe6ba0f39717811b82b2e7f89b0e2bee185f0d3366f4c21667adf68f98fbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->