### PR TITLE
fix(dashboard): Stabilise useUiLanguageLoader callback to prevent render loop

### DIFF
--- a/packages/dashboard/src/lib/hooks/use-ui-language-loader.ts
+++ b/packages/dashboard/src/lib/hooks/use-ui-language-loader.ts
@@ -1,5 +1,6 @@
 import { loadI18nMessages } from '@/vdb/lib/load-i18n-messages.js';
 import { useLingui } from '@lingui/react/macro';
+import { useCallback } from 'react';
 
 let currentlyLoading: string | null = null;
 
@@ -15,16 +16,22 @@ let currentlyLoading: string | null = null;
 export function useUiLanguageLoader() {
     const { i18n } = useLingui();
 
-    async function loadAndActivateLocale(locale: string) {
-        if (currentlyLoading === locale) {
-            return;
-        }
-        currentlyLoading = locale;
-        const messages = await loadI18nMessages(locale);
-        i18n.load(locale, messages);
-        i18n.activate(locale);
-        currentlyLoading = null;
-    }
+    const loadAndActivateLocale = useCallback(
+        async (locale: string) => {
+            if (currentlyLoading === locale || i18n.locale === locale) {
+                return;
+            }
+            currentlyLoading = locale;
+            try {
+                const messages = await loadI18nMessages(locale);
+                i18n.load(locale, messages);
+                i18n.activate(locale);
+            } finally {
+                currentlyLoading = null;
+            }
+        },
+        [i18n],
+    );
 
     return { loadAndActivateLocale };
 }


### PR DESCRIPTION
# Description

`useUiLanguageLoader` returned a new `loadAndActivateLocale` function on every render. Because that function calls `i18n.activate()` — which `@lingui`'s `I18nProvider` turns into a re-render of every `useLingui` consumer — using it from a `useEffect` (as `react-hooks/exhaustive-deps` requires) makes the effect re-run on every render and compounds into an infinite render loop. The loop continuously resets Base UI popover / data-table selection state, which can make row checkboxes and the per-row "⋮" action menus unusable across the dashboard.

This memoises the callback with `useCallback` (keyed on `i18n`) so its identity is stable across renders, and skips re-activation when the requested locale is already active. The existing click-handler caller (`language-dialog`) is unaffected.

Fixes #4847.

> Note: this supersedes #4848, which GitHub auto-closed after an accidental force-push to the head branch. The diff is identical (single file, +17/-10).

### Verification

I confirmed the mechanism and the fix with a minimal reproduction on the real Lingui runtime (a faithful copy of the hook + `@lingui/core`/`@lingui/react` + React 19, run under `@testing-library/react`):

- the original hook returns a new `loadAndActivateLocale` reference on every render; an effect depending on it re-runs on every unrelated re-render; activating a locale from such an effect loops indefinitely (`i18n.activate()` emits a `change` event unconditionally, so `I18nProvider` re-renders even for the already-active locale);
- the memoised version returns a stable reference, the effect does not re-run on unrelated re-renders, and activating a locale from an effect settles after a single activation.

# Breaking changes

None.

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784461110&installation_id=128408429&pr_number=4851&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4851&signature=4702f25b47b49619acc244bab8d53a2a06bfaf2c50477fd2aff8891cb8eb4370"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->