### PR TITLE
fix(dashboard): Serve Assets SPA route when hard-loading /dashboard/assets

### DIFF
--- a/packages/dashboard/plugin/dashboard.plugin.ts
+++ b/packages/dashboard/plugin/dashboard.plugin.ts
@@ -19,6 +19,7 @@ import { adminApiExtensions } from './api/api-extensions.js';
 import { MetricsResolver } from './api/metrics.resolver.js';
 import { loggerCtx, manageDashboardGlobalViews } from './constants.js';
 import { MetricsService } from './service/metrics.service.js';
+import { createDashboardStaticServer, isStaticAssetRequest } from './static-server.js';
 
 /**
  * @description
@@ -184,40 +185,7 @@ export class DashboardPlugin implements NestModule {
     }
 
     private createStaticServer(dashboardPath: string) {
-        const limiter = rateLimit({
-            windowMs: 60 * 1000,
-            limit: this.rateLimitRequests,
-            standardHeaders: true,
-            legacyHeaders: false,
-            // Content-hashed bundles under /assets/ are immutable and a single
-            // page load fires ~190 chunk requests; counting them against the
-            // bucket exhausts it within a few tabs (see #4665).
-            skip: req => req.path.startsWith('/assets/'),
-        });
-
-        const dashboardServer = express.Router();
-        dashboardServer.use(limiter);
-        // Serve hashed assets with a long-lived immutable Cache-Control header
-        // so CDNs and browsers can cache them indefinitely. This is safe because
-        // Vite emits content-hashed filenames into /assets — a missing chunk
-        // means a stale reference, so the explicit 404 handler below stops the
-        // request from falling through to the SPA index.html shell, which would
-        // otherwise be served with the asset's expected MIME and crash the app
-        // on "Unexpected token '<'".
-        dashboardServer.use(
-            '/assets',
-            express.static(path.join(dashboardPath, 'assets'), {
-                maxAge: '1y',
-                immutable: true,
-            }),
-        );
-        dashboardServer.use('/assets', (_req, res) => res.status(404).end());
-        dashboardServer.use(express.static(dashboardPath));
-        dashboardServer.use((req, res) => {
-            res.sendFile('index.html', { root: dashboardPath });
-        });
-
-        return dashboardServer;
+        return createDashboardStaticServer(dashboardPath, this.rateLimitRequests);
     }
 
     private async checkViteDevServer(port: number): Promise<boolean> {
@@ -290,9 +258,7 @@ export class DashboardPlugin implements NestModule {
             limit: this.rateLimitRequests,
             standardHeaders: true,
             legacyHeaders: false,
-            // See note in createStaticServer — /assets/* is immutable and a
-            // single page load fires ~190 chunk requests.
-            skip: req => req.path.startsWith('/assets/'),
+            skip: req => isStaticAssetRequest(req.path),
         });
 
         // Pre-create handlers to avoid recreating them on each request

--- a/packages/dashboard/plugin/static-server.ts
+++ b/packages/dashboard/plugin/static-server.ts
@@ -1,0 +1,80 @@
+import express from 'express';
+import { rateLimit } from 'express-rate-limit';
+import * as path from 'node:path';
+
+/**
+ * @description
+ * Content-hashed bundles under `/assets/` are immutable and a single page load fires
+ * ~190 chunk requests; counting them against the rate-limit bucket exhausts it within a
+ * few tabs (see #4665). This predicate exempts them and is shared by both the static
+ * server and the dynamic (Vite dev) proxy handler so the exemption can't drift.
+ */
+export const isStaticAssetRequest = (reqPath: string): boolean => reqPath.startsWith('/assets/');
+
+/**
+ * @description
+ * Builds the Express router that serves the compiled Dashboard SPA as static files.
+ *
+ * Two concerns have to coexist under the `/assets` URL namespace:
+ *
+ * 1. **Vite build artifacts** — content-hashed bundles (`index-<hash>.js`, CSS, fonts,
+ *    source maps) which Vite emits into the `assets` dir. A request for a hashed chunk
+ *    that no longer exists (a client holding a stale `index.html` across a deploy) must
+ *    return a clean `404` rather than falling through to the `index.html` history
+ *    fallback — otherwise the module loader receives HTML for a `.js` request and the
+ *    app hard-crashes on `Uncaught SyntaxError: Unexpected token '<'`.
+ * 2. **The Assets SPA route** — the dashboard has a top-level navigation route literally
+ *    named `assets` (`/assets`, `/assets/<id>`). Hard-loading it must serve `index.html`
+ *    like every other deep route.
+ *
+ * Build artifacts always carry a file extension; SPA routes never do. We therefore only
+ * emit the stale-chunk `404` for requests that look like a file, and let extensionless
+ * `/assets*` requests fall through to the history fallback. See #4841.
+ */
+export function createDashboardStaticServer(dashboardPath: string, rateLimitRequests: number) {
+    const limiter = rateLimit({
+        windowMs: 60 * 1000,
+        limit: rateLimitRequests,
+        standardHeaders: true,
+        legacyHeaders: false,
+        skip: req => isStaticAssetRequest(req.path),
+    });
+
+    const dashboardServer = express.Router();
+    dashboardServer.use(limiter);
+    // Serve hashed assets with a long-lived immutable Cache-Control header so CDNs and
+    // browsers can cache them indefinitely. `redirect: false` stops `express.static` from
+    // 301-ing the bare `/assets` path to `/assets/` (which is the SPA route, not the dir).
+    dashboardServer.use(
+        '/assets',
+        express.static(path.join(dashboardPath, 'assets'), {
+            maxAge: '1y',
+            immutable: true,
+            redirect: false,
+        }),
+    );
+    // Stale-chunk guard: only requests for an actual build artifact (which always has a
+    // file extension) 404 here. Extensionless `/assets` and `/assets/<id>` are the Assets
+    // SPA route and must fall through to the index.html history fallback below. (#4841)
+    //
+    // Assumption: no `/assets` SPA route segment contains a dot — true today (asset ids
+    // are numeric/UUID; list filters live in the query string). The structurally robust
+    // fix would be to rename Vite's `build.assetsDir` so the artifact dir and the SPA
+    // route no longer share the `/assets` prefix; that is left out of scope here to avoid
+    // invalidating asset URLs already baked into deployed `index.html` files.
+    dashboardServer.use('/assets', (req, res, next) => {
+        if (path.extname(req.path)) {
+            res.status(404).end();
+            return;
+        }
+        next();
+    });
+    // `redirect: false` here too, so the physically-present `assets/` directory does not
+    // 301 `/assets` → `/assets/` before the SPA fallback can serve index.html.
+    dashboardServer.use(express.static(dashboardPath, { redirect: false }));
+    dashboardServer.use((req, res) => {
+        res.sendFile('index.html', { root: dashboardPath });
+    });
+
+    return dashboardServer;
+}

--- a/packages/dashboard/vite/tests/dashboard-static-server.spec.ts
+++ b/packages/dashboard/vite/tests/dashboard-static-server.spec.ts
@@ -1,0 +1,147 @@
+import express from 'express';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { createDashboardStaticServer } from '../../plugin/static-server.js';
+
+/**
+ * Regression coverage for #4841 — hard-loading `/dashboard/assets` returned a 404
+ * because the `/assets` stale-chunk guard is a prefix match that also caught the
+ * Assets SPA route. These tests mount the real static server under `/dashboard`
+ * (mirroring how DashboardPlugin serves it in production) and assert that SPA
+ * routes hard-load the index.html shell while genuine build artifacts still serve
+ * (and missing ones still 404, so the module loader never receives HTML-as-JS).
+ */
+describe('Dashboard static server', () => {
+    let server: http.Server;
+    let baseUrl: string;
+    let buildDir: string;
+    const realChunk = 'index-abc123.js';
+    const realStyles = 'styles-abc123.css';
+
+    beforeAll(async () => {
+        buildDir = fs.mkdtempSync(path.join(os.tmpdir(), 'vdb-static-'));
+        fs.mkdirSync(path.join(buildDir, 'assets'), { recursive: true });
+        fs.writeFileSync(
+            path.join(buildDir, 'index.html'),
+            '<!doctype html><html><head></head><body><div id="app">DASHBOARD_SHELL</div></body></html>',
+        );
+        fs.writeFileSync(path.join(buildDir, 'assets', realChunk), 'console.log("real chunk");');
+        fs.writeFileSync(path.join(buildDir, 'assets', realStyles), 'body{color:red}');
+
+        const app = express();
+        // Mounted under /dashboard to mirror how DashboardPlugin serves it in production.
+        app.use('/dashboard', createDashboardStaticServer(buildDir, 100_000));
+
+        await new Promise<void>(resolve => {
+            server = app.listen(0, () => resolve());
+        });
+        const address = server.address();
+        const port = typeof address === 'object' && address ? address.port : 0;
+        baseUrl = `http://127.0.0.1:${port}`;
+    });
+
+    afterAll(async () => {
+        await new Promise<void>(resolve => server.close(() => resolve()));
+        fs.rmSync(buildDir, { recursive: true, force: true });
+    });
+
+    async function get(p: string) {
+        // redirect: 'manual' so a 301 surfaces as a failing status rather than being followed.
+        const res = await fetch(baseUrl + p, { redirect: 'manual' });
+        const body = await res.text();
+        const headers = Object.fromEntries(res.headers.entries());
+        return { status: res.status, contentType: res.headers.get('content-type') ?? '', headers, body };
+    }
+
+    describe('Assets SPA route hard-loads the index.html shell', () => {
+        it('GET /dashboard/assets', async () => {
+            const res = await get('/dashboard/assets');
+            expect(res.status).toBe(200);
+            expect(res.contentType).toContain('text/html');
+            expect(res.body).toContain('DASHBOARD_SHELL');
+        });
+
+        it('GET /dashboard/assets/ (trailing slash)', async () => {
+            const res = await get('/dashboard/assets/');
+            expect(res.status).toBe(200);
+            expect(res.contentType).toContain('text/html');
+            expect(res.body).toContain('DASHBOARD_SHELL');
+        });
+
+        it('GET /dashboard/assets with a query string', async () => {
+            const res = await get('/dashboard/assets?perPage=24&viewMode=grid');
+            expect(res.status).toBe(200);
+            expect(res.contentType).toContain('text/html');
+        });
+
+        it('GET /dashboard/assets/:id (asset detail route)', async () => {
+            const res = await get('/dashboard/assets/123');
+            expect(res.status).toBe(200);
+            expect(res.contentType).toContain('text/html');
+            expect(res.body).toContain('DASHBOARD_SHELL');
+        });
+    });
+
+    describe('genuine build artifacts are served', () => {
+        it('serves a real JS chunk with a long-lived immutable cache header', async () => {
+            const res = await get(`/dashboard/assets/${realChunk}`);
+            expect(res.status).toBe(200);
+            expect(res.contentType).toContain('javascript');
+            expect(res.body).toContain('real chunk');
+            // The immutable/long-max-age cache header is load-bearing for CDN behaviour (#4665).
+            const cacheControl = res.headers['cache-control'] ?? '';
+            expect(cacheControl).toContain('immutable');
+            expect(cacheControl).toContain('max-age=31536000');
+        });
+
+        it('serves a real CSS artifact', async () => {
+            const res = await get(`/dashboard/assets/${realStyles}`);
+            expect(res.status).toBe(200);
+            expect(res.contentType).toContain('text/css');
+        });
+    });
+
+    describe('stale-chunk crash guard is intact', () => {
+        it('404s a missing JS chunk instead of serving the HTML shell', async () => {
+            const res = await get('/dashboard/assets/index-staleHASH.js');
+            expect(res.status).toBe(404);
+            expect(res.contentType).not.toContain('text/html');
+            expect(res.body).not.toContain('DASHBOARD_SHELL');
+        });
+
+        it('404s a missing CSS chunk instead of serving the HTML shell', async () => {
+            const res = await get('/dashboard/assets/missing-xyz.css');
+            expect(res.status).toBe(404);
+            expect(res.body).not.toContain('DASHBOARD_SHELL');
+        });
+
+        // Documents the discriminator's assumption: a `/assets` path whose last segment
+        // contains a dot is treated as a (missing) build artifact and 404s. This is safe
+        // today because no Assets SPA route segment contains a dot (ids are numeric/UUID).
+        // If that ever changes, this test should be revisited alongside the route.
+        it('treats a dotted /assets path segment as an artifact (current behaviour)', async () => {
+            const res = await get('/dashboard/assets/some.slug');
+            expect(res.status).toBe(404);
+            expect(res.body).not.toContain('DASHBOARD_SHELL');
+        });
+    });
+
+    describe('control routes keep working', () => {
+        it('serves index.html for a non-assets deep route', async () => {
+            const res = await get('/dashboard/catalog/products/1');
+            expect(res.status).toBe(200);
+            expect(res.contentType).toContain('text/html');
+            expect(res.body).toContain('DASHBOARD_SHELL');
+        });
+
+        it('serves index.html for the dashboard root', async () => {
+            const res = await get('/dashboard/');
+            expect(res.status).toBe(200);
+            expect(res.contentType).toContain('text/html');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

Hard-loading (direct nav / refresh / bookmark) the Dashboard's **Assets** page returned a **404** instead of the Assets list. Client-side navigation worked, and every other deep route (`/dashboard/catalog/...`, `/dashboard/orders/...`) hard-loaded fine — only `/dashboard/assets*` was affected.

Fixes #4841

## Root cause

`DashboardPlugin`'s static server registers a stale-chunk guard with `dashboardServer.use('/assets', (_req, res) => res.status(404).end())`. Express `use('/assets', …)` is a **prefix** match, so it caught not only Vite build artifacts (`/assets/index-<hash>.js`, `.css`, fonts, maps) but also the dashboard's Assets **SPA route** (`/assets`, `/assets/<id>`). Those requests were 404'd before reaching the `index.html` history-fallback.

The guard must stay: across deploys, content-hashed chunk filenames change, and a client holding a stale `index.html` requests an old chunk. Without the 404 it would fall through to `index.html` (HTML served for a `.js` request) and crash the module loader with `Uncaught SyntaxError: Unexpected token '<'`. The problem is only that the guard's URL namespace shares a name with a SPA route.

## The change

- Build artifacts always carry a file extension; SPA routes never do. The guard now only 404s requests whose path has an extension (`path.extname(req.path)`); extensionless `/assets` and `/assets/<id>` fall through to the history fallback.
- Added `redirect: false` to both `express.static` mounts so the physically-present `assets/` directory doesn't 301 `/assets` → `/assets/` before the fallback runs.
- Extracted the static-server router construction from the private `createStaticServer` method into an exported `createDashboardStaticServer(dashboardPath, rateLimitRequests)` in `packages/dashboard/plugin/static-server.ts`, so it can be unit-tested without importing `@vendure/core`. The `/assets/` rate-limit-skip predicate (shared with the dynamic proxy handler, #4665) is now a single exported `isStaticAssetRequest` to prevent the two copies drifting.

## Test plan

**Automated** — new `packages/dashboard/vite/tests/dashboard-static-server.spec.ts` mounts the real `createDashboardStaticServer` under `/dashboard` on a Node http server (mirroring production) against a temp build dir (`index.html` + `assets/index-<hash>.js` + a css). 11 tests:

- Assets SPA route: `/assets`, `/assets/`, `?query`, `/assets/<id>` → 200 `text/html` (the bug).
- Real build artifacts: JS chunk (+ asserts the `immutable; max-age=31536000` cache header) and CSS → 200 with correct content-type.
- Stale-chunk crash guard: missing `.js` / `.css` → 404, **not** HTML.
- Discriminator assumption: a dotted `/assets` segment is treated as an artifact (documents current behaviour).
- Controls: non-assets deep route + dashboard root → 200 html.

Verified: with the pre-fix logic **4 tests fail** (the SPA routes); with the fix **all 11 pass**. Plugin `tsc` build + ESLint clean.

**Full Vendure boot smoke (real start-server path).** Because this change lives in `DashboardPlugin`'s startup/middleware code, it was additionally verified end-to-end by booting a real Vendure server via `bootstrap()` — isolated (sqljs in-memory DB, free port, `viteDevServerPort` pointed at a dead port to force **built/static** mode) — so the request actually flows through `DashboardPlugin.configure()` → `createDynamicHandler` → `staticServer`. The plugin boots cleanly and every access point behaves correctly against the **real production build** (`packages/dev-server/dist`):

| Request | Result |
|---|---|
| `/dashboard/assets` · `/assets/` · `?query` · `/assets/:id` | 200 `text/html` (SPA shell) |
| `/dashboard/assets/<real-hash>.js` | 200 `text/javascript`, `cache-control: …immutable` |
| `/dashboard/assets/index-STALEHASH.js` | 404, not HTML (crash-guard intact) |
| `/dashboard/catalog/products/1` · `/dashboard/` | 200 `text/html` (controls) |

No 301 redirects (the `redirect: false` additions). This is a server-side static-routing change with no rendered-UI surface, so this real-server smoke + the unit test are the verification rather than a browser screenshot.

Note on test placement: the dashboard vitest config excludes `plugin/**` from test *discovery*, so the spec lives in `vite/tests/` (node env) and imports the plugin helper — this is the first such cross-import and is intentional.

## Out of scope (follow-up)

The structurally robust fix is to rename Vite's `build.assetsDir` so the artifact dir and the SPA route never share the `/assets` prefix. That's deliberately not done here to avoid invalidating asset URLs already baked into deployed `index.html` files. The `path.extname` discriminator rests on the assumption that no `/assets` SPA route segment contains a dot (true today: asset ids are numeric/UUID, list filters live in the query string) — documented in the code and covered by a test.
