### PR TITLE
fix(email-plugin): Add pooled SMTP options to SMTPTransportOptions

### DIFF
--- a/packages/email-plugin/package.json
+++ b/packages/email-plugin/package.json
@@ -17,7 +17,7 @@
         "watch": "tsc -p ./tsconfig.build.json --watch",
         "build": "rimraf lib && tsc -p ./tsconfig.build.json",
         "lint": "eslint --fix .",
-        "test": "vitest --config vitest.config.mts --run"
+        "test": "vitest --config vitest.config.mts --run --typecheck"
     },
     "homepage": "https://www.vendure.io/",
     "funding": "https://github.com/sponsors/michaelbromley",

--- a/packages/email-plugin/src/transport-options.spec-d.ts
+++ b/packages/email-plugin/src/transport-options.spec-d.ts
@@ -1,0 +1,32 @@
+import { assertType, describe, it } from 'vitest';
+
+import { SMTPTransportOptions } from './types';
+
+// https://github.com/vendurehq/vendure/issues/4602
+// Nodemailer pooled SMTP options (pool, maxConnections, ...) work at runtime because the
+// transport object is forwarded directly to nodemailer.createTransport(), but they were
+// missing from SMTPTransportOptions. These type-level tests fail to compile on master.
+describe('SMTPTransportOptions pooled SMTP options (#4602)', () => {
+    it('accepts Nodemailer pooled SMTP options', () => {
+        assertType<SMTPTransportOptions>({
+            type: 'smtp',
+            host: 'smtp.example.com',
+            port: 587,
+            pool: true,
+            maxConnections: 1,
+            maxMessages: 100,
+            rateDelta: 1000,
+            rateLimit: 5,
+            auth: { user: 'user', pass: 'pass' },
+        });
+    });
+
+    it('still accepts a plain (non-pooled) SMTP config', () => {
+        assertType<SMTPTransportOptions>({
+            type: 'smtp',
+            host: 'smtp.example.com',
+            port: 587,
+            auth: { user: 'user', pass: 'pass' },
+        });
+    });
+});

--- a/packages/email-plugin/src/types.ts
+++ b/packages/email-plugin/src/types.ts
@@ -3,6 +3,7 @@ import { Omit } from '@vendure/common/lib/omit';
 import { Injector, RequestContext, SerializedRequestContext, VendureEvent } from '@vendure/core';
 import { Attachment } from 'nodemailer/lib/mailer';
 import SESTransport from 'nodemailer/lib/ses-transport';
+import SMTPPool from 'nodemailer/lib/smtp-pool';
 import SMTPTransport from 'nodemailer/lib/smtp-transport';
 
 import { EmailGenerator } from './generator/email-generator';
@@ -193,6 +194,43 @@ export interface SMTPTransportOptions extends SMTPTransport.Options {
      * @default false
      */
     logging?: boolean;
+    /**
+     * @description
+     * Set to true to use a pooled connection (defaults to false) instead of creating a new connection for
+     * every email. Nodemailer pooled-SMTP option, forwarded directly to `nodemailer.createTransport()`.
+     *
+     * @default false
+     */
+    pool?: boolean;
+    /**
+     * @description
+     * The maximum number of simultaneous connections to make against the SMTP server.
+     * Only applies when `pool` is `true`.
+     *
+     * @default 5
+     */
+    maxConnections?: SMTPPool.Options['maxConnections'];
+    /**
+     * @description
+     * Limits the number of messages sent over a single connection. After `maxMessages` is reached the
+     * connection is dropped and a new one is created. Only applies when `pool` is `true`.
+     *
+     * @default 100
+     */
+    maxMessages?: SMTPPool.Options['maxMessages'];
+    /**
+     * @description
+     * Defines the time measuring period in milliseconds for rate limiting. Only applies when `pool` is `true`.
+     *
+     * @default 1000
+     */
+    rateDelta?: SMTPPool.Options['rateDelta'];
+    /**
+     * @description
+     * Limits the number of messages sent in the `rateDelta` window. Once reached, sending is paused until
+     * the end of the period. Only applies when `pool` is `true`.
+     */
+    rateLimit?: SMTPPool.Options['rateLimit'];
 }
 
 /**

--- a/packages/email-plugin/tsconfig.spec-d.json
+++ b/packages/email-plugin/tsconfig.spec-d.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "include": ["src/**/*.spec-d.ts"]
+}

--- a/packages/email-plugin/vitest.config.mts
+++ b/packages/email-plugin/vitest.config.mts
@@ -1,7 +1,19 @@
+import path from 'path';
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+    test: {
+        // Type-level tests (`*.spec-d.ts`) are run via `vitest --typecheck`.
+        // `tsconfig.spec-d.json` deliberately scopes the type-check program to the
+        // `*.spec-d.ts` files (and their transitive imports) only — it does NOT type-check
+        // the runtime specs. This is intentional: the runtime `plugin.spec.ts` has a
+        // pre-existing type issue (accessing the private `EmailPlugin.options`) that is
+        // unrelated to type tests and out of scope here. Project-wide `tsc` is unaffected.
+        typecheck: {
+            tsconfig: path.join(__dirname, 'tsconfig.spec-d.json'),
+        },
+    },
     plugins: [
         // SWC required to support decorators used in test plugins
         // See https://github.com/vitest-dev/vitest/issues/708#issuecomment-1118628479


### PR DESCRIPTION
## Summary

`@vendure/email-plugin` with `transport.type = 'smtp'` rejects Nodemailer pooled-SMTP options (`pool`, `maxConnections`, …) at the type level, even though they work at runtime:

```ts
EmailPlugin.init({ transport: { type: 'smtp', host, port, pool: true, maxConnections: 1, auth } })
// TS2345: 'pool' does not exist in type 'SMTPTransportOptions'
```

Fixes #4602

## Root cause

`SMTPTransportOptions` extends `SMTPTransport.Options` — Nodemailer's **non-pooled** SMTP type. The pooled options live on a separate `SMTPPool.Options` type. `NodemailerEmailSender.getSmtpTransport()` forwards the options object straight to `nodemailer.createTransport()`, so pooled options already work at runtime; only the typings were out of step.

## The change

Add the five pooled options to `SMTPTransportOptions` as optional members, typed via indexed access from `SMTPPool.Options` (`nodemailer/lib/smtp-pool`) so they stay in sync with `@types/nodemailer`:

- `pool?: boolean` — Nodemailer's type is the literal `pool: true`, but `boolean` matches the runtime (omitted/`false` = non-pooled) and is friendlier.
- `maxConnections`, `maxMessages`, `rateDelta`, `rateLimit` — `SMTPPool.Options['<key>']` indexed access.

Each has `@description` / `@default` JSDoc matching the existing members so it renders on the Transport Options docs page. `service` / `url` / `getSocket` are already inherited from `SMTPTransport.Options`, so they're intentionally not duplicated.

## Test plan

New **type-level** test `src/transport-options.spec-d.ts` (vitest `assertType`), run via `vitest --typecheck`:

- a config using all five pooled options type-checks;
- a plain non-pooled config still type-checks.

Verified: with the pooled members removed (simulating `master`) the pooled case fails with the exact issue error (`'pool' does not exist in type 'SMTPTransportOptions'`); with the fix both pass. Runtime specs (46) pass; `tsc` build + ESLint clean.

To make this runnable, `vitest.config.mts` gains a `typecheck` block pointing at a new dedicated `tsconfig.spec-d.json` whose `include` is only `src/**/*.spec-d.ts`. This mirrors the `typecheck` setup in `packages/common/vitest.config.mts` and **deliberately scopes** the type-check program to the spec-d files (and their imports) so it doesn't pull in the runtime specs.

## Out of scope (follow-up)

Scoping the type-check program was necessary because `plugin.spec.ts:973` has a **pre-existing** type error (`Property 'options' is private and only accessible within class 'EmailPlugin'`) that surfaces when `--typecheck` runs against the package's normal tsconfig. It is unrelated to this fix (it only appears under type-checking, never in the SWC-transpiled runtime run) and is left untouched here — worth a separate cleanup ticket.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4861"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784807733&installation_id=128408429&pr_number=4861&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4861&signature=3cb85916f44a4b18d368c00ec1f31d8dbedf91309a5bfec87780ffd0db5cc0c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->