### PR TITLE
fix(core): Exclude draft orders from promotion usage limit counts

### DIFF
--- a/packages/core/e2e/draft-order.e2e-spec.ts
+++ b/packages/core/e2e/draft-order.e2e-spec.ts
@@ -3,6 +3,7 @@ import { LanguageCode } from '@vendure/common/lib/generated-types';
 import {
     DefaultOrderPlacedStrategy,
     mergeConfig,
+    minimumOrderAmount,
     Order,
     orderPercentageDiscount,
     OrderState,
@@ -27,6 +28,7 @@ import {
     addManualPaymentDocument,
     adminTransitionToStateDocument,
     createPromotionDocument,
+    deletePromotionDocument,
     getCustomerListDocument,
 } from './graphql/shared-definitions';
 import { getActiveCustomerOrdersDocument } from './graphql/shop-definitions';
@@ -417,6 +419,94 @@ describe('Draft Orders resolver', () => {
         expect(TestOrderPlacedStrategy.spy.mock.calls.length).toBe(1);
         expect(TestOrderPlacedStrategy.spy.mock.calls[0][0].code).toBe(draftOrder.code);
     });
+
+    // https://github.com/vendurehq/vendure/issues/4753
+    // An auto-applied promotion with a perCustomerUsageLimit must not toggle on/off
+    // as a draft order is recalculated. Draft orders are not "placed" and must not
+    // count towards a promotion's usage limit.
+    describe('perCustomerUsageLimit on draft orders', () => {
+        const promotionName = 'Auto free order (per-customer limit)';
+        let promotionId: string;
+        let perCustomerDraftOrderId: string;
+        let orderLineId: string;
+
+        beforeAll(async () => {
+            const { createPromotion } = await adminClient.query(createPromotionDocument, {
+                input: {
+                    enabled: true,
+                    conditions: [
+                        {
+                            code: minimumOrderAmount.code,
+                            arguments: [
+                                { name: 'amount', value: '100' },
+                                { name: 'taxInclusive', value: 'true' },
+                            ],
+                        },
+                    ],
+                    perCustomerUsageLimit: 1,
+                    actions: [
+                        {
+                            code: orderPercentageDiscount.code,
+                            arguments: [{ name: 'discount', value: '100' }],
+                        },
+                    ],
+                    translations: [{ languageCode: LanguageCode.en, name: promotionName }],
+                },
+            });
+            if (!createPromotion || !('id' in createPromotion)) {
+                throw new Error(`Failed to create promotion: ${JSON.stringify(createPromotion)}`);
+            }
+            promotionId = createPromotion.id;
+        });
+
+        afterAll(async () => {
+            await adminClient.query(deletePromotionDocument, { id: promotionId });
+        });
+
+        async function appliedDiscountDescriptions(): Promise<string[]> {
+            const { order } = await adminClient.query(getDraftOrderDiscountsDocument, {
+                id: perCustomerDraftOrderId,
+            });
+            return (order?.discounts ?? []).map(d => d.description);
+        }
+
+        it('promotion stays applied across repeated draft order updates', async () => {
+            const { createDraftOrder } = await adminClient.query(createDraftOrderDocument);
+            perCustomerDraftOrderId = createDraftOrder.id;
+
+            // perCustomerUsageLimit is only enforced once the customer is known
+            const { setCustomerForDraftOrder } = await adminClient.query(setCustomerForDraftOrderDocument, {
+                orderId: perCustomerDraftOrderId,
+                customerId: customers[0].id,
+            });
+            orderGuard.assertSuccess(setCustomerForDraftOrder);
+
+            // First eligible item -> promotion applied
+            const { addItemToDraftOrder: add1 } = await adminClient.query(addItemToDraftOrderDocument, {
+                orderId: perCustomerDraftOrderId,
+                input: { productVariantId: 'T_5', quantity: 1 },
+            });
+            orderGuard.assertSuccess(add1);
+            orderLineId = add1.lines[0].id;
+            expect(await appliedDiscountDescriptions()).toEqual([promotionName]);
+
+            // Second update (recalculation) must NOT toggle the promotion off
+            const { addItemToDraftOrder: add2 } = await adminClient.query(addItemToDraftOrderDocument, {
+                orderId: perCustomerDraftOrderId,
+                input: { productVariantId: 'T_5', quantity: 1 },
+            });
+            orderGuard.assertSuccess(add2);
+            expect(await appliedDiscountDescriptions()).toEqual([promotionName]);
+
+            // Third update (recalculation) must still keep the promotion applied
+            const { adjustDraftOrderLine } = await adminClient.query(adjustDraftOrderLineDocument, {
+                orderId: perCustomerDraftOrderId,
+                input: { orderLineId, quantity: 4 },
+            });
+            orderGuard.assertSuccess(adjustDraftOrderLine);
+            expect(await appliedDiscountDescriptions()).toEqual([promotionName]);
+        });
+    });
 });
 
 // Local fragment without countryCode to match original test expectations
@@ -513,6 +603,19 @@ const draftOrderWithLinesFragment = graphql(
     `,
     [draftOrderShippingAddressFragment, paymentFragment],
 );
+
+const getDraftOrderDiscountsDocument = graphql(`
+    query GetDraftOrderDiscounts($id: ID!) {
+        order(id: $id) {
+            id
+            totalWithTax
+            discounts {
+                description
+                amountWithTax
+            }
+        }
+    }
+`);
 
 const createDraftOrderDocument = graphql(
     `

--- a/packages/core/src/service/services/promotion.service.ts
+++ b/packages/core/src/service/services/promotion.service.ts
@@ -398,16 +398,23 @@ export class PromotionService {
 
     /**
      * Returns a base query builder for counting promotion usages on placed orders.
-     * Excludes cancelled orders, active (un-placed) orders, and seller-type orders.
+     * Excludes cancelled orders, draft orders, active (un-placed) orders, and
+     * seller-type orders.
      */
     private placedOrdersWithPromotionQb(ctx: RequestContext) {
-        return this.connection
-            .getRepository(ctx, Order)
-            .createQueryBuilder('order')
-            .innerJoin('order.promotions', 'promotion')
-            .andWhere('order.state != :state', { state: 'Cancelled' as OrderState })
-            .andWhere('order.active = :active', { active: false })
-            .andWhere('order.type != :type', { type: OrderType.Seller });
+        return (
+            this.connection
+                .getRepository(ctx, Order)
+                .createQueryBuilder('order')
+                .innerJoin('order.promotions', 'promotion')
+                .andWhere('order.state != :state', { state: 'Cancelled' as OrderState })
+                // Draft orders also have active=false, so they must be excluded explicitly,
+                // otherwise a draft would count its own promotions as a consumed usage and
+                // toggle them on/off on each recalculation (#4753).
+                .andWhere('order.state != :draftState', { draftState: 'Draft' as OrderState })
+                .andWhere('order.active = :active', { active: false })
+                .andWhere('order.type != :type', { type: OrderType.Seller })
+        );
     }
 
     private async getUsageCountsBatch(


### PR DESCRIPTION
## Summary

An auto-applied promotion with `perCustomerUsageLimit = 1` toggles on/off after **every** Draft Order update once a customer is assigned. The promotion is applied, then removed on the next recalculation, then re-applied, and so on.

Fixes #4753

## Root cause

`PromotionService.placedOrdersWithPromotionQb` builds the query used to count how many times a promotion has been used (for both `usageLimit` and `perCustomerUsageLimit`). It treated an order as a "placed" usage when:

```
state != 'Cancelled'  AND  active = false  AND  type != Seller
```

Draft orders have `active = false` **and** `state = 'Draft'`, so they pass this filter. The toggle then works like this:

1. Recalc #1 — the draft has no promotion association yet → usage count `0` → promotion is eligible, applied, and the association is saved.
2. Recalc #2 — the draft now has the promotion associated and counts as a consumed usage (`active=false`, `state=Draft`, same customer) → count `1` → `perCustomerUsageLimit (1) <= 1` → exhausted → promotion removed.
3. Recalc #3 — count `0` again → applied. → **toggle**.

This affects all three usage-count paths (auto-applied via `getUsageCountsBatch`, and the coupon paths `countPromotionUsages` / `countPromotionUsagesForCustomer`), since they all build on this shared query.

## The change

Exclude `Draft`-state orders from the shared usage-count query builder — a draft is not a "placed" order and must not count toward a promotion's usage limit. Once a draft is completed it transitions out of `Draft` (`Draft → ArrangingPayment`), so it correctly resumes counting once placed. This mirrors the existing `order.state != 'Draft'` exclusion already used elsewhere (`order.service.ts`).

```ts
.andWhere('order.state != :state', { state: 'Cancelled' as OrderState })
.andWhere('order.state != :draftState', { draftState: 'Draft' as OrderState }) // new
.andWhere('order.active = :active', { active: false })
.andWhere('order.type != :type', { type: OrderType.Seller });
```

## Test plan

**Automated (e2e regression):** added `perCustomerUsageLimit on draft orders` in `packages/core/e2e/draft-order.e2e-spec.ts`. It creates an auto-applied promotion with `perCustomerUsageLimit=1`, creates a draft order, assigns a customer, adds an eligible item (promo applied), then performs two further updates and asserts the discount stays applied.
- Fails on `master` (discount becomes `[]` after the 2nd update).
- Passes on this branch.
- Full `draft-order` (17) + `order-promotion` (62) suites pass.

The reverse contract — a *placed* order for the same customer still exhausts the limit — is already covered by `order-promotion.e2e-spec.ts` (`perCustomerUsageLimit` → "does not auto-apply promotion after per-customer limit is reached").

**Manual (Dashboard smoke):** verified on the running Dashboard against a backend with the fix. Auto promo `perCustomerUsageLimit=1`, draft order + customer + eligible item:

| Step | Action | Result |
|------|--------|--------|
| 1 | Add item (qty 1) | Discount applied, total €0.00 |
| 2 | Increase qty → 2 (recalc) | Discount **still applied**, total €0.00 (toggles off on master) |
| 3 | Increase qty → 3 (recalc) | Discount **still applied**, total €0.00 |

Screenshots attached in the Linear issue (OSS-544).

## Out of scope (follow-up)

The auto-applied usage-count path (`getUsageCountsBatch`) does not pass an `excludeOrderId`, unlike the coupon paths. This is safe for drafts after this fix, but the `ArrangingPayment` recalculation path shares the original asymmetry — worth a separate look.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784712136&installation_id=128408429&pr_number=4854&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4854&signature=0fadce3c1e29821c72074666ef9b57e43bc950c2f126c6b352526e119f44529c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->