### PR TITLE
feat(core): Add CustomerChannelAssignmentStrategy to control channel auto-assign

### DIFF
--- a/docs/docs/reference/core-plugins/dashboard-plugin/dashboard-plugin-options.mdx
+++ b/docs/docs/reference/core-plugins/dashboard-plugin/dashboard-plugin-options.mdx
@@ -2,7 +2,7 @@
 title: "DashboardPluginOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/dashboard/plugin/dashboard.plugin.ts" sourceLine="29" packageName="@vendure/dashboard" />
+<GenerationInfo sourceFile="packages/dashboard/plugin/dashboard.plugin.ts" sourceLine="30" packageName="@vendure/dashboard" />
 
 Configuration options for the [DashboardPlugin](/reference/core-plugins/dashboard-plugin/#dashboardplugin).
 

--- a/docs/docs/reference/core-plugins/dashboard-plugin/index.mdx
+++ b/docs/docs/reference/core-plugins/dashboard-plugin/index.mdx
@@ -2,7 +2,7 @@
 title: "DashboardPlugin"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/dashboard/plugin/dashboard.plugin.ts" sourceLine="119" packageName="@vendure/dashboard" />
+<GenerationInfo sourceFile="packages/dashboard/plugin/dashboard.plugin.ts" sourceLine="120" packageName="@vendure/dashboard" />
 
 This plugin serves the static files of the Vendure Dashboard and provides the
 GraphQL extensions needed for the order metrics on the dashboard index page.

--- a/docs/docs/reference/dashboard/extensions-api/custom-providers.mdx
+++ b/docs/docs/reference/dashboard/extensions-api/custom-providers.mdx
@@ -1,0 +1,57 @@
+---
+title: "Custom Providers"
+generated: true
+---
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/extension-api/custom-providers.ts" sourceLine="20" packageName="@vendure/dashboard" since="3.7.0" />
+
+Allows you to define custom React providers that wrap selected parts of the dashboard UI.
+This is useful for cross-cutting concerns such as custom context, error boundaries,
+feature flags, telemetry, or theming.
+
+Providers can be mounted at either the application root (`'app'`) or the authenticated
+layout main content area (`'layout'`, i.e. the `<Outlet />` subtree only; sidebar and
+header are outside this wrapper).
+
+```ts title="Signature"
+type DashboardCustomProviderDefinition = {
+    id: string;
+    component: ComponentType<{ children: ReactNode }>;
+    order?: number;
+    location?: 'app' | 'layout';
+}
+```
+
+<div className="members-wrapper">
+
+### id
+
+<MemberInfo kind="property" type={`string`}   />
+
+A unique identifier for this custom provider.
+### component
+
+<MemberInfo kind="property" type={`ComponentType<{ children: ReactNode }>`}   />
+
+The React provider component to render. It receives `children` and should
+return a wrapped subtree.
+### order
+
+<MemberInfo kind="property" type={`number`}   />
+
+Optional. Controls render order relative to other providers at the same location.
+Lower numbers render first (outermost), higher numbers render later (innermost).
+### location
+
+<MemberInfo kind="property" type={`'app' | 'layout'`}   />
+
+Determines where this provider is mounted in the dashboard hierarchy.
+
+- `'app'`: Wraps the entire dashboard application at the root level.
+- `'layout'`: Wraps the main content area of the authenticated layout (the `<Outlet />` subtree).
+
+The sidebar and header are outside this wrapper.
+
+Optional. Defaults to 'app' if not specified.
+
+
+</div>

--- a/docs/docs/reference/dashboard/extensions-api/define-dashboard-extension.mdx
+++ b/docs/docs/reference/dashboard/extensions-api/define-dashboard-extension.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## defineDashboardExtension
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/extension-api/define-dashboard-extension.ts" sourceLine="89" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/extension-api/define-dashboard-extension.ts" sourceLine="90" packageName="@vendure/dashboard" since="3.3.0" />
 
 The main entry point for extensions to the React-based dashboard. Every dashboard extension
 must contain a call to this function, usually in the entry point file that is referenced by
@@ -44,7 +44,7 @@ Parameters
 
 ## DashboardExtension
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/extension-api/extension-api-types.ts" sourceLine="37" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/extension-api/extension-api-types.ts" sourceLine="38" packageName="@vendure/dashboard" since="3.3.0" />
 
 This is the main interface for defining _all_ extensions to the dashboard.
 
@@ -72,6 +72,7 @@ interface DashboardExtension {
     login?: DashboardLoginExtensions;
     historyEntries?: DashboardHistoryEntryComponent[];
     toolbarItems?: DashboardToolbarItemDefinition[];
+    customProviders?: DashboardCustomProviderDefinition[];
 }
 ```
 
@@ -169,6 +170,11 @@ in the Order or Customer history lists.
 Allows you to define custom toolbar items in the app shell header bar.
 Toolbar items appear alongside the breadcrumbs, dev mode indicator,
 and alerts icon.
+### customProviders
+
+<MemberInfo kind="property" type={`<a href='/reference/dashboard/extensions-api/custom-providers#dashboardcustomproviderdefinition'>DashboardCustomProviderDefinition</a>[]`}  since="3.7.0"  />
+
+Allows you to add custom providers in different locations.
 
 
 </div>

--- a/docs/docs/reference/dashboard/hooks/use-ui-language-loader.mdx
+++ b/docs/docs/reference/dashboard/hooks/use-ui-language-loader.mdx
@@ -2,7 +2,7 @@
 title: "UseUiLanguageLoader"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/dashboard/src/lib/hooks/use-ui-language-loader.ts" sourceLine="15" packageName="@vendure/dashboard" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/hooks/use-ui-language-loader.ts" sourceLine="16" packageName="@vendure/dashboard" />
 
 Loads the UI translations for the given locale and activates it
 with the Lingui I18nProvider. Generally this is used internally

--- a/docs/docs/reference/typescript-api/assets/asset-options.mdx
+++ b/docs/docs/reference/typescript-api/assets/asset-options.mdx
@@ -2,7 +2,7 @@
 title: "AssetOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="716" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="730" packageName="@vendure/core" />
 
 The AssetOptions define how assets (images and other files) are named and stored, and how preview images are generated.
 

--- a/docs/docs/reference/typescript-api/assets/asset-options.mdx
+++ b/docs/docs/reference/typescript-api/assets/asset-options.mdx
@@ -2,7 +2,7 @@
 title: "AssetOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="730" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="727" packageName="@vendure/core" />
 
 The AssetOptions define how assets (images and other files) are named and stored, and how preview images are generated.
 

--- a/docs/docs/reference/typescript-api/auth/auth-options.mdx
+++ b/docs/docs/reference/typescript-api/auth/auth-options.mdx
@@ -196,11 +196,8 @@ Allows you to define access control for entity queries at three levels:
 
 <MemberInfo kind="property" type={`<a href='/reference/typescript-api/auth/customer-channel-assignment-strategy#customerchannelassignmentstrategy'>CustomerChannelAssignmentStrategy</a>`} default={`<a href='/reference/typescript-api/auth/customer-channel-assignment-strategy#defaultcustomerchannelassignmentstrategy'>DefaultCustomerChannelAssignmentStrategy</a>`}  since="3.7.0"  />
 
-Controls whether the AuthGuard silently auto-assigns an authenticated Customer to the active
-Channel, via the strategy's `canAssignCustomerToChannel()` method. Enforced by the AuthGuard,
-and never for the default Channel or under `disableAuth`; the Shop API account-creation flows
-(registration, verification, external auth, guest checkout) are not affected.
-
+Determines whether an authenticated Customer is auto-assigned to the active Channel.
+This is skipped for the default channel, `disableAuth`, and registration/checkout flows.
 The default strategy always assigns.
 
 

--- a/docs/docs/reference/typescript-api/auth/auth-options.mdx
+++ b/docs/docs/reference/typescript-api/auth/auth-options.mdx
@@ -2,7 +2,7 @@
 title: "AuthOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="363" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="364" packageName="@vendure/core" />
 
 The AuthOptions define how authentication and authorization is managed.
 
@@ -28,6 +28,7 @@ interface AuthOptions {
     passwordValidationStrategy?: PasswordValidationStrategy;
     verificationTokenStrategy?: VerificationTokenStrategy;
     entityAccessControlStrategy?: EntityAccessControlStrategy;
+    customerChannelAssignmentStrategy?: CustomerChannelAssignmentStrategy;
 }
 ```
 
@@ -191,6 +192,16 @@ Allows you to define access control for entity queries at three levels:
 - `applyAccessControl()` — synchronous row-level QB filtering (every entity query)
 
 **Developer preview:** this API is subject to change in future releases.
+### customerChannelAssignmentStrategy
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/auth/customer-channel-assignment-strategy#customerchannelassignmentstrategy'>CustomerChannelAssignmentStrategy</a>`} default={`<a href='/reference/typescript-api/auth/customer-channel-assignment-strategy#defaultcustomerchannelassignmentstrategy'>DefaultCustomerChannelAssignmentStrategy</a>`}  since="3.7.0"  />
+
+Controls whether the AuthGuard silently auto-assigns an authenticated Customer to the active
+Channel, via the strategy's `canAssignCustomerToChannel()` method. Enforced by the AuthGuard,
+and never for the default Channel or under `disableAuth`; the Shop API account-creation flows
+(registration, verification, external auth, guest checkout) are not affected.
+
+The default strategy always assigns.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/auth/cookie-options.mdx
+++ b/docs/docs/reference/typescript-api/auth/cookie-options.mdx
@@ -2,7 +2,7 @@
 title: "CookieOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="258" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="259" packageName="@vendure/core" />
 
 Options for the handling of the cookies used to track sessions (only applicable if
 `authOptions.tokenMethod` is set to `'cookie'`). These options are passed directly

--- a/docs/docs/reference/typescript-api/auth/customer-channel-assignment-strategy.mdx
+++ b/docs/docs/reference/typescript-api/auth/customer-channel-assignment-strategy.mdx
@@ -1,0 +1,97 @@
+---
+title: "CustomerChannelAssignmentStrategy"
+generated: true
+---
+## CustomerChannelAssignmentStrategy
+
+<GenerationInfo sourceFile="packages/core/src/config/auth/customer-channel-assignment-strategy.ts" sourceLine="49" packageName="@vendure/core" since="3.7.0" />
+
+Controls whether the AuthGuard silently makes an authenticated [Customer](/reference/typescript-api/entities/customer#customer) a member of the
+Channel their request is pointed at.
+
+Vendure adds any authenticated Customer to whatever Channel they land on. That is
+fine for a single storefront, but not for multi-channel setups where membership should stay
+deliberate: a B2B Channel you only join by invitation, or storefronts that must not share
+customers. Implement this strategy to decide, per request, whether that auto-join happens.
+
+It is consulted only by the AuthGuard, and only for a non-member on a non-default Channel. It
+never runs for the default Channel, under `disableAuth`, or during account creation (registration,
+verification, external auth, guest checkout), which always join the Channel they run on.
+
+Note this governs *membership*, not access: returning `false` does not reject the request. The
+Customer can still use the Channel for the current session; they simply aren't recorded as a
+member.
+
+The [DefaultCustomerChannelAssignmentStrategy](/reference/typescript-api/auth/customer-channel-assignment-strategy#defaultcustomerchannelassignmentstrategy) always returns `true`.
+
+*Example*
+
+```ts
+// Membership is granted by an admin, never auto-joined.
+class InviteOnlyChannelStrategy implements CustomerChannelAssignmentStrategy {
+    canAssignCustomerToChannel() {
+        return false;
+    }
+}
+```
+
+:::info
+
+This is configured via the `authOptions.customerChannelAssignmentStrategy` property of your
+VendureConfig.
+
+:::
+
+```ts title="Signature"
+interface CustomerChannelAssignmentStrategy extends InjectableStrategy {
+    canAssignCustomerToChannel(
+        ctx: RequestContext,
+        customer: Customer,
+        channelId: ID,
+    ): boolean | Promise<boolean>;
+}
+```
+* Extends: [`InjectableStrategy`](/reference/typescript-api/common/injectable-strategy#injectablestrategy)
+
+
+
+<div className="members-wrapper">
+
+### canAssignCustomerToChannel
+
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, customer: <a href='/reference/typescript-api/entities/customer#customer'>Customer</a>, channelId: <a href='/reference/typescript-api/common/id#id'>ID</a>) => boolean | Promise<boolean>`}   />
+
+Return `true` to make the Customer a member of the active Channel, or `false` to let them use
+it for this session without persisting membership.
+
+Called by the AuthGuard when a non-member's request activates a non-default Channel that isn't
+already the session's active channel: on login, or whenever the active channel changes.
+
+
+</div>
+## DefaultCustomerChannelAssignmentStrategy
+
+<GenerationInfo sourceFile="packages/core/src/config/auth/default-customer-channel-assignment-strategy.ts" sourceLine="12" packageName="@vendure/core" since="3.7.0" />
+
+The default [CustomerChannelAssignmentStrategy](/reference/typescript-api/auth/customer-channel-assignment-strategy#customerchannelassignmentstrategy): a Customer is auto-assigned to whichever
+Channel they authenticate against.
+
+```ts title="Signature"
+class DefaultCustomerChannelAssignmentStrategy implements CustomerChannelAssignmentStrategy {
+    canAssignCustomerToChannel() => boolean;
+}
+```
+* Implements: [`CustomerChannelAssignmentStrategy`](/reference/typescript-api/auth/customer-channel-assignment-strategy#customerchannelassignmentstrategy)
+
+
+
+<div className="members-wrapper">
+
+### canAssignCustomerToChannel
+
+<MemberInfo kind="method" type={`() => boolean`}   />
+
+
+
+
+</div>

--- a/docs/docs/reference/typescript-api/auth/customer-channel-assignment-strategy.mdx
+++ b/docs/docs/reference/typescript-api/auth/customer-channel-assignment-strategy.mdx
@@ -53,10 +53,9 @@ interface CustomerChannelAssignmentStrategy extends InjectableStrategy {
 Return `true` to assign the Customer to the current Channel,
 or `false` to let them use it for this session without assigning.
 
-The AuthGuard consults this when an authenticated Customer's request targets a different
-Channel than the one currently active on their session — on the first request after signing
-in, or later when a request switches Channel. It is only consulted on a non-default Channel
-where the Customer is not already a member.
+Triggered when an authenticated Customer's request targets a different
+Channel than the one currently active on their session. This doesn't run on the default Channel
+or if the Customer is already a member of the Channel.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/auth/customer-channel-assignment-strategy.mdx
+++ b/docs/docs/reference/typescript-api/auth/customer-channel-assignment-strategy.mdx
@@ -4,30 +4,19 @@ generated: true
 ---
 ## CustomerChannelAssignmentStrategy
 
-<GenerationInfo sourceFile="packages/core/src/config/auth/customer-channel-assignment-strategy.ts" sourceLine="49" packageName="@vendure/core" since="3.7.0" />
+<GenerationInfo sourceFile="packages/core/src/config/auth/customer-channel-assignment-strategy.ts" sourceLine="38" packageName="@vendure/core" since="3.7.0" />
 
-Controls whether the AuthGuard silently makes an authenticated [Customer](/reference/typescript-api/entities/customer#customer) a member of the
-Channel their request is pointed at.
+Determines if an authenticated Customer should be automatically assigned to the current Channel.
+Use this to keep customer bases strictly separated in multi-channel or B2B setups.
 
-Vendure adds any authenticated Customer to whatever Channel they land on. That is
-fine for a single storefront, but not for multi-channel setups where membership should stay
-deliberate: a B2B Channel you only join by invitation, or storefronts that must not share
-customers. Implement this strategy to decide, per request, whether that auto-join happens.
-
-It is consulted only by the AuthGuard, and only for a non-member on a non-default Channel. It
-never runs for the default Channel, under `disableAuth`, or during account creation (registration,
-verification, external auth, guest checkout), which always join the Channel they run on.
-
-Note this governs *membership*, not access: returning `false` does not reject the request. The
-Customer can still use the Channel for the current session; they simply aren't recorded as a
-member.
-
-The [DefaultCustomerChannelAssignmentStrategy](/reference/typescript-api/auth/customer-channel-assignment-strategy#defaultcustomerchannelassignmentstrategy) always returns `true`.
+NOTE: This controls channel membership, not API access. Returning `false`
+won't block the request, it just stops the customer from bein assigned to this channel.
+(This is skipped on the default channel and during registration/checkout).
 
 *Example*
 
 ```ts
-// Membership is granted by an admin, never auto-joined.
+// Membership is granted by an admin, never auto-assigned.
 class InviteOnlyChannelStrategy implements CustomerChannelAssignmentStrategy {
     canAssignCustomerToChannel() {
         return false;
@@ -61,11 +50,13 @@ interface CustomerChannelAssignmentStrategy extends InjectableStrategy {
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, customer: <a href='/reference/typescript-api/entities/customer#customer'>Customer</a>, channelId: <a href='/reference/typescript-api/common/id#id'>ID</a>) => boolean | Promise<boolean>`}   />
 
-Return `true` to make the Customer a member of the active Channel, or `false` to let them use
-it for this session without persisting membership.
+Return `true` to assign the Customer to the current Channel,
+or `false` to let them use it for this session without assigning.
 
-Called by the AuthGuard when a non-member's request activates a non-default Channel that isn't
-already the session's active channel: on login, or whenever the active channel changes.
+The AuthGuard consults this when an authenticated Customer's request targets a different
+Channel than the one currently active on their session — on the first request after signing
+in, or later when a request switches Channel. It is only consulted on a non-default Channel
+where the Customer is not already a member.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
+++ b/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
@@ -2,7 +2,7 @@
 title: "SuperadminCredentials"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="892" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="906" packageName="@vendure/core" />
 
 These credentials will be used to create the Superadmin user & administrator
 when Vendure first bootstraps.

--- a/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
+++ b/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
@@ -2,7 +2,7 @@
 title: "SuperadminCredentials"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="906" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="903" packageName="@vendure/core" />
 
 These credentials will be used to create the Superadmin user & administrator
 when Vendure first bootstraps.

--- a/docs/docs/reference/typescript-api/configuration/api-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/api-options.mdx
@@ -2,7 +2,7 @@
 title: "ApiOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="79" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="80" packageName="@vendure/core" />
 
 The ApiOptions define how the Vendure GraphQL APIs are exposed, as well as allowing the API layer
 to be extended with middleware.

--- a/docs/docs/reference/typescript-api/configuration/default-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/default-config.mdx
@@ -2,7 +2,7 @@
 title: "DefaultConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/default-config.ts" sourceLine="72" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/default-config.ts" sourceLine="73" packageName="@vendure/core" />
 
 The default configuration settings which are used if not explicitly overridden in the bootstrap() call.
 

--- a/docs/docs/reference/typescript-api/configuration/entity-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/entity-options.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## EntityOptions
 
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1104" packageName="@vendure/core" since="1.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1101" packageName="@vendure/core" since="1.3.0" />
 
 Options relating to the internal handling of entities.
 

--- a/docs/docs/reference/typescript-api/configuration/entity-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/entity-options.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## EntityOptions
 
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1090" packageName="@vendure/core" since="1.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1104" packageName="@vendure/core" since="1.3.0" />
 
 Options relating to the internal handling of entities.
 

--- a/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "RuntimeVendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1376" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1390" packageName="@vendure/core" />
 
 This interface represents the VendureConfig object available at run-time, i.e. the user-supplied
 config values have been merged with the [defaultConfig](/reference/typescript-api/configuration/default-config#defaultconfig) values.

--- a/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "RuntimeVendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1390" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1387" packageName="@vendure/core" />
 
 This interface represents the VendureConfig object available at run-time, i.e. the user-supplied
 config values have been merged with the [defaultConfig](/reference/typescript-api/configuration/default-config#defaultconfig) values.

--- a/docs/docs/reference/typescript-api/configuration/system-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/system-options.mdx
@@ -2,7 +2,7 @@
 title: "SystemOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1202" packageName="@vendure/core" since="1.6.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1199" packageName="@vendure/core" since="1.6.0" />
 
 Options relating to system functions.
 

--- a/docs/docs/reference/typescript-api/configuration/system-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/system-options.mdx
@@ -2,7 +2,7 @@
 title: "SystemOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1188" packageName="@vendure/core" since="1.6.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1202" packageName="@vendure/core" since="1.6.0" />
 
 Options relating to system functions.
 

--- a/docs/docs/reference/typescript-api/configuration/trust-proxy-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/trust-proxy-options.mdx
@@ -2,7 +2,7 @@
 title: "TrustProxyOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="248" packageName="@vendure/core" since="3.4.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="249" packageName="@vendure/core" since="3.4.0" />
 
 Configures Express trust proxy settings when running behind a reverse proxy (usually the case with most hosting services).
 Setting `trustProxy` allows you to retrieve the original IP address from the `X-Forwarded-For` header.

--- a/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "VendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1243" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1240" packageName="@vendure/core" />
 
 All possible configuration options are defined by the
 [`VendureConfig`](https://github.com/vendurehq/vendure/blob/master/packages/core/src/config/vendure-config.ts) interface.

--- a/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "VendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1229" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1243" packageName="@vendure/core" />
 
 All possible configuration options are defined by the
 [`VendureConfig`](https://github.com/vendurehq/vendure/blob/master/packages/core/src/config/vendure-config.ts) interface.

--- a/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
+++ b/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
@@ -2,7 +2,7 @@
 title: "ImportExportOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="990" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1004" packageName="@vendure/core" />
 
 Options related to importing & exporting data.
 

--- a/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
+++ b/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
@@ -2,7 +2,7 @@
 title: "ImportExportOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1004" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1001" packageName="@vendure/core" />
 
 Options related to importing & exporting data.
 

--- a/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
+++ b/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
@@ -2,7 +2,7 @@
 title: "JobQueueOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1028" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1025" packageName="@vendure/core" />
 
 Options related to the built-in job queue.
 

--- a/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
+++ b/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
@@ -2,7 +2,7 @@
 title: "JobQueueOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1014" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1028" packageName="@vendure/core" />
 
 Options related to the built-in job queue.
 

--- a/docs/docs/reference/typescript-api/orders/order-options.mdx
+++ b/docs/docs/reference/typescript-api/orders/order-options.mdx
@@ -2,7 +2,7 @@
 title: "OrderOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="576" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="573" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/orders/order-options.mdx
+++ b/docs/docs/reference/typescript-api/orders/order-options.mdx
@@ -2,7 +2,7 @@
 title: "OrderOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="562" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="576" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/payment/payment-options.mdx
+++ b/docs/docs/reference/typescript-api/payment/payment-options.mdx
@@ -2,7 +2,7 @@
 title: "PaymentOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="914" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="928" packageName="@vendure/core" />
 
 Defines payment-related options in the [VendureConfig](/reference/typescript-api/configuration/vendure-config#vendureconfig).
 

--- a/docs/docs/reference/typescript-api/payment/payment-options.mdx
+++ b/docs/docs/reference/typescript-api/payment/payment-options.mdx
@@ -2,7 +2,7 @@
 title: "PaymentOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="928" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="925" packageName="@vendure/core" />
 
 Defines payment-related options in the [VendureConfig](/reference/typescript-api/configuration/vendure-config#vendureconfig).
 

--- a/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
+++ b/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
@@ -2,7 +2,7 @@
 title: "CatalogOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="763" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="777" packageName="@vendure/core" />
 
 Options related to products and collections.
 

--- a/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
+++ b/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
@@ -2,7 +2,7 @@
 title: "CatalogOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="777" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="774" packageName="@vendure/core" />
 
 Options related to products and collections.
 

--- a/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
+++ b/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
@@ -2,7 +2,7 @@
 title: "PromotionOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="839" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="836" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
+++ b/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
@@ -2,7 +2,7 @@
 title: "PromotionOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="825" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="839" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
+++ b/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
@@ -2,7 +2,7 @@
 title: "SchedulerOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1067" packageName="@vendure/core" since="3.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1064" packageName="@vendure/core" since="3.3.0" />
 
 Options related to scheduled tasks..
 

--- a/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
+++ b/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
@@ -2,7 +2,7 @@
 title: "SchedulerOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1053" packageName="@vendure/core" since="3.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1067" packageName="@vendure/core" since="3.3.0" />
 
 Options related to scheduled tasks..
 

--- a/docs/docs/reference/typescript-api/services/customer-channel-assignment-service.mdx
+++ b/docs/docs/reference/typescript-api/services/customer-channel-assignment-service.mdx
@@ -1,0 +1,27 @@
+---
+title: "CustomerChannelAssignmentService"
+generated: true
+---
+<GenerationInfo sourceFile="packages/core/src/service/helpers/customer-channel-assignment/customer-channel-assignment.service.ts" sourceLine="17" packageName="@vendure/core" />
+
+Handles the assignment of a signed-in Customer to the active Channel.
+
+```ts title="Signature"
+class CustomerChannelAssignmentService {
+    constructor(configService: ConfigService, customerService: CustomerService, channelService: ChannelService)
+    tryAssignToActiveChannel(ctx: RequestContext) => Promise<void>;
+}
+```
+
+<div className="members-wrapper">
+
+### tryAssignToActiveChannel
+
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>) => Promise<void>`}   />
+
+Assigns the active Customer to the active Channel where appropriate. Does not block the
+request: a Customer the strategy declines to assign may still operate on the Channel for the
+current session, just without a persisted membership.
+
+
+</div>

--- a/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
+++ b/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
@@ -2,7 +2,7 @@
 title: "ShippingOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="841" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="855" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
+++ b/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
@@ -2,7 +2,7 @@
 title: "ShippingOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="855" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="852" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/tax/tax-options.mdx
+++ b/docs/docs/reference/typescript-api/tax/tax-options.mdx
@@ -2,7 +2,7 @@
 title: "TaxOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="968" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="965" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/tax/tax-options.mdx
+++ b/docs/docs/reference/typescript-api/tax/tax-options.mdx
@@ -2,7 +2,7 @@
 title: "TaxOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="954" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="968" packageName="@vendure/core" />
 
 
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -946,7 +946,7 @@
                   "title": "AssetOptions",
                   "slug": "asset-options",
                   "file": "docs/reference/typescript-api/assets/asset-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "AssetPreviewStrategy",
@@ -990,7 +990,7 @@
                   "title": "AuthOptions",
                   "slug": "auth-options",
                   "file": "docs/reference/typescript-api/auth/auth-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "BcryptPasswordHashingStrategy",
@@ -1008,7 +1008,7 @@
                   "title": "CustomerChannelAssignmentStrategy",
                   "slug": "customer-channel-assignment-strategy",
                   "file": "docs/reference/typescript-api/auth/customer-channel-assignment-strategy.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "DefaultPasswordValidationStrategy",
@@ -1086,7 +1086,7 @@
                   "title": "SuperadminCredentials",
                   "slug": "superadmin-credentials",
                   "file": "docs/reference/typescript-api/auth/superadmin-credentials.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "VerificationTokenStrategy",
@@ -1390,7 +1390,7 @@
                   "title": "EntityOptions",
                   "slug": "entity-options",
                   "file": "docs/reference/typescript-api/configuration/entity-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "MergeConfig",
@@ -1414,7 +1414,7 @@
                   "title": "RuntimeVendureConfig",
                   "slug": "runtime-vendure-config",
                   "file": "docs/reference/typescript-api/configuration/runtime-vendure-config.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "SettingsStoreFields",
@@ -1432,7 +1432,7 @@
                   "title": "SystemOptions",
                   "slug": "system-options",
                   "file": "docs/reference/typescript-api/configuration/system-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "TrustProxyOptions",
@@ -1444,7 +1444,7 @@
                   "title": "VendureConfig",
                   "slug": "vendure-config",
                   "file": "docs/reference/typescript-api/configuration/vendure-config.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2116,7 +2116,7 @@
                   "title": "ImportExportOptions",
                   "slug": "import-export-options",
                   "file": "docs/reference/typescript-api/import-export/import-export-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "ImportParser",
@@ -2196,7 +2196,7 @@
                   "title": "JobQueueOptions",
                   "slug": "job-queue-options",
                   "file": "docs/reference/typescript-api/job-queue/job-queue-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "JobQueueService",
@@ -2450,7 +2450,7 @@
                   "title": "OrderOptions",
                   "slug": "order-options",
                   "file": "docs/reference/typescript-api/orders/order-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "OrderPlacedStrategy",
@@ -2530,7 +2530,7 @@
                   "title": "PaymentOptions",
                   "slug": "payment-options",
                   "file": "docs/reference/typescript-api/payment/payment-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "PaymentProcess",
@@ -2624,7 +2624,7 @@
                   "title": "CatalogOptions",
                   "slug": "catalog-options",
                   "file": "docs/reference/typescript-api/products-stock/catalog-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "DefaultProductVariantPriceCalculationStrategy",
@@ -2698,7 +2698,7 @@
                   "title": "PromotionOptions",
                   "slug": "promotion-options",
                   "file": "docs/reference/typescript-api/promotions/promotion-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2792,7 +2792,7 @@
                   "title": "SchedulerOptions",
                   "slug": "scheduler-options",
                   "file": "docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "SchedulerService",
@@ -2899,6 +2899,12 @@
                   "slug": "country-service",
                   "file": "docs/reference/typescript-api/services/country-service.mdx",
                   "lastModified": "2026-04-20T16:08:16+02:00"
+                },
+                {
+                  "title": "CustomerChannelAssignmentService",
+                  "slug": "customer-channel-assignment-service",
+                  "file": "docs/reference/typescript-api/services/customer-channel-assignment-service.mdx",
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "CustomerGroupService",
@@ -3208,7 +3214,7 @@
                   "title": "ShippingOptions",
                   "slug": "shipping-options",
                   "file": "docs/reference/typescript-api/shipping/shipping-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "ShouldRunCheckFn",
@@ -3284,7 +3290,7 @@
                   "title": "TaxOptions",
                   "slug": "tax-options",
                   "file": "docs/reference/typescript-api/tax/tax-options.mdx",
-                  "lastModified": "2026-06-23T15:36:24Z"
+                  "lastModified": "2026-06-24T09:25:30Z"
                 },
                 {
                   "title": "TaxZoneStrategy",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1008,7 +1008,7 @@
                   "title": "CustomerChannelAssignmentStrategy",
                   "slug": "customer-channel-assignment-strategy",
                   "file": "docs/reference/typescript-api/auth/customer-channel-assignment-strategy.mdx",
-                  "lastModified": "2026-06-24T09:25:30Z"
+                  "lastModified": "2026-06-24T09:29:11Z"
                 },
                 {
                   "title": "DefaultPasswordValidationStrategy",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -946,7 +946,7 @@
                   "title": "AssetOptions",
                   "slug": "asset-options",
                   "file": "docs/reference/typescript-api/assets/asset-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "AssetPreviewStrategy",
@@ -990,7 +990,7 @@
                   "title": "AuthOptions",
                   "slug": "auth-options",
                   "file": "docs/reference/typescript-api/auth/auth-options.mdx",
-                  "lastModified": "2026-03-31T16:05:42+02:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "BcryptPasswordHashingStrategy",
@@ -1002,7 +1002,13 @@
                   "title": "CookieOptions",
                   "slug": "cookie-options",
                   "file": "docs/reference/typescript-api/auth/cookie-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
+                },
+                {
+                  "title": "CustomerChannelAssignmentStrategy",
+                  "slug": "customer-channel-assignment-strategy",
+                  "file": "docs/reference/typescript-api/auth/customer-channel-assignment-strategy.mdx",
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "DefaultPasswordValidationStrategy",
@@ -1080,7 +1086,7 @@
                   "title": "SuperadminCredentials",
                   "slug": "superadmin-credentials",
                   "file": "docs/reference/typescript-api/auth/superadmin-credentials.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "VerificationTokenStrategy",
@@ -1342,7 +1348,7 @@
                   "title": "ApiOptions",
                   "slug": "api-options",
                   "file": "docs/reference/typescript-api/configuration/api-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "CollectionFilter",
@@ -1354,7 +1360,7 @@
                   "title": "DefaultConfig",
                   "slug": "default-config",
                   "file": "docs/reference/typescript-api/configuration/default-config.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "DefaultSlugStrategy",
@@ -1384,7 +1390,7 @@
                   "title": "EntityOptions",
                   "slug": "entity-options",
                   "file": "docs/reference/typescript-api/configuration/entity-options.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "MergeConfig",
@@ -1408,7 +1414,7 @@
                   "title": "RuntimeVendureConfig",
                   "slug": "runtime-vendure-config",
                   "file": "docs/reference/typescript-api/configuration/runtime-vendure-config.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "SettingsStoreFields",
@@ -1426,19 +1432,19 @@
                   "title": "SystemOptions",
                   "slug": "system-options",
                   "file": "docs/reference/typescript-api/configuration/system-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "TrustProxyOptions",
                   "slug": "trust-proxy-options",
                   "file": "docs/reference/typescript-api/configuration/trust-proxy-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "VendureConfig",
                   "slug": "vendure-config",
                   "file": "docs/reference/typescript-api/configuration/vendure-config.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2110,7 +2116,7 @@
                   "title": "ImportExportOptions",
                   "slug": "import-export-options",
                   "file": "docs/reference/typescript-api/import-export/import-export-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "ImportParser",
@@ -2190,7 +2196,7 @@
                   "title": "JobQueueOptions",
                   "slug": "job-queue-options",
                   "file": "docs/reference/typescript-api/job-queue/job-queue-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "JobQueueService",
@@ -2444,7 +2450,7 @@
                   "title": "OrderOptions",
                   "slug": "order-options",
                   "file": "docs/reference/typescript-api/orders/order-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "OrderPlacedStrategy",
@@ -2524,7 +2530,7 @@
                   "title": "PaymentOptions",
                   "slug": "payment-options",
                   "file": "docs/reference/typescript-api/payment/payment-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "PaymentProcess",
@@ -2618,7 +2624,7 @@
                   "title": "CatalogOptions",
                   "slug": "catalog-options",
                   "file": "docs/reference/typescript-api/products-stock/catalog-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "DefaultProductVariantPriceCalculationStrategy",
@@ -2692,7 +2698,7 @@
                   "title": "PromotionOptions",
                   "slug": "promotion-options",
                   "file": "docs/reference/typescript-api/promotions/promotion-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2786,7 +2792,7 @@
                   "title": "SchedulerOptions",
                   "slug": "scheduler-options",
                   "file": "docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "SchedulerService",
@@ -3202,7 +3208,7 @@
                   "title": "ShippingOptions",
                   "slug": "shipping-options",
                   "file": "docs/reference/typescript-api/shipping/shipping-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "ShouldRunCheckFn",
@@ -3278,7 +3284,7 @@
                   "title": "TaxOptions",
                   "slug": "tax-options",
                   "file": "docs/reference/typescript-api/tax/tax-options.mdx",
-                  "lastModified": "2026-03-11T12:31:39+01:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "TaxZoneStrategy",
@@ -3898,6 +3904,12 @@
                   "lastModified": "2026-04-20T16:08:16+02:00"
                 },
                 {
+                  "title": "Custom Providers",
+                  "slug": "custom-providers",
+                  "file": "docs/reference/dashboard/extensions-api/custom-providers.mdx",
+                  "lastModified": "2026-06-23T15:36:24Z"
+                },
+                {
                   "title": "DataTables",
                   "slug": "data-tables",
                   "file": "docs/reference/dashboard/extensions-api/data-tables.mdx",
@@ -3907,7 +3919,7 @@
                   "title": "DefineDashboardExtension",
                   "slug": "define-dashboard-extension",
                   "file": "docs/reference/dashboard/extensions-api/define-dashboard-extension.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-06-23T15:36:24Z"
                 },
                 {
                   "title": "DetailForms",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3538,10 +3538,10 @@
                   "title": "DashboardPluginOptions",
                   "slug": "dashboard-plugin-options",
                   "file": "docs/reference/core-plugins/dashboard-plugin/dashboard-plugin-options.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-06-23T15:47:56Z"
                 }
               ],
-              "lastModified": "2026-04-20T16:08:16+02:00"
+              "lastModified": "2026-06-23T15:47:56Z"
             },
             {
               "title": "EmailPlugin",
@@ -4145,7 +4145,7 @@
                   "title": "UseUiLanguageLoader",
                   "slug": "use-ui-language-loader",
                   "file": "docs/reference/dashboard/hooks/use-ui-language-loader.mdx",
-                  "lastModified": "2026-01-28T14:49:21+01:00"
+                  "lastModified": "2026-06-23T15:47:56Z"
                 },
                 {
                   "title": "UseWidgetFilters",

--- a/packages/core/e2e/customer-channel-assignment-strategy.e2e-spec.ts
+++ b/packages/core/e2e/customer-channel-assignment-strategy.e2e-spec.ts
@@ -1,0 +1,162 @@
+import { CurrencyCode, LanguageCode } from '@vendure/common/lib/generated-types';
+import { CustomerChannelAssignmentStrategy, mergeConfig, RequestContext } from '@vendure/core';
+import { createTestEnvironment, E2E_DEFAULT_CHANNEL_TOKEN } from '@vendure/testing';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
+
+import { ResultOf } from './graphql/graphql-admin';
+import { createChannelDocument, getCustomerListDocument, MeDocument } from './graphql/shared-definitions';
+import { getProductsTake3Document } from './graphql/shop-definitions';
+
+const NO_AUTOJOIN_CHANNEL_CODE = 'no-autojoin-channel';
+const NO_AUTOJOIN_CHANNEL_TOKEN = 'no_autojoin_channel_token';
+const OPEN_CHANNEL_CODE = 'open-channel';
+const OPEN_CHANNEL_TOKEN = 'open_channel_token';
+
+/**
+ * Suppresses the silent auto-join for the no-autojoin channel. Every other channel behaves as the
+ * default (auto-join).
+ */
+class TestCustomerChannelAssignmentStrategy implements CustomerChannelAssignmentStrategy {
+    canAssignCustomerToChannel(ctx: RequestContext): boolean {
+        return ctx.channel.code !== NO_AUTOJOIN_CHANNEL_CODE;
+    }
+}
+
+type CustomerListItem = ResultOf<typeof getCustomerListDocument>['customers']['items'][number];
+
+describe('CustomerChannelAssignmentStrategy', () => {
+    const { server, adminClient, shopClient } = createTestEnvironment(
+        mergeConfig(testConfig(), {
+            authOptions: {
+                customerChannelAssignmentStrategy: new TestCustomerChannelAssignmentStrategy(),
+            },
+        }),
+    );
+    let customer: CustomerListItem;
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
+            customerCount: 1,
+        });
+        await adminClient.asSuperAdmin();
+
+        const { customers } = await adminClient.query(getCustomerListDocument, { options: { take: 1 } });
+        customer = customers.items[0];
+
+        for (const [code, token] of [
+            [NO_AUTOJOIN_CHANNEL_CODE, NO_AUTOJOIN_CHANNEL_TOKEN],
+            [OPEN_CHANNEL_CODE, OPEN_CHANNEL_TOKEN],
+        ]) {
+            await adminClient.query(createChannelDocument, {
+                input: {
+                    code,
+                    token,
+                    defaultLanguageCode: LanguageCode.en,
+                    currencyCode: CurrencyCode.GBP,
+                    pricesIncludeTax: true,
+                    defaultShippingZoneId: 'T_1',
+                    defaultTaxZoneId: 'T_1',
+                },
+            });
+        }
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    async function channelMembers(token: string) {
+        adminClient.setChannelToken(token);
+        const { customers } = await adminClient.query(getCustomerListDocument);
+        return customers.items.map(c => c.emailAddress);
+    }
+
+    it('lets an authenticated non-member operate on a no-autojoin channel without persisting membership', async () => {
+        shopClient.setChannelToken(NO_AUTOJOIN_CHANNEL_TOKEN);
+        await shopClient.asUserWithCredentials(customer.emailAddress, 'test');
+
+        // The authenticated, customer-scoped query succeeds.
+        const { me } = await shopClient.query(MeDocument);
+        expect(me?.identifier).toBe(customer.emailAddress);
+
+        // But the Customer is not recorded as a member of the channel.
+        expect(await channelMembers(NO_AUTOJOIN_CHANNEL_TOKEN)).not.toContain(customer.emailAddress);
+    });
+
+    it('auto-joins the customer on an open channel', async () => {
+        shopClient.setChannelToken(OPEN_CHANNEL_TOKEN);
+        await shopClient.asUserWithCredentials(customer.emailAddress, 'test');
+        await shopClient.query(MeDocument);
+
+        expect(await channelMembers(OPEN_CHANNEL_TOKEN)).toContain(customer.emailAddress);
+    });
+
+    it('re-evaluates per channel when the active channel changes mid-session', async () => {
+        shopClient.setChannelToken(OPEN_CHANNEL_TOKEN);
+        await shopClient.asUserWithCredentials(customer.emailAddress, 'test');
+
+        shopClient.setChannelToken(NO_AUTOJOIN_CHANNEL_TOKEN);
+        const { me } = await shopClient.query(MeDocument);
+        expect(me?.identifier).toBe(customer.emailAddress);
+
+        expect(await channelMembers(NO_AUTOJOIN_CHANNEL_TOKEN)).not.toContain(customer.emailAddress);
+    });
+
+    it('allows an anonymous public query on a no-autojoin channel', async () => {
+        shopClient.setChannelToken(NO_AUTOJOIN_CHANNEL_TOKEN);
+        await shopClient.asAnonymousUser();
+        const { products } = await shopClient.query(getProductsTake3Document);
+        expect(Array.isArray(products.items)).toBe(true);
+    });
+
+    it('skips an authenticated user that has no Customer record', async () => {
+        // The SuperAdmin user has no Customer, so the auto-join path must skip it on a non-default
+        // channel rather than failing.
+        adminClient.setChannelToken(NO_AUTOJOIN_CHANNEL_TOKEN);
+        const { customers } = await adminClient.query(getCustomerListDocument);
+        expect(Array.isArray(customers.items)).toBe(true);
+    });
+});
+
+describe('default channel is never gated', () => {
+    class NeverAssignStrategy implements CustomerChannelAssignmentStrategy {
+        canAssignCustomerToChannel(): boolean {
+            return false;
+        }
+    }
+
+    const { server, adminClient, shopClient } = createTestEnvironment(
+        mergeConfig(testConfig(), {
+            authOptions: { customerChannelAssignmentStrategy: new NeverAssignStrategy() },
+        }),
+    );
+    let email: string;
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
+            customerCount: 1,
+        });
+        await adminClient.asSuperAdmin();
+        const { customers } = await adminClient.query(getCustomerListDocument, { options: { take: 1 } });
+        email = customers.items[0].emailAddress;
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    it('still authenticates on the default channel under a never-assign strategy', async () => {
+        shopClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+        await shopClient.asUserWithCredentials(email, 'test');
+        const { me } = await shopClient.query(MeDocument);
+        expect(me?.identifier).toBe(email);
+    });
+});

--- a/packages/core/src/api/middleware/auth-guard.ts
+++ b/packages/core/src/api/middleware/auth-guard.ts
@@ -88,7 +88,7 @@ export class AuthGuard implements CanActivate {
 
     private async setActiveChannel(
         requestContext: RequestContext,
-        session: CachedSession | undefined,
+        session?: CachedSession,
     ): Promise<boolean> {
         if (!session) {
             return false;
@@ -101,7 +101,7 @@ export class AuthGuard implements CanActivate {
             return false;
         }
         if (requestContext.activeUserId) {
-            await this.customerChannelAssignmentService.resolve(requestContext);
+            await this.customerChannelAssignmentService.tryAssignToActiveChannel(requestContext);
         }
         await this.sessionService.setActiveChannel(session, requestContext.channel);
         return true;

--- a/packages/core/src/api/middleware/auth-guard.ts
+++ b/packages/core/src/api/middleware/auth-guard.ts
@@ -10,11 +10,9 @@ import { API_KEY_AUTH_STRATEGY_NAME } from '../../config';
 import { ConfigService } from '../../config/config.service';
 import { Logger, LogLevel } from '../../config/logger/vendure-logger';
 import { CachedSession } from '../../config/session-cache/session-cache-strategy';
-import { Customer } from '../../entity/customer/customer.entity';
+import { CustomerChannelAssignmentService } from '../../service/helpers/customer-channel-assignment/customer-channel-assignment.service';
 import { RequestContextService } from '../../service/helpers/request-context/request-context.service';
 import { ApiKeyService } from '../../service/services/api-key.service';
-import { ChannelService } from '../../service/services/channel.service';
-import { CustomerService } from '../../service/services/customer.service';
 import { SessionService } from '../../service/services/session.service';
 import { extractSessionToken, ExtractTokenResult } from '../common/extract-session-token';
 import { getApiType } from '../common/get-api-type';
@@ -44,8 +42,7 @@ export class AuthGuard implements CanActivate {
         private configService: ConfigService,
         private requestContextService: RequestContextService,
         private sessionService: SessionService,
-        private customerService: CustomerService,
-        private channelService: ChannelService,
+        private customerChannelAssignmentService: CustomerChannelAssignmentService,
         private apiKeyService: ApiKeyService,
     ) {}
 
@@ -91,7 +88,7 @@ export class AuthGuard implements CanActivate {
 
     private async setActiveChannel(
         requestContext: RequestContext,
-        session?: CachedSession,
+        session: CachedSession | undefined,
     ): Promise<boolean> {
         if (!session) {
             return false;
@@ -100,39 +97,14 @@ export class AuthGuard implements CanActivate {
         // does not correspond to the current channel, the activeChannelId on the session is set
         const activeChannelShouldBeSet =
             !session.activeChannelId || session.activeChannelId !== requestContext.channelId;
-        if (activeChannelShouldBeSet) {
-            await this.sessionService.setActiveChannel(session, requestContext.channel);
-            if (requestContext.activeUserId) {
-                const customer = await this.customerService.findOneByUserId(
-                    requestContext,
-                    requestContext.activeUserId,
-                    false,
-                );
-                // To avoid assigning the customer to the active channel on every request,
-                // it is only done on the first request and whenever the channel changes
-                if (customer) {
-                    try {
-                        await this.channelService.assignToChannels(requestContext, Customer, customer.id, [
-                            requestContext.channelId,
-                        ]);
-                    } catch (e: any) {
-                        const isDuplicateError =
-                            e.code === 'ER_DUP_ENTRY' /* mySQL/MariaDB */ ||
-                            e.code === '23505'; /* postgres */
-                        if (isDuplicateError) {
-                            // For a duplicate error, this means that concurrent requests have resulted in attempting to
-                            // assign the Customer to the channel more than once. In this case we can safely ignore the
-                            // error as the Customer was successfully assigned in the earlier call.
-                            // See https://github.com/vendurehq/vendure/issues/834
-                        } else {
-                            throw e;
-                        }
-                    }
-                }
-            }
-            return true;
+        if (!activeChannelShouldBeSet) {
+            return false;
         }
-        return false;
+        if (requestContext.activeUserId) {
+            await this.customerChannelAssignmentService.resolve(requestContext);
+        }
+        await this.sessionService.setActiveChannel(session, requestContext.channel);
+        return true;
     }
 
     private async getSession(

--- a/packages/core/src/config/auth/customer-channel-assignment-strategy.ts
+++ b/packages/core/src/config/auth/customer-channel-assignment-strategy.ts
@@ -41,10 +41,9 @@ export interface CustomerChannelAssignmentStrategy extends InjectableStrategy {
      * Return `true` to assign the Customer to the current Channel,
      * or `false` to let them use it for this session without assigning.
      *
-     * The AuthGuard consults this when an authenticated Customer's request targets a different
-     * Channel than the one currently active on their session — on the first request after signing
-     * in, or later when a request switches Channel. It is only consulted on a non-default Channel
-     * where the Customer is not already a member.
+     * Triggered when an authenticated Customer's request targets a different
+     * Channel than the one currently active on their session. This doesn't run on the default Channel
+     * or if the Customer is already a member of the Channel.
      */
     canAssignCustomerToChannel(
         ctx: RequestContext,

--- a/packages/core/src/config/auth/customer-channel-assignment-strategy.ts
+++ b/packages/core/src/config/auth/customer-channel-assignment-strategy.ts
@@ -6,27 +6,16 @@ import { Customer } from '../../entity/customer/customer.entity';
 
 /**
  * @description
- * Controls whether the AuthGuard silently makes an authenticated {@link Customer} a member of the
- * Channel their request is pointed at.
+ * Determines if an authenticated Customer should be automatically assigned to the current Channel.
+ * Use this to keep customer bases strictly separated in multi-channel or B2B setups.
  *
- * Vendure adds any authenticated Customer to whatever Channel they land on. That is
- * fine for a single storefront, but not for multi-channel setups where membership should stay
- * deliberate: a B2B Channel you only join by invitation, or storefronts that must not share
- * customers. Implement this strategy to decide, per request, whether that auto-join happens.
- *
- * It is consulted only by the AuthGuard, and only for a non-member on a non-default Channel. It
- * never runs for the default Channel, under `disableAuth`, or during account creation (registration,
- * verification, external auth, guest checkout), which always join the Channel they run on.
- *
- * Note this governs *membership*, not access: returning `false` does not reject the request. The
- * Customer can still use the Channel for the current session; they simply aren't recorded as a
- * member.
- *
- * The {@link DefaultCustomerChannelAssignmentStrategy} always returns `true`.
+ * NOTE: This controls channel membership, not API access. Returning `false`
+ * won't block the request, it just stops the customer from bein assigned to this channel.
+ * (This is skipped on the default channel and during registration/checkout).
  *
  * @example
  * ```ts
- * // Membership is granted by an admin, never auto-joined.
+ * // Membership is granted by an admin, never auto-assigned.
  * class InviteOnlyChannelStrategy implements CustomerChannelAssignmentStrategy {
  *     canAssignCustomerToChannel() {
  *         return false;
@@ -49,11 +38,13 @@ import { Customer } from '../../entity/customer/customer.entity';
 export interface CustomerChannelAssignmentStrategy extends InjectableStrategy {
     /**
      * @description
-     * Return `true` to make the Customer a member of the active Channel, or `false` to let them use
-     * it for this session without persisting membership.
+     * Return `true` to assign the Customer to the current Channel,
+     * or `false` to let them use it for this session without assigning.
      *
-     * Called by the AuthGuard when a non-member's request activates a non-default Channel that isn't
-     * already the session's active channel: on login, or whenever the active channel changes.
+     * The AuthGuard consults this when an authenticated Customer's request targets a different
+     * Channel than the one currently active on their session — on the first request after signing
+     * in, or later when a request switches Channel. It is only consulted on a non-default Channel
+     * where the Customer is not already a member.
      */
     canAssignCustomerToChannel(
         ctx: RequestContext,

--- a/packages/core/src/config/auth/customer-channel-assignment-strategy.ts
+++ b/packages/core/src/config/auth/customer-channel-assignment-strategy.ts
@@ -1,0 +1,63 @@
+import { ID } from '@vendure/common/lib/shared-types';
+
+import { RequestContext } from '../../api/common/request-context';
+import { InjectableStrategy } from '../../common/types/injectable-strategy';
+import { Customer } from '../../entity/customer/customer.entity';
+
+/**
+ * @description
+ * Controls whether the AuthGuard silently makes an authenticated {@link Customer} a member of the
+ * Channel their request is pointed at.
+ *
+ * Vendure adds any authenticated Customer to whatever Channel they land on. That is
+ * fine for a single storefront, but not for multi-channel setups where membership should stay
+ * deliberate: a B2B Channel you only join by invitation, or storefronts that must not share
+ * customers. Implement this strategy to decide, per request, whether that auto-join happens.
+ *
+ * It is consulted only by the AuthGuard, and only for a non-member on a non-default Channel. It
+ * never runs for the default Channel, under `disableAuth`, or during account creation (registration,
+ * verification, external auth, guest checkout), which always join the Channel they run on.
+ *
+ * Note this governs *membership*, not access: returning `false` does not reject the request. The
+ * Customer can still use the Channel for the current session; they simply aren't recorded as a
+ * member.
+ *
+ * The {@link DefaultCustomerChannelAssignmentStrategy} always returns `true`.
+ *
+ * @example
+ * ```ts
+ * // Membership is granted by an admin, never auto-joined.
+ * class InviteOnlyChannelStrategy implements CustomerChannelAssignmentStrategy {
+ *     canAssignCustomerToChannel() {
+ *         return false;
+ *     }
+ * }
+ * ```
+ *
+ * :::info
+ *
+ * This is configured via the `authOptions.customerChannelAssignmentStrategy` property of your
+ * VendureConfig.
+ *
+ * :::
+ *
+ * @docsCategory auth
+ * @docsPage CustomerChannelAssignmentStrategy
+ * @docsWeight 0
+ * @since 3.7.0
+ */
+export interface CustomerChannelAssignmentStrategy extends InjectableStrategy {
+    /**
+     * @description
+     * Return `true` to make the Customer a member of the active Channel, or `false` to let them use
+     * it for this session without persisting membership.
+     *
+     * Called by the AuthGuard when a non-member's request activates a non-default Channel that isn't
+     * already the session's active channel: on login, or whenever the active channel changes.
+     */
+    canAssignCustomerToChannel(
+        ctx: RequestContext,
+        customer: Customer,
+        channelId: ID,
+    ): boolean | Promise<boolean>;
+}

--- a/packages/core/src/config/auth/default-customer-channel-assignment-strategy.ts
+++ b/packages/core/src/config/auth/default-customer-channel-assignment-strategy.ts
@@ -1,0 +1,16 @@
+import { CustomerChannelAssignmentStrategy } from './customer-channel-assignment-strategy';
+
+/**
+ * @description
+ * The default {@link CustomerChannelAssignmentStrategy}: a Customer is auto-assigned to whichever
+ * Channel they authenticate against.
+ *
+ * @docsCategory auth
+ * @docsPage CustomerChannelAssignmentStrategy
+ * @since 3.7.0
+ */
+export class DefaultCustomerChannelAssignmentStrategy implements CustomerChannelAssignmentStrategy {
+    canAssignCustomerToChannel(): boolean {
+        return true;
+    }
+}

--- a/packages/core/src/config/config.module.ts
+++ b/packages/core/src/config/config.module.ts
@@ -86,6 +86,7 @@ export class ConfigModule implements OnApplicationBootstrap, OnApplicationShutdo
             adminApiKeyStrategy,
             shopApiKeyStrategy,
             entityAccessControlStrategy,
+            customerChannelAssignmentStrategy,
         } = this.configService.authOptions;
         const { taxZoneStrategy, taxLineCalculationStrategy, orderTaxCalculationStrategy } =
             this.configService.taxOptions;
@@ -166,6 +167,7 @@ export class ConfigModule implements OnApplicationBootstrap, OnApplicationShutdo
             adminApiKeyStrategy,
             shopApiKeyStrategy,
             entityAccessControlStrategy,
+            customerChannelAssignmentStrategy,
         ];
     }
 

--- a/packages/core/src/config/default-config.ts
+++ b/packages/core/src/config/default-config.ts
@@ -19,6 +19,7 @@ import { DefaultAssetNamingStrategy } from './asset-naming-strategy/default-asse
 import { NoAssetPreviewStrategy } from './asset-preview-strategy/no-asset-preview-strategy';
 import { NoAssetStorageStrategy } from './asset-storage-strategy/no-asset-storage-strategy';
 import { BcryptPasswordHashingStrategy } from './auth/bcrypt-password-hashing-strategy';
+import { DefaultCustomerChannelAssignmentStrategy } from './auth/default-customer-channel-assignment-strategy';
 import { DefaultEntityAccessControlStrategy } from './auth/default-entity-access-control-strategy';
 import { DefaultPasswordValidationStrategy } from './auth/default-password-validation-strategy';
 import { DefaultVerificationTokenStrategy } from './auth/default-verification-token-strategy';
@@ -125,6 +126,7 @@ export const defaultConfig: RuntimeVendureConfig = {
         passwordValidationStrategy: new DefaultPasswordValidationStrategy({ minLength: 4, maxLength: 72 }),
         verificationTokenStrategy: new DefaultVerificationTokenStrategy(),
         entityAccessControlStrategy: new DefaultEntityAccessControlStrategy(),
+        customerChannelAssignmentStrategy: new DefaultCustomerChannelAssignmentStrategy(),
     },
     catalogOptions: {
         collectionFilters: defaultCollectionFilters,

--- a/packages/core/src/config/index.ts
+++ b/packages/core/src/config/index.ts
@@ -8,6 +8,8 @@ export * from './asset-preview-strategy/asset-preview-strategy';
 export * from './asset-storage-strategy/asset-storage-strategy';
 export * from './auth/authentication-strategy';
 export * from './auth/bcrypt-password-hashing-strategy';
+export * from './auth/customer-channel-assignment-strategy';
+export * from './auth/default-customer-channel-assignment-strategy';
 export * from './auth/default-entity-access-control-strategy';
 export * from './auth/default-password-validation-strategy';
 export * from './auth/default-verification-token-strategy';

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -18,6 +18,7 @@ import { AssetNamingStrategy } from './asset-naming-strategy/asset-naming-strate
 import { AssetPreviewStrategy } from './asset-preview-strategy/asset-preview-strategy';
 import { AssetStorageStrategy } from './asset-storage-strategy/asset-storage-strategy';
 import { AuthenticationStrategy } from './auth/authentication-strategy';
+import { CustomerChannelAssignmentStrategy } from './auth/customer-channel-assignment-strategy';
 import { EntityAccessControlStrategy } from './auth/entity-access-control-strategy';
 import { PasswordHashingStrategy } from './auth/password-hashing-strategy';
 import { PasswordValidationStrategy } from './auth/password-validation-strategy';
@@ -553,6 +554,19 @@ export interface AuthOptions {
      * @experimental
      */
     entityAccessControlStrategy?: EntityAccessControlStrategy;
+    /**
+     * @description
+     * Controls whether the AuthGuard silently auto-assigns an authenticated Customer to the active
+     * Channel, via the strategy's `canAssignCustomerToChannel()` method. Enforced by the AuthGuard,
+     * and never for the default Channel or under `disableAuth`; the Shop API account-creation flows
+     * (registration, verification, external auth, guest checkout) are not affected.
+     *
+     * The default strategy always assigns.
+     *
+     * @default DefaultCustomerChannelAssignmentStrategy
+     * @since 3.7.0
+     */
+    customerChannelAssignmentStrategy?: CustomerChannelAssignmentStrategy;
 }
 
 /**

--- a/packages/core/src/config/vendure-config.ts
+++ b/packages/core/src/config/vendure-config.ts
@@ -556,11 +556,8 @@ export interface AuthOptions {
     entityAccessControlStrategy?: EntityAccessControlStrategy;
     /**
      * @description
-     * Controls whether the AuthGuard silently auto-assigns an authenticated Customer to the active
-     * Channel, via the strategy's `canAssignCustomerToChannel()` method. Enforced by the AuthGuard,
-     * and never for the default Channel or under `disableAuth`; the Shop API account-creation flows
-     * (registration, verification, external auth, guest checkout) are not affected.
-     *
+     * Determines whether an authenticated Customer is auto-assigned to the active Channel.
+     * This is skipped for the default channel, `disableAuth`, and registration/checkout flows.
      * The default strategy always assigns.
      *
      * @default DefaultCustomerChannelAssignmentStrategy

--- a/packages/core/src/service/helpers/customer-channel-assignment/customer-channel-assignment.service.spec.ts
+++ b/packages/core/src/service/helpers/customer-channel-assignment/customer-channel-assignment.service.spec.ts
@@ -1,0 +1,168 @@
+import { Test } from '@nestjs/testing';
+import { DEFAULT_CHANNEL_CODE } from '@vendure/common/lib/shared-constants';
+import { ID } from '@vendure/common/lib/shared-types';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { RequestContext } from '../../../api/common/request-context';
+import { ConfigService } from '../../../config/config.service';
+import { MockConfigService } from '../../../config/config.service.mock';
+import { Channel } from '../../../entity/channel/channel.entity';
+import { Customer } from '../../../entity/customer/customer.entity';
+import { ChannelService } from '../../services/channel.service';
+import { CustomerService } from '../../services/customer.service';
+
+import { CustomerChannelAssignmentService } from './customer-channel-assignment.service';
+
+const USER_ID = 'T_10';
+const CHANNEL_ID = 'T_2';
+const NON_DEFAULT_CODE = 'gated-channel';
+
+function createCtx(channelCode: string, hasUser = true): RequestContext {
+    const channel = new Channel({ code: channelCode, id: CHANNEL_ID });
+    return new RequestContext({
+        apiType: 'shop',
+        channel,
+        session: hasUser ? ({ user: { id: USER_ID } } as any) : undefined,
+        isAuthorized: true,
+        authorizedAsOwnerOnly: false,
+    });
+}
+
+const customer = { id: 'T_5' } as Customer;
+
+describe('CustomerChannelAssignmentService', () => {
+    let service: CustomerChannelAssignmentService;
+    let configService: MockConfigService;
+    let findOneByUserId: ReturnType<typeof vi.fn>;
+    let assignToChannels: ReturnType<typeof vi.fn>;
+    let canAssignCustomerToChannel: ReturnType<typeof vi.fn>;
+
+    beforeEach(async () => {
+        findOneByUserId = vi.fn();
+        assignToChannels = vi.fn().mockResolvedValue(undefined);
+        canAssignCustomerToChannel = vi.fn().mockReturnValue(true);
+
+        const module = await Test.createTestingModule({
+            providers: [
+                CustomerChannelAssignmentService,
+                { provide: ConfigService, useClass: MockConfigService },
+                { provide: CustomerService, useValue: { findOneByUserId } },
+                { provide: ChannelService, useValue: { assignToChannels } },
+            ],
+        }).compile();
+
+        service = module.get(CustomerChannelAssignmentService);
+        configService = module.get<ConfigService, MockConfigService>(ConfigService);
+        configService.authOptions = {
+            disableAuth: false,
+            customerChannelAssignmentStrategy: {
+                canAssignCustomerToChannel,
+            },
+        } as any;
+    });
+
+    /** member-filtered call (filterOnChannel=true) returns the member; the unfiltered call the entity. */
+    function mockCustomer(opts: { isMember: boolean; exists: boolean }) {
+        findOneByUserId.mockImplementation((_ctx: RequestContext, _userId: ID, filterOnChannel = true) => {
+            if (filterOnChannel) {
+                return Promise.resolve(opts.isMember ? customer : undefined);
+            }
+            return Promise.resolve(opts.exists ? customer : undefined);
+        });
+    }
+
+    describe('non-default channel', () => {
+        it('joins a non-member when the strategy allows assignment', async () => {
+            mockCustomer({ isMember: false, exists: true });
+
+            await service.resolve(createCtx(NON_DEFAULT_CODE));
+
+            expect(canAssignCustomerToChannel).toHaveBeenCalled();
+            expect(assignToChannels).toHaveBeenCalledWith(expect.anything(), Customer, customer.id, [
+                CHANNEL_ID,
+            ]);
+        });
+
+        it('allows a non-member without joining when assignment is suppressed', async () => {
+            mockCustomer({ isMember: false, exists: true });
+            canAssignCustomerToChannel.mockReturnValue(false);
+
+            await service.resolve(createCtx(NON_DEFAULT_CODE));
+
+            expect(assignToChannels).not.toHaveBeenCalled();
+        });
+
+        it('short-circuits an existing member without consulting the strategy', async () => {
+            mockCustomer({ isMember: true, exists: true });
+
+            await service.resolve(createCtx(NON_DEFAULT_CODE));
+
+            expect(canAssignCustomerToChannel).not.toHaveBeenCalled();
+            expect(assignToChannels).not.toHaveBeenCalled();
+        });
+
+        it('skips an authenticated user that has no Customer record', async () => {
+            mockCustomer({ isMember: false, exists: false });
+
+            await service.resolve(createCtx(NON_DEFAULT_CODE));
+
+            expect(canAssignCustomerToChannel).not.toHaveBeenCalled();
+            expect(assignToChannels).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('ungated path', () => {
+        it('assigns on the default channel without consulting the strategy', async () => {
+            mockCustomer({ isMember: false, exists: true });
+
+            await service.resolve(createCtx(DEFAULT_CHANNEL_CODE));
+
+            expect(assignToChannels).toHaveBeenCalledWith(expect.anything(), Customer, customer.id, [
+                CHANNEL_ID,
+            ]);
+            expect(canAssignCustomerToChannel).not.toHaveBeenCalled();
+        });
+
+        it('assigns under disableAuth without consulting the strategy', async () => {
+            mockCustomer({ isMember: false, exists: true });
+            (configService.authOptions as any).disableAuth = true;
+
+            await service.resolve(createCtx(NON_DEFAULT_CODE));
+
+            expect(assignToChannels).toHaveBeenCalled();
+            expect(canAssignCustomerToChannel).not.toHaveBeenCalled();
+        });
+
+        it('skips assignment on the default channel when the user has no Customer record', async () => {
+            mockCustomer({ isMember: false, exists: false });
+
+            await service.resolve(createCtx(DEFAULT_CHANNEL_CODE));
+
+            expect(assignToChannels).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('auto-join write', () => {
+        it('swallows a duplicate-key error from a concurrent assign (issue #834)', async () => {
+            mockCustomer({ isMember: false, exists: true });
+            assignToChannels.mockRejectedValue({ code: '23505' });
+
+            await expect(service.resolve(createCtx(NON_DEFAULT_CODE))).resolves.toBeUndefined();
+        });
+
+        it('rethrows a non-duplicate error from the assign', async () => {
+            mockCustomer({ isMember: false, exists: true });
+            assignToChannels.mockRejectedValue({ code: 'SOME_OTHER_ERROR' });
+
+            await expect(service.resolve(createCtx(NON_DEFAULT_CODE))).rejects.toEqual({
+                code: 'SOME_OTHER_ERROR',
+            });
+        });
+    });
+
+    it('does nothing when there is no authenticated user', async () => {
+        await service.resolve(createCtx(NON_DEFAULT_CODE, false));
+
+        expect(findOneByUserId).not.toHaveBeenCalled();
+    });
+});

--- a/packages/core/src/service/helpers/customer-channel-assignment/customer-channel-assignment.service.spec.ts
+++ b/packages/core/src/service/helpers/customer-channel-assignment/customer-channel-assignment.service.spec.ts
@@ -72,22 +72,22 @@ describe('CustomerChannelAssignmentService', () => {
     }
 
     describe('non-default channel', () => {
-        it('joins a non-member when the strategy allows assignment', async () => {
+        it('assigns a non-member when the strategy allows assignment', async () => {
             mockCustomer({ isMember: false, exists: true });
 
-            await service.resolve(createCtx(NON_DEFAULT_CODE));
+            await service.tryAssignToActiveChannel(createCtx(NON_DEFAULT_CODE));
 
-            expect(canAssignCustomerToChannel).toHaveBeenCalled();
+            expect(canAssignCustomerToChannel).toHaveBeenCalledWith(expect.anything(), customer, CHANNEL_ID);
             expect(assignToChannels).toHaveBeenCalledWith(expect.anything(), Customer, customer.id, [
                 CHANNEL_ID,
             ]);
         });
 
-        it('allows a non-member without joining when assignment is suppressed', async () => {
+        it('allows a non-member without assigning when assignment is suppressed', async () => {
             mockCustomer({ isMember: false, exists: true });
             canAssignCustomerToChannel.mockReturnValue(false);
 
-            await service.resolve(createCtx(NON_DEFAULT_CODE));
+            await service.tryAssignToActiveChannel(createCtx(NON_DEFAULT_CODE));
 
             expect(assignToChannels).not.toHaveBeenCalled();
         });
@@ -95,7 +95,7 @@ describe('CustomerChannelAssignmentService', () => {
         it('short-circuits an existing member without consulting the strategy', async () => {
             mockCustomer({ isMember: true, exists: true });
 
-            await service.resolve(createCtx(NON_DEFAULT_CODE));
+            await service.tryAssignToActiveChannel(createCtx(NON_DEFAULT_CODE));
 
             expect(canAssignCustomerToChannel).not.toHaveBeenCalled();
             expect(assignToChannels).not.toHaveBeenCalled();
@@ -104,7 +104,7 @@ describe('CustomerChannelAssignmentService', () => {
         it('skips an authenticated user that has no Customer record', async () => {
             mockCustomer({ isMember: false, exists: false });
 
-            await service.resolve(createCtx(NON_DEFAULT_CODE));
+            await service.tryAssignToActiveChannel(createCtx(NON_DEFAULT_CODE));
 
             expect(canAssignCustomerToChannel).not.toHaveBeenCalled();
             expect(assignToChannels).not.toHaveBeenCalled();
@@ -115,7 +115,7 @@ describe('CustomerChannelAssignmentService', () => {
         it('assigns on the default channel without consulting the strategy', async () => {
             mockCustomer({ isMember: false, exists: true });
 
-            await service.resolve(createCtx(DEFAULT_CHANNEL_CODE));
+            await service.tryAssignToActiveChannel(createCtx(DEFAULT_CHANNEL_CODE));
 
             expect(assignToChannels).toHaveBeenCalledWith(expect.anything(), Customer, customer.id, [
                 CHANNEL_ID,
@@ -127,7 +127,7 @@ describe('CustomerChannelAssignmentService', () => {
             mockCustomer({ isMember: false, exists: true });
             (configService.authOptions as any).disableAuth = true;
 
-            await service.resolve(createCtx(NON_DEFAULT_CODE));
+            await service.tryAssignToActiveChannel(createCtx(NON_DEFAULT_CODE));
 
             expect(assignToChannels).toHaveBeenCalled();
             expect(canAssignCustomerToChannel).not.toHaveBeenCalled();
@@ -136,32 +136,34 @@ describe('CustomerChannelAssignmentService', () => {
         it('skips assignment on the default channel when the user has no Customer record', async () => {
             mockCustomer({ isMember: false, exists: false });
 
-            await service.resolve(createCtx(DEFAULT_CHANNEL_CODE));
+            await service.tryAssignToActiveChannel(createCtx(DEFAULT_CHANNEL_CODE));
 
             expect(assignToChannels).not.toHaveBeenCalled();
         });
     });
 
-    describe('auto-join write', () => {
+    describe('assign write', () => {
         it('swallows a duplicate-key error from a concurrent assign (issue #834)', async () => {
             mockCustomer({ isMember: false, exists: true });
             assignToChannels.mockRejectedValue({ code: '23505' });
 
-            await expect(service.resolve(createCtx(NON_DEFAULT_CODE))).resolves.toBeUndefined();
+            await expect(
+                service.tryAssignToActiveChannel(createCtx(NON_DEFAULT_CODE)),
+            ).resolves.toBeUndefined();
         });
 
         it('rethrows a non-duplicate error from the assign', async () => {
             mockCustomer({ isMember: false, exists: true });
             assignToChannels.mockRejectedValue({ code: 'SOME_OTHER_ERROR' });
 
-            await expect(service.resolve(createCtx(NON_DEFAULT_CODE))).rejects.toEqual({
+            await expect(service.tryAssignToActiveChannel(createCtx(NON_DEFAULT_CODE))).rejects.toEqual({
                 code: 'SOME_OTHER_ERROR',
             });
         });
     });
 
     it('does nothing when there is no authenticated user', async () => {
-        await service.resolve(createCtx(NON_DEFAULT_CODE, false));
+        await service.tryAssignToActiveChannel(createCtx(NON_DEFAULT_CODE, false));
 
         expect(findOneByUserId).not.toHaveBeenCalled();
     });

--- a/packages/core/src/service/helpers/customer-channel-assignment/customer-channel-assignment.service.ts
+++ b/packages/core/src/service/helpers/customer-channel-assignment/customer-channel-assignment.service.ts
@@ -10,11 +10,9 @@ import { CustomerService } from '../../services/customer.service';
 
 /**
  * @description
- * Decides whether a signed-in Customer is silently added to the Channel their request points at, so
- * the {@link AuthGuard} doesn't have to carry that logic itself. Someone who already belongs is left
- * untouched; otherwise the configured {@link CustomerChannelAssignmentStrategy} says whether to
- * quietly add them. The default Channel and disableAuth dev mode skip the strategy and always
- * auto-join.
+ * Handles the assignment of a signed-in Customer to the active Channel.
+ *
+ * @docsCategory services
  */
 @Injectable()
 export class CustomerChannelAssignmentService {
@@ -26,22 +24,21 @@ export class CustomerChannelAssignmentService {
 
     /**
      * @description
-     * Auto-joins the active Customer to the active Channel where appropriate. Does not block the
+     * Assigns the active Customer to the active Channel where appropriate. Does not block the
      * request: a Customer the strategy declines to assign may still operate on the Channel for the
      * current session, just without a persisted membership.
      */
-    async resolve(ctx: RequestContext): Promise<void> {
+    async tryAssignToActiveChannel(ctx: RequestContext): Promise<void> {
         const userId = ctx.activeUserId;
         if (!userId) {
             return;
         }
         const { disableAuth, customerChannelAssignmentStrategy } = this.configService.authOptions;
 
-        // The default Channel and disableAuth dev mode always auto-join and never consult the strategy.
-        const isUngated = disableAuth || ctx.channel.code === DEFAULT_CHANNEL_CODE;
+        // The default Channel and disableAuth dev mode always assign and never consult the strategy.
+        const isGated = !disableAuth && ctx.channel.code !== DEFAULT_CHANNEL_CODE;
 
-        // On a non-default Channel an existing member is already where they belong, so there's nothing to do.
-        if (!isUngated) {
+        if (isGated) {
             const member = await this.customerService.findOneByUserId(ctx, userId, true);
             if (member) {
                 return;
@@ -55,7 +52,7 @@ export class CustomerChannelAssignmentService {
         }
 
         const canAssign =
-            isUngated ||
+            !isGated ||
             (await customerChannelAssignmentStrategy.canAssignCustomerToChannel(
                 ctx,
                 customer,

--- a/packages/core/src/service/helpers/customer-channel-assignment/customer-channel-assignment.service.ts
+++ b/packages/core/src/service/helpers/customer-channel-assignment/customer-channel-assignment.service.ts
@@ -1,0 +1,84 @@
+import { Injectable } from '@nestjs/common';
+import { DEFAULT_CHANNEL_CODE } from '@vendure/common/lib/shared-constants';
+import { ID } from '@vendure/common/lib/shared-types';
+
+import { RequestContext } from '../../../api/common/request-context';
+import { ConfigService } from '../../../config/config.service';
+import { Customer } from '../../../entity/customer/customer.entity';
+import { ChannelService } from '../../services/channel.service';
+import { CustomerService } from '../../services/customer.service';
+
+/**
+ * @description
+ * Decides whether a signed-in Customer is silently added to the Channel their request points at, so
+ * the {@link AuthGuard} doesn't have to carry that logic itself. Someone who already belongs is left
+ * untouched; otherwise the configured {@link CustomerChannelAssignmentStrategy} says whether to
+ * quietly add them. The default Channel and disableAuth dev mode skip the strategy and always
+ * auto-join.
+ */
+@Injectable()
+export class CustomerChannelAssignmentService {
+    constructor(
+        private configService: ConfigService,
+        private customerService: CustomerService,
+        private channelService: ChannelService,
+    ) {}
+
+    /**
+     * @description
+     * Auto-joins the active Customer to the active Channel where appropriate. Does not block the
+     * request: a Customer the strategy declines to assign may still operate on the Channel for the
+     * current session, just without a persisted membership.
+     */
+    async resolve(ctx: RequestContext): Promise<void> {
+        const userId = ctx.activeUserId;
+        if (!userId) {
+            return;
+        }
+        const { disableAuth, customerChannelAssignmentStrategy } = this.configService.authOptions;
+
+        // The default Channel and disableAuth dev mode always auto-join and never consult the strategy.
+        const isUngated = disableAuth || ctx.channel.code === DEFAULT_CHANNEL_CODE;
+
+        // On a non-default Channel an existing member is already where they belong, so there's nothing to do.
+        if (!isUngated) {
+            const member = await this.customerService.findOneByUserId(ctx, userId, true);
+            if (member) {
+                return;
+            }
+        }
+
+        // No Customer record (e.g. an Administrator) means there is nothing to assign.
+        const customer = await this.customerService.findOneByUserId(ctx, userId, false);
+        if (!customer) {
+            return;
+        }
+
+        const canAssign =
+            isUngated ||
+            (await customerChannelAssignmentStrategy.canAssignCustomerToChannel(
+                ctx,
+                customer,
+                ctx.channelId,
+            ));
+        if (canAssign) {
+            await this.assignToActiveChannel(ctx, customer.id);
+        }
+    }
+
+    private async assignToActiveChannel(ctx: RequestContext, customerId: ID): Promise<void> {
+        try {
+            await this.channelService.assignToChannels(ctx, Customer, customerId, [ctx.channelId]);
+        } catch (e: any) {
+            // Two requests for the same Customer can reach this at once and both try to add the same
+            // Channel. If the database rejects ours as a duplicate, the other one already did the
+            // work, so let it pass. Any other failure is real and should surface.
+            // See https://github.com/vendurehq/vendure/issues/834
+            const isDuplicateError =
+                e.code === 'ER_DUP_ENTRY' /* MySQL/MariaDB */ || e.code === '23505'; /* Postgres */
+            if (!isDuplicateError) {
+                throw e;
+            }
+        }
+    }
+}

--- a/packages/core/src/service/service.module.ts
+++ b/packages/core/src/service/service.module.ts
@@ -10,6 +10,7 @@ import { SchedulerModule } from '../scheduler/scheduler.module';
 import { ActiveOrderService } from './helpers/active-order/active-order.service';
 import { ConfigArgService } from './helpers/config-arg/config-arg.service';
 import { CustomFieldRelationService } from './helpers/custom-field-relation/custom-field-relation.service';
+import { CustomerChannelAssignmentService } from './helpers/customer-channel-assignment/customer-channel-assignment.service';
 import { EntityDuplicatorService } from './helpers/entity-duplicator/entity-duplicator.service';
 import { EntityHydrator } from './helpers/entity-hydrator/entity-hydrator.service';
 import { EntitySlugService } from './helpers/entity-slug.service';
@@ -137,6 +138,7 @@ const helpers = [
     ProductPriceApplicator,
     EntityHydrator,
     RequestContextService,
+    CustomerChannelAssignmentService,
     TranslatorService,
     EntityDuplicatorService,
     FacetValueChecker,


### PR DESCRIPTION
# Description

Adds `CustomerChannelAssignmentStrategy` that controls whether the `AuthGuard` auto-assign an authenticated Customer to the non-default Channel their request token points at.

The strategy has a single hook, `canAssignCustomerToChannel(ctx, customer, channelId)`, that controls **channel assignment only, not access**:

- Returning `true` makes the Customer a member of the active Channel, preserving Vendure's existing always-assign behaviour.
- Returning `false` declines the channel assignment but does **not** block the request; the Customer can still operate on the Channel for the current session.

It is consulted only by the `AuthGuard`, and only for a non-member on a non-default Channel. It is never consulted for the default Channel, under `disableAuth`, or during account-creation flows (registration, verification, external auth, guest checkout). 

The shipped `DefaultCustomerChannelAssignmentStrategy` returns `true`, so existing projects behave exactly as before.

Fixes #4499

# Breaking changes

None. The default strategy preserves the current behaviour: every authenticated Customer is auto-assigned to the Channel they authenticate against.

# Screenshots

N/A — server-side behaviour only.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4863"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784820926&installation_id=128408429&pr_number=4863&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4863&signature=40c926eb46a386b8e21e2b0f0666cc2042004b20e95971969c840cab0bf08183"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->