### PR TITLE
docs: Add vendure doctor CLI command docs

### DIFF
--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -18,22 +18,9 @@ The Vendure CLI comes installed with a new Vendure project by default from v2.2.
 
 To manually install the CLI, run:
 
-<Tabs groupId="package-manager">
-<TabItem value="npm" label="npm" default>
-
 ```bash
 npm install -D @vendure/cli
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-yarn add -D @vendure/cli
-```
-
-</TabItem>
-</Tabs>
 
 ## Interactive vs Non-Interactive Mode
 
@@ -50,22 +37,9 @@ The `add` command is used to add new entities, resolvers, services, plugins, and
 
 From your project's **root directory**, run:
 
-<Tabs groupId="package-manager">
-<TabItem value="npm" label="npm" default>
-
 ```bash
 npx vendure add
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-yarn vendure add
-```
-
-</TabItem>
-</Tabs>
 
 ![Add command](./add-command.webp)
 
@@ -77,9 +51,6 @@ analyze your project source code to deeply understand and correctly update your 
 ### Non-Interactive Mode
 
 For automation or when you know exactly what you need to add, you can use the non-interactive mode with specific arguments and options:
-
-<Tabs groupId="package-manager">
-<TabItem value="npm" label="npm" default>
 
 ```bash
 # Create a new plugin
@@ -112,44 +83,6 @@ npx vendure add -d MyPlugin
 # Use custom config file
 npx vendure add -p MyPlugin --config ./custom-vendure.config.ts
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-# Create a new plugin
-yarn vendure add -p MyPlugin
-
-# Add an entity to a plugin
-yarn vendure add -e MyEntity --selected-plugin MyPlugin
-
-# Add an entity with features
-yarn vendure add -e MyEntity --selected-plugin MyPlugin --custom-fields --translatable
-
-# Add a service to a plugin
-yarn vendure add -s MyService --selected-plugin MyPlugin
-
-# Add a service with specific type
-yarn vendure add -s MyService --selected-plugin MyPlugin --type entity
-
-# Add job queue support to a plugin
-yarn vendure add -j MyPlugin --name my-job --selected-service MyService
-
-# Add GraphQL codegen to a plugin
-yarn vendure add -c MyPlugin
-
-# Add API extension to a plugin
-yarn vendure add -a MyPlugin --queryName getCustomData --mutationName updateCustomData
-
-# Add Dashboard extensions to a plugin
-yarn vendure add -d MyPlugin
-
-# Use custom config file
-yarn vendure add -p MyPlugin --config ./custom-vendure.config.ts
-```
-
-</TabItem>
-</Tabs>
 
 #### Add Command Options
 
@@ -199,31 +132,15 @@ The `migrate` command is used to generate and manage [database migrations](/deve
 
 From your project's **root directory**, run:
 
-<Tabs groupId="package-manager">
-<TabItem value="npm" label="npm" default>
-
 ```bash
 npx vendure migrate
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-yarn vendure migrate
-```
-
-</TabItem>
-</Tabs>
 
 ![Migrate command](./migrate-command.webp)
 
 ### Non-Interactive Mode
 
 For migration operations, use specific arguments and options:
-
-<Tabs groupId="package-manager">
-<TabItem value="npm" label="npm" default>
 
 ```bash
 # Generate a new migration
@@ -238,26 +155,6 @@ npx vendure migrate --revert
 # Generate migration with custom output directory
 npx vendure migrate -g my-migration -o ./custom/migrations
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-# Generate a new migration
-yarn vendure migrate -g my-migration-name
-
-# Run pending migrations
-yarn vendure migrate -r
-
-# Revert the last migration
-yarn vendure migrate --revert
-
-# Generate migration with custom output directory
-yarn vendure migrate -g my-migration -o ./custom/migrations
-```
-
-</TabItem>
-</Tabs>
 
 #### Migrate Command Options
 
@@ -283,22 +180,9 @@ This is useful when integrating with GraphQL tooling such as your [IDE's GraphQL
 
 From your project's **root directory**, run:
 
-<Tabs groupId="package-manager">
-<TabItem value="npm" label="npm" default>
-
 ```bash
 npx vendure schema
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-yarn vendure schema
-```
-
-</TabItem>
-</Tabs>
 
 ![Schema command](./schema-command.webp)
 
@@ -306,32 +190,15 @@ yarn vendure schema
 
 To automate or quickly generate a schema in one command
 
-<Tabs groupId="package-manager">
-<TabItem value="npm" label="npm" default>
-
 ```bash
 # Create a schema file in SDL format for the Admin API
 npx vendure schema --api admin
 
 # Create a JSON format schema of the Shop API
-npx vendure migrate --api shop --format json
+npx vendure schema --api shop --format json
 ```
 
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-# Create a schema file in SDL format for the Admin API
-yarn vendure schema --api admin
-
-# Create a JSON format schema of the Shop API
-yarn vendure migrate --api shop --format json
-```
-
-</TabItem>
-</Tabs>
-
-#### Migrate Command Options
+#### Schema Command Options
 
 | Flag | Long Form             | Description                                     | Example                                                        |
 | ---- | --------------------- | ----------------------------------------------- | -------------------------------------------------------------- |
@@ -352,22 +219,9 @@ a new machine, or as a guard rail in CI.
 
 Unlike the other commands, `doctor` is **non-interactive only** - it runs all applicable checks and prints a report:
 
-<Tabs groupId="package-manager">
-<TabItem value="npm" label="npm" default>
-
 ```bash
 npx vendure doctor
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-yarn vendure doctor
-```
-
-</TabItem>
-</Tabs>
 
 ### What gets checked
 
@@ -409,24 +263,10 @@ Each check reports one of four statuses: `pass`, `warn`, `fail`, or `skip`.
 
 Use `--check` to run only a subset of checks. The flag is variadic, so list the check names after it:
 
-<Tabs groupId="package-manager">
-<TabItem value="npm" label="npm" default>
-
 ```bash
 # Run only the dependencies and config checks
 npx vendure doctor --check dependencies config
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-# Run only the dependencies and config checks
-yarn vendure doctor --check dependencies config
-```
-
-</TabItem>
-</Tabs>
 
 Valid check names are: `project`, `dependencies`, `config`, `schema`, `database`.
 
@@ -434,22 +274,9 @@ Valid check names are: `project`, `dependencies`, `config`, `schema`, `database`
 
 When preparing for a production deployment, run the production profile to surface unsafe settings:
 
-<Tabs groupId="package-manager">
-<TabItem value="npm" label="npm" default>
-
 ```bash
 npx vendure doctor --profile production
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-yarn vendure doctor --profile production
-```
-
-</TabItem>
-</Tabs>
 
 This adds a **Production** check that warns about settings such as `disableAuth`, default superadmin
 credentials, a missing cookie secret, enabled introspection/playground/debug, overly broad CORS,
@@ -461,24 +288,10 @@ For CI pipelines, combine `--strict` with `--format json`. The `--strict` flag t
 failures, and the command exits with a non-zero code when the overall result is a failure - so a
 warning will fail your build:
 
-<Tabs groupId="package-manager">
-<TabItem value="npm" label="npm" default>
-
 ```bash
 # Fail the build on any warning or failure, and emit machine-readable output
 npx vendure doctor --strict --format json
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-# Fail the build on any warning or failure, and emit machine-readable output
-yarn vendure doctor --strict --format json
-```
-
-</TabItem>
-</Tabs>
 
 #### Doctor Command Options
 

--- a/docs/docs/guides/developer-guide/cli/index.mdx
+++ b/docs/docs/guides/developer-guide/cli/index.mdx
@@ -340,6 +340,156 @@ yarn vendure migrate --api shop --format json
 | `-n` | `--file-name <name>`  | The name of the generated file                  | `vendure schema --api admin --file-name introspection.graphql` |
 | `-f` | `--format <sdl,json>` | The output format (defaults to SDL)             | `vendure schema --api admin --format json`                     |
 
+## The Doctor Command
+
+:::info
+The `doctor` command was added in Vendure v3.7
+:::
+
+The `doctor` command runs a series of diagnostic checks against your Vendure project and produces an
+actionable report. It is useful for debugging a misbehaving project, verifying an upgrade, onboarding
+a new machine, or as a guard rail in CI.
+
+Unlike the other commands, `doctor` is **non-interactive only** - it runs all applicable checks and prints a report:
+
+<Tabs groupId="package-manager">
+<TabItem value="npm" label="npm" default>
+
+```bash
+npx vendure doctor
+```
+
+</TabItem>
+<TabItem value="yarn" label="yarn">
+
+```bash
+yarn vendure doctor
+```
+
+</TabItem>
+</Tabs>
+
+### What gets checked
+
+By default, the following checks run in order:
+
+| Check            | What it verifies                                                                                                                                                |
+| ---------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Project**      | Vendure project structure, config file discovery, package manager detection, lockfile consistency, and monorepo support.                                       |
+| **Dependencies** | `@vendure/*` packages are on matching versions, no duplicate singleton dependencies (`graphql`, `typeorm`, `@nestjs/core`, `@nestjs/common`, `@apollo/server`), and that a database driver is installed. |
+| **Config**       | Your config loads and validates via `preBootstrapConfig()` (custom fields, entities), and that plugin compatibility ranges are satisfied.                       |
+| **Schema**       | The Admin API and Shop API GraphQL schemas build successfully, so all plugin extensions and custom field types compile.                                         |
+| **Database**     | Database connectivity, using safe read-only overrides. Warns if `synchronize: true` is set.                                                                     |
+
+The **Production** check is not run by default - enable it with `--profile production` (see below).
+
+:::info
+The checks are **dependency-ordered**. If the **Project** check fails, all later checks are skipped.
+If the **Config** check fails, the **Schema**, **Database**, and **Production** checks are skipped, since
+they all depend on a successfully loaded config.
+:::
+
+### Example output
+
+```text
+Vendure Doctor
+
+Project         pass  Vendure config found at src/vendure-config.ts
+Dependencies    pass  All dependency checks passed
+Config          pass  Vendure config loaded and validated successfully
+Schema          pass  Admin and Shop schemas generated successfully
+Database        pass  Successfully connected to postgres database
+
+Result: passed
+```
+
+Each check reports one of four statuses: `pass`, `warn`, `fail`, or `skip`.
+
+### Running specific checks
+
+Use `--check` to run only a subset of checks. The flag is variadic, so list the check names after it:
+
+<Tabs groupId="package-manager">
+<TabItem value="npm" label="npm" default>
+
+```bash
+# Run only the dependencies and config checks
+npx vendure doctor --check dependencies config
+```
+
+</TabItem>
+<TabItem value="yarn" label="yarn">
+
+```bash
+# Run only the dependencies and config checks
+yarn vendure doctor --check dependencies config
+```
+
+</TabItem>
+</Tabs>
+
+Valid check names are: `project`, `dependencies`, `config`, `schema`, `database`.
+
+### Production profile
+
+When preparing for a production deployment, run the production profile to surface unsafe settings:
+
+<Tabs groupId="package-manager">
+<TabItem value="npm" label="npm" default>
+
+```bash
+npx vendure doctor --profile production
+```
+
+</TabItem>
+<TabItem value="yarn" label="yarn">
+
+```bash
+yarn vendure doctor --profile production
+```
+
+</TabItem>
+</Tabs>
+
+This adds a **Production** check that warns about settings such as `disableAuth`, default superadmin
+credentials, a missing cookie secret, enabled introspection/playground/debug, overly broad CORS,
+in-memory job queue/cache/session strategies, and missing asset storage.
+
+### Using in CI
+
+For CI pipelines, combine `--strict` with `--format json`. The `--strict` flag treats warnings as
+failures, and the command exits with a non-zero code when the overall result is a failure - so a
+warning will fail your build:
+
+<Tabs groupId="package-manager">
+<TabItem value="npm" label="npm" default>
+
+```bash
+# Fail the build on any warning or failure, and emit machine-readable output
+npx vendure doctor --strict --format json
+```
+
+</TabItem>
+<TabItem value="yarn" label="yarn">
+
+```bash
+# Fail the build on any warning or failure, and emit machine-readable output
+yarn vendure doctor --strict --format json
+```
+
+</TabItem>
+</Tabs>
+
+#### Doctor Command Options
+
+| Long Form           | Description                                                                            | Example                                       |
+| ------------------- | ------------------------------------------------------------------------------------- | --------------------------------------------- |
+| `--config <path>`   | Specify the path to a custom Vendure config file                                       | `vendure doctor --config ./src/my-config.ts`  |
+| `--check <names...>` | Run specific checks only (`project`, `dependencies`, `config`, `schema`, `database`)  | `vendure doctor --check config schema`        |
+| `--profile <name>`  | Run profile-specific checks (`production`)                                              | `vendure doctor --profile production`         |
+| `--format <type>`   | Output format: `text` (default) or `json`                                              | `vendure doctor --format json`                |
+| `--strict`          | Treat warnings as failures (useful for CI)                                             | `vendure doctor --strict`                     |
+
 ## Working in Monorepos
 
 The Vendure CLI automatically supports monorepo structures where packages have their own `tsconfig.json` files that extend a shared base configuration.
@@ -414,4 +564,5 @@ npx vendure --help
 npx vendure add --help
 npx vendure migrate --help
 npx vendure schema --help
+npx vendure doctor --help
 ```

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -218,7 +218,7 @@
           "title": "CLI",
           "slug": "cli",
           "file": "docs/guides/developer-guide/cli/index.mdx",
-          "lastModified": "2026-02-12T16:47:03+01:00"
+          "lastModified": "2026-06-24T18:21:23+02:00"
         },
         {
           "title": "Configuration",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -218,7 +218,7 @@
           "title": "CLI",
           "slug": "cli",
           "file": "docs/guides/developer-guide/cli/index.mdx",
-          "lastModified": "2026-06-24T18:21:23+02:00"
+          "lastModified": "2026-06-24T18:28:16+02:00"
         },
         {
           "title": "Configuration",


### PR DESCRIPTION
## Description

Documents the new `vendure doctor` CLI command added in #4777.

Adds a "The Doctor Command" section to the CLI guide (`docs/docs/guides/developer-guide/cli/index.mdx`), covering:

- The five default checks (Project, Dependencies, Config, Schema, Database) and what each verifies
- The dependency-ordering behaviour — why a Project or Config failure cascades downstream checks into `skip`
- Example console output
- `--check` subset usage (documented as variadic: `--check dependencies config`)
- The `--profile production` profile and the unsafe settings it flags
- Using `doctor` in CI with `--strict` + `--format json` and the non-zero exit behaviour
- A full options table

Also adds `npx vendure doctor --help` to the "Getting Help" section.

Note: documents `production` as a `--profile` value only (not a `--check` value), matching the actual command behaviour in `doctor.ts`.

Relates to #4776

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784910102&installation_id=128408429&pr_number=4872&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4872&signature=8e51f3a4f5ad976a40f8713773d26d21c04e61512472207336aaf4dad89734d9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->