### PR TITLE
fix(core): seed StockLevel on channel assignment (multi-channel)

### DIFF
--- a/packages/core/e2e/stock-location.e2e-spec.ts
+++ b/packages/core/e2e/stock-location.e2e-spec.ts
@@ -230,6 +230,31 @@ describe('Stock location', () => {
             expect(stockLocations.items[0].name).toBe('Channel location');
         });
 
+        it('assigning a product to the channel seeds a StockLevel for the channel location (#4860)', async () => {
+            // Re-assign the product now that the channel has its own stock location: the assignment
+            // should create a `stockOnHand: 0` StockLevel for that location, so per-channel inventory
+            // is usable immediately (without manually setting any stock).
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            await adminClient.query(assignProductToChannelDocument, {
+                input: {
+                    channelId: secondChannelId,
+                    productIds: ['T_1'],
+                },
+            });
+
+            adminClient.setChannelToken(SECOND_CHANNEL_TOKEN);
+            const { productVariant } = await adminClient.query(testGetStockLevelsForVariantDocument, {
+                id: 'T_1',
+            });
+
+            expect(productVariant?.stockLevels.length).toBe(1);
+            expect(productVariant?.stockLevels[0]).toEqual({
+                stockOnHand: 0,
+                stockAllocated: 0,
+                stockLocationId: channelStockLocationId,
+            });
+        });
+
         it('assign stock to location in channel', async () => {
             adminClient.setChannelToken(SECOND_CHANNEL_TOKEN);
             const { updateProductVariants } = await adminClient.query(testSetStockLevelInLocationDocument, {

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -811,8 +811,9 @@ export class ProductVariantService {
      */
     /**
      * Ensures a `stockOnHand: 0` StockLevel exists for each given variant at every StockLocation of
-     * the given channel. Idempotent and batched: it pre-fetches existing levels and only saves the
-     * missing ones (one SELECT + one bulk insert), so existing stock is never touched.
+     * the given channel. Idempotent, batched and concurrency-safe: it issues a single bulk insert
+     * with `orIgnore()`, so rows that already exist (unique productVariantId + stockLocationId) are
+     * skipped at the DB level and never overwritten — even under concurrent assignment/create requests.
      */
     private async ensureStockLevelsForChannel(
         ctx: RequestContext,
@@ -831,24 +832,21 @@ export class ProductVariantService {
         if (stockLocations.length === 0) {
             return;
         }
-        const locationIds = stockLocations.map(location => location.id);
-        const existing = await this.connection.getRepository(ctx, StockLevel).find({
-            where: { productVariantId: In(variantIds), stockLocationId: In(locationIds) },
-        });
-        const existingKeys = new Set(existing.map(sl => `${sl.productVariantId}:${sl.stockLocationId}`));
-        const toCreate: StockLevel[] = [];
-        for (const productVariantId of variantIds) {
-            for (const stockLocationId of locationIds) {
-                if (!existingKeys.has(`${productVariantId}:${stockLocationId}`)) {
-                    toCreate.push(
-                        new StockLevel({ productVariantId, stockLocationId, stockOnHand: 0, stockAllocated: 0 }),
-                    );
-                }
-            }
-        }
-        if (toCreate.length) {
-            await this.connection.getRepository(ctx, StockLevel).save(toCreate);
-        }
+        const newStockLevels = variantIds.flatMap(productVariantId =>
+            stockLocations.map(stockLocation => ({
+                productVariantId,
+                stockLocationId: stockLocation.id,
+                stockOnHand: 0,
+                stockAllocated: 0,
+            })),
+        );
+        await this.connection
+            .getRepository(ctx, StockLevel)
+            .createQueryBuilder()
+            .insert()
+            .values(newStockLevels)
+            .orIgnore()
+            .execute();
     }
 
     async assignProductVariantsToChannel(

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -33,6 +33,7 @@ import {
     OrderLine,
     ProductOptionGroup,
     ProductVariantPrice,
+    StockLocation,
     TaxCategory,
 } from '../../entity';
 import { FacetValue } from '../../entity/facet-value/facet-value.entity';
@@ -824,6 +825,16 @@ export class ProductVariantService {
         });
         const priceFactor = input.priceFactor != null ? input.priceFactor : 1;
         const targetChannel = await this.connection.getEntityOrThrow(ctx, Channel, input.channelId);
+        // The stock locations that belong to the target channel. A StockLevel is seeded for each
+        // of them (per variant) below, so that per-channel inventory works immediately: otherwise
+        // the channel-filtered `stockLevels` field resolves to `[]` in the newly-assigned channel,
+        // which in the Dashboard produces an invalid variant form / permanently-disabled Update.
+        const targetChannelStockLocations = await this.connection
+            .getRepository(ctx, StockLocation)
+            .createQueryBuilder('stockLocation')
+            .innerJoin('stockLocation.channels', 'channel')
+            .where('channel.id = :channelId', { channelId: input.channelId })
+            .getMany();
         for (const variant of variants) {
             if (variant.deletedAt) {
                 continue;
@@ -841,6 +852,11 @@ export class ProductVariantService {
             );
             const assetIds = variant.assets?.map(a => a.assetId) || [];
             await this.assetService.assignToChannel(ctx, { channelId: input.channelId, assetIds });
+            // `getStockLevel` is idempotent: it creates a `stockOnHand: 0` StockLevel when missing
+            // and is a no-op when one already exists.
+            for (const stockLocation of targetChannelStockLocations) {
+                await this.stockLevelService.getStockLevel(ctx, variant.id, stockLocation.id);
+            }
         }
         const result = await this.findByIds(
             ctx,

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -33,6 +33,7 @@ import {
     OrderLine,
     ProductOptionGroup,
     ProductVariantPrice,
+    StockLevel,
     StockLocation,
     TaxCategory,
 } from '../../entity';
@@ -473,6 +474,9 @@ export class ProductVariantService {
                 defaultChannel.defaultCurrencyCode,
             );
         }
+        // Seed a StockLevel for the current channel's stock locations (idempotent), so a variant
+        // created directly within a non-default channel is immediately editable in the Dashboard.
+        await this.ensureStockLevelsForChannel(ctx, [createdVariant.id], ctx.channelId);
         return createdVariant.id;
     }
 
@@ -805,6 +809,48 @@ export class ProductVariantService {
      * Assigns the specified ProductVariants to the specified Channel. In doing so, it will create a new
      * {@link ProductVariantPrice} and also assign the associated Product and any Assets to the Channel too.
      */
+    /**
+     * Ensures a `stockOnHand: 0` StockLevel exists for each given variant at every StockLocation of
+     * the given channel. Idempotent and batched: it pre-fetches existing levels and only saves the
+     * missing ones (one SELECT + one bulk insert), so existing stock is never touched.
+     */
+    private async ensureStockLevelsForChannel(
+        ctx: RequestContext,
+        variantIds: ID[],
+        channelId: ID,
+    ): Promise<void> {
+        if (variantIds.length === 0) {
+            return;
+        }
+        const stockLocations = await this.connection
+            .getRepository(ctx, StockLocation)
+            .createQueryBuilder('stockLocation')
+            .innerJoin('stockLocation.channels', 'channel')
+            .where('channel.id = :channelId', { channelId })
+            .getMany();
+        if (stockLocations.length === 0) {
+            return;
+        }
+        const locationIds = stockLocations.map(location => location.id);
+        const existing = await this.connection.getRepository(ctx, StockLevel).find({
+            where: { productVariantId: In(variantIds), stockLocationId: In(locationIds) },
+        });
+        const existingKeys = new Set(existing.map(sl => `${sl.productVariantId}:${sl.stockLocationId}`));
+        const toCreate: StockLevel[] = [];
+        for (const productVariantId of variantIds) {
+            for (const stockLocationId of locationIds) {
+                if (!existingKeys.has(`${productVariantId}:${stockLocationId}`)) {
+                    toCreate.push(
+                        new StockLevel({ productVariantId, stockLocationId, stockOnHand: 0, stockAllocated: 0 }),
+                    );
+                }
+            }
+        }
+        if (toCreate.length) {
+            await this.connection.getRepository(ctx, StockLevel).save(toCreate);
+        }
+    }
+
     async assignProductVariantsToChannel(
         ctx: RequestContext,
         input: AssignProductVariantsToChannelInput,
@@ -825,16 +871,7 @@ export class ProductVariantService {
         });
         const priceFactor = input.priceFactor != null ? input.priceFactor : 1;
         const targetChannel = await this.connection.getEntityOrThrow(ctx, Channel, input.channelId);
-        // The stock locations that belong to the target channel. A StockLevel is seeded for each
-        // of them (per variant) below, so that per-channel inventory works immediately: otherwise
-        // the channel-filtered `stockLevels` field resolves to `[]` in the newly-assigned channel,
-        // which in the Dashboard produces an invalid variant form / permanently-disabled Update.
-        const targetChannelStockLocations = await this.connection
-            .getRepository(ctx, StockLocation)
-            .createQueryBuilder('stockLocation')
-            .innerJoin('stockLocation.channels', 'channel')
-            .where('channel.id = :channelId', { channelId: input.channelId })
-            .getMany();
+        const assignedVariantIds: ID[] = [];
         for (const variant of variants) {
             if (variant.deletedAt) {
                 continue;
@@ -852,12 +889,13 @@ export class ProductVariantService {
             );
             const assetIds = variant.assets?.map(a => a.assetId) || [];
             await this.assetService.assignToChannel(ctx, { channelId: input.channelId, assetIds });
-            // `getStockLevel` is idempotent: it creates a `stockOnHand: 0` StockLevel when missing
-            // and is a no-op when one already exists.
-            for (const stockLocation of targetChannelStockLocations) {
-                await this.stockLevelService.getStockLevel(ctx, variant.id, stockLocation.id);
-            }
+            assignedVariantIds.push(variant.id);
         }
+        // Seed a StockLevel for each of the target channel's stock locations so that per-channel
+        // inventory is usable immediately (otherwise the channel-filtered `stockLevels` field
+        // resolves to `[]` in the newly-assigned channel — which the Dashboard renders as an
+        // invalid variant form with a permanently-disabled "Update" button).
+        await this.ensureStockLevelsForChannel(ctx, assignedVariantIds, input.channelId);
         const result = await this.findByIds(
             ctx,
             variants.map(v => v.id),

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -902,6 +902,10 @@ export class ProductVariantService {
             .createQueryBuilder()
             .insert()
             .values(newStockLevels)
+            // Fix for MySQL and MariaDB < 10.5: updateEntity(false) prevents TypeORM from using the
+            // RETURNING clause after the INSERT IGNORE, where an ignored-duplicate row reports
+            // insertId 0 and the re-select would otherwise throw. The seeded ids are never used here.
+            .updateEntity(false)
             .orIgnore()
             .execute();
     }

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -474,8 +474,9 @@ export class ProductVariantService {
                 defaultChannel.defaultCurrencyCode,
             );
         }
-        // Seed a StockLevel for the current channel's stock locations (idempotent), so a variant
-        // created directly within a non-default channel is immediately editable in the Dashboard.
+        // Seed a StockLevel for the current channel's stock locations (idempotent), so that for a
+        // variant created directly within a non-default channel the channel-filtered `stockLevels`
+        // field resolves to a real entry rather than an empty array until stock is first adjusted.
         await this.ensureStockLevelsForChannel(ctx, [createdVariant.id], ctx.channelId);
         return createdVariant.id;
     }
@@ -809,46 +810,6 @@ export class ProductVariantService {
      * Assigns the specified ProductVariants to the specified Channel. In doing so, it will create a new
      * {@link ProductVariantPrice} and also assign the associated Product and any Assets to the Channel too.
      */
-    /**
-     * Ensures a `stockOnHand: 0` StockLevel exists for each given variant at every StockLocation of
-     * the given channel. Idempotent, batched and concurrency-safe: it issues a single bulk insert
-     * with `orIgnore()`, so rows that already exist (unique productVariantId + stockLocationId) are
-     * skipped at the DB level and never overwritten — even under concurrent assignment/create requests.
-     */
-    private async ensureStockLevelsForChannel(
-        ctx: RequestContext,
-        variantIds: ID[],
-        channelId: ID,
-    ): Promise<void> {
-        if (variantIds.length === 0) {
-            return;
-        }
-        const stockLocations = await this.connection
-            .getRepository(ctx, StockLocation)
-            .createQueryBuilder('stockLocation')
-            .innerJoin('stockLocation.channels', 'channel')
-            .where('channel.id = :channelId', { channelId })
-            .getMany();
-        if (stockLocations.length === 0) {
-            return;
-        }
-        const newStockLevels = variantIds.flatMap(productVariantId =>
-            stockLocations.map(stockLocation => ({
-                productVariantId,
-                stockLocationId: stockLocation.id,
-                stockOnHand: 0,
-                stockAllocated: 0,
-            })),
-        );
-        await this.connection
-            .getRepository(ctx, StockLevel)
-            .createQueryBuilder()
-            .insert()
-            .values(newStockLevels)
-            .orIgnore()
-            .execute();
-    }
-
     async assignProductVariantsToChannel(
         ctx: RequestContext,
         input: AssignProductVariantsToChannelInput,
@@ -890,9 +851,8 @@ export class ProductVariantService {
             assignedVariantIds.push(variant.id);
         }
         // Seed a StockLevel for each of the target channel's stock locations so that per-channel
-        // inventory is usable immediately (otherwise the channel-filtered `stockLevels` field
-        // resolves to `[]` in the newly-assigned channel — which the Dashboard renders as an
-        // invalid variant form with a permanently-disabled "Update" button).
+        // inventory is usable immediately; otherwise the channel-filtered `stockLevels` field
+        // resolves to `[]` in the newly-assigned channel until stock is first adjusted there.
         await this.ensureStockLevelsForChannel(ctx, assignedVariantIds, input.channelId);
         const result = await this.findByIds(
             ctx,
@@ -904,6 +864,46 @@ export class ProductVariantService {
             );
         }
         return result;
+    }
+
+    /**
+     * Ensures a `stockOnHand: 0` StockLevel exists for each given variant at every StockLocation of
+     * the given channel. Idempotent, batched and concurrency-safe: it issues a single bulk insert
+     * with `orIgnore()`, so rows that already exist (unique productVariantId + stockLocationId) are
+     * skipped at the DB level and never overwritten — even under concurrent assignment/create requests.
+     */
+    private async ensureStockLevelsForChannel(
+        ctx: RequestContext,
+        variantIds: ID[],
+        channelId: ID,
+    ): Promise<void> {
+        if (variantIds.length === 0) {
+            return;
+        }
+        const stockLocations = await this.connection
+            .getRepository(ctx, StockLocation)
+            .createQueryBuilder('stockLocation')
+            .innerJoin('stockLocation.channels', 'channel')
+            .where('channel.id = :channelId', { channelId })
+            .getMany();
+        if (stockLocations.length === 0) {
+            return;
+        }
+        const newStockLevels = variantIds.flatMap(productVariantId =>
+            stockLocations.map(stockLocation => ({
+                productVariantId,
+                stockLocationId: stockLocation.id,
+                stockOnHand: 0,
+                stockAllocated: 0,
+            })),
+        );
+        await this.connection
+            .getRepository(ctx, StockLevel)
+            .createQueryBuilder()
+            .insert()
+            .values(newStockLevels)
+            .orIgnore()
+            .execute();
     }
 
     async removeProductVariantsFromChannel(


### PR DESCRIPTION
## Summary

Fixes #4860.

With `MultiChannelStockLocationStrategy` (the default since 3.1.0), assigning a `ProductVariant` to a channel created a `ProductVariantPrice` but **no `StockLevel`** for that channel's `StockLocation(s)`. Since `StockLevelService.getStockLevelsForVariant` is channel-filtered (`stockLocation.channels.id = ctx.channelId`), `ProductVariant.stockLevels` then resolves to `[]` in the newly-assigned channel.

In the new React Dashboard this makes the variant detail form invalid (the empty `stockLevels` becomes a phantom `[{}]` row that fails the generated zod schema), so the **"Update" button stays permanently disabled** while the unsaved-changes guard still fires — the variant can't be edited at all from the secondary channel.

## Change

`ProductVariantService.assignProductVariantsToChannel()` now ensures a `StockLevel` exists for each of the target channel's stock locations, right after assigning the variant + price + assets:

```ts
const targetChannelStockLocations = await this.connection
    .getRepository(ctx, StockLocation)
    .createQueryBuilder('stockLocation')
    .innerJoin('stockLocation.channels', 'channel')
    .where('channel.id = :channelId', { channelId: input.channelId })
    .getMany();
// …per variant, after assignToChannel(assets):
for (const stockLocation of targetChannelStockLocations) {
    await this.stockLevelService.getStockLevel(ctx, variant.id, stockLocation.id);
}
```

- `StockLevelService.getStockLevel` is **idempotent**: it creates a `stockOnHand: 0` row when missing and is a no-op when one already exists, so existing levels are untouched.
- Implemented by querying `StockLocation` directly through the already-injected `TransactionalConnection` (no new service dependencies / no `RequestContextService` round-trip), which keeps the change minimal and avoids any DI cycle.

## Notes / open questions

- **Scope:** this covers the channel-**assignment** path (the case in the issue). The issue also mentions the *create-in-a-channel* path (`createSingle` only seeds the default location via `adjustProductVariantStock`). Happy to extend this PR to cover that too if you'd prefer it in one go.
- **Approach:** seeding at `stockOnHand: 0` for *all* of the target channel's stock locations — flagging in case you'd rather restrict to a single/default location for the channel.
- **Tests:** I'd add a regression e2e test to `packages/core/e2e/product-channel.e2e-spec.ts` (assign a product to a channel that has its own `StockLocation`, then assert `productVariant.stockLevels` is non-empty in that channel's context). I couldn't fully run the e2e suite locally — glad to add it once the approach looks right to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4864"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784820978&installation_id=128408429&pr_number=4864&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4864&signature=bc7e8ba51d6602a6aeaf4d217239571187ae3150664a003bd869a0e216efd543"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->