### PR TITLE
fix(dashboard): Guard getHTML() against destroyed rich text editor

### DIFF
--- a/packages/dashboard/src/lib/components/shared/rich-text-editor/rich-text-editor.tsx
+++ b/packages/dashboard/src/lib/components/shared/rich-text-editor/rich-text-editor.tsx
@@ -78,7 +78,7 @@ export function RichTextEditor({ value, onChange, disabled = false, placeholder 
         content: value,
         editable: !disabled,
         onUpdate: ({ editor }) => {
-            if (!disabled) {
+            if (!disabled && !editor.isDestroyed) {
                 isInternalUpdate.current = true;
                 const newValue = editor.getHTML();
                 if (value !== newValue) {
@@ -94,7 +94,7 @@ export function RichTextEditor({ value, onChange, disabled = false, placeholder 
     }, [editorExtensions]);
 
     useLayoutEffect(() => {
-        if (editor && !isInternalUpdate.current) {
+        if (editor && !editor.isDestroyed && !isInternalUpdate.current) {
             const currentContent = editor.getHTML();
             if (currentContent !== value) {
                 const { from, to } = editor.state.selection;


### PR DESCRIPTION
## Description

The rich text editor called `editor.getHTML()` in two places without checking whether the editor had already been destroyed. When the host component unmounts while an update is pending (e.g. navigating away from a Payment Method detail page, whose `description` field renders `RichTextInput`), the destroyed editor has a `null` ProseMirror schema, and `DOMSerializer.fromSchema(schema)` throws:

```
TypeError: Cannot read properties of null (reading 'cached')
    at DOMSerializer.fromSchema
    at getHTML
```

This guards both `getHTML()` call sites with `!editor.isDestroyed`, which is the recommended workaround for [ueberdosis/tiptap#2380](https://github.com/ueberdosis/tiptap/issues/2380). No behavior change for a live editor — it only skips work once the editor is gone.

Closes #4858

## Breaking changes

None.

## Screenshots

N/A

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/vendurehq/vendure/blob/master/CONTRIBUTING.md) doc
- [x] My commit message follows the [conventional commits](https://www.conventionalcommits.org) format
- [ ] I have added tests (N/A — defensive guard against destroyed-editor state)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784740424&installation_id=128408429&pr_number=4859&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4859&signature=f9ea7358f7a4d3df504a36eedf20532fc389e078d45dae0fefbba023bbd61858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->