### PR TITLE
fix(dashboard): use rich text editor for shipping method description

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
@@ -3,7 +3,7 @@ import { FormFieldWrapper } from '@/vdb/components/shared/form-field-wrapper.js'
 import { TranslatableFormFieldWrapper } from '@/vdb/components/shared/translatable-form-field.js';
 import { Button } from '@/vdb/components/ui/button.js';
 import { Input } from '@/vdb/components/ui/input.js';
-import { Textarea } from '@/vdb/components/ui/textarea.js';
+import { RichTextInput } from '@/vdb/components/data-input/rich-text-input.js';
 import { NEW_ENTITY_PATH } from '@/vdb/constants.js';
 import {    CustomFieldsPageBlock,
     DetailFormGrid,
@@ -160,7 +160,7 @@ function ShippingMethodDetailPage() {
                             control={form.control}
                             name="description"
                             label={<Trans>Description</Trans>}
-                            render={({ field }) => <Textarea {...field} />}
+                            render={({ field }) => <RichTextInput {...field} />}
                         />
                     </div>
                     <DetailFormGrid>


### PR DESCRIPTION
# Description

The shipping method description field was using a plain textarea while 
the payment method description uses a rich text editor. Both are 
customer-facing fields that show up at checkout so they should work 
the same way.

Swapped the plain Textarea for the RichTextInput component that payment 
methods already use. No new dependencies added, same component, one 
file changed.

Fixes #4852 

# Breaking changes

No breaking changes.

# Screenshots
<img width="1161" height="794" alt="aftershippingmehtod" src="https://github.com/user-attachments/assets/53c51e1a-85b7-4f66-a10b-956c9b2bbf22" />

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4853"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784464447&installation_id=128408429&pr_number=4853&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4853&signature=4a2a09a5a2de1df35241b475509a4588fef0731a00568ae4597e9a8ba9bd0685"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->