### PR TITLE
docs: Remove redundant package-manager tabs from Admin UI guide

### DIFF
--- a/docs/docs/guides/extending-the-admin-ui/getting-started/index.mdx
+++ b/docs/docs/guides/extending-the-admin-ui/getting-started/index.mdx
@@ -28,42 +28,16 @@ UI extensions fall into two categories:
 
 First, install the [`@vendure/ui-devkit` package](https://www.npmjs.com/package/@vendure/ui-devkit) as a dev dependency:
 
-<Tabs>
-<TabItem value="npm" label="npm" default>
-
 ```bash
 npm install --save-dev @vendure/ui-devkit
 ```
 
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-yarn add --dev @vendure/ui-devkit
-```
-
-</TabItem>
-</Tabs>
-
 :::info
 If you plan to use React components in your UI extensions, you should also install the `@types/react` package:
-
-<Tabs>
-<TabItem value="npm" label="npm" default>
 
 ```bash
 npm install --save-dev @types/react
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-yarn add --dev @types/react
-```
-
-</TabItem>
-</Tabs>
 
 :::
 
@@ -324,22 +298,9 @@ compileUiExtensions({
 
 This can then be run from the command line:
 
-<Tabs>
-<TabItem value="npm" label="npm" default>
-
 ```bash
 npx ts-node src/compile-admin-ui.ts
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-yarn ts-node src/compile-admin-ui.ts
-```
-
-</TabItem>
-</Tabs>
 
 Once complete, the production-ready app bundle will be output to `admin-ui/dist/browser`. This method is suitable for a production setup, so that the Admin UI can be compiled ahead-of-time as part of your deployment process. This ensures that your Vendure server starts up as quickly as possible. In this case, you can pass the path of the compiled app to the AdminUiPlugin:
 
@@ -378,22 +339,9 @@ Vendure's output dist folder, include the following commands in your package.jso
 "build:admin" will remove the admin-ui folder and run the compileUiExtensions function to generate the admin-ui Angular app.
 Make sure to install `copyfiles` before running the "copy" command:
 
-<Tabs>
-<TabItem value="npm" label="npm" default>
-
 ```bash
 npm install copyfiles
 ```
-
-</TabItem>
-<TabItem value="yarn" label="yarn">
-
-```bash
-yarn add copyfiles
-```
-
-</TabItem>
-</Tabs>
 
 :::
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -818,7 +818,7 @@
               "title": "Getting Started",
               "slug": "getting-started",
               "file": "docs/guides/extending-the-admin-ui/getting-started/index.mdx",
-              "lastModified": "2026-02-12T16:47:03+01:00"
+              "lastModified": "2026-06-24T18:35:17+02:00"
             },
             {
               "title": "UI Library",


### PR DESCRIPTION
## Description

Follow-up to #4872. Removes the remaining manual package-manager `<Tabs>`/`<TabItem>` (npm/yarn) wrappers from the Admin UI getting-started guide.

The docs site auto-renders a package-manager tab strip (npm/pnpm/yarn/bun) for any plain bash code block containing a package-manager command, so the manual wrappers were double-rendering a redundant npm/yarn tab control above the real one.

Converts all four blocks in `docs/docs/guides/extending-the-admin-ui/getting-started/index.mdx` to plain bash code blocks (`@vendure/ui-devkit` install, `@types/react` install, `compile-admin-ui.ts` run, `copyfiles` install).

The legitimate `groupId="framework"` (Angular vs React) tabs are left untouched.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4873"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1784910885&installation_id=128408429&pr_number=4873&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4873&signature=9dcaf20b1d7662e07cf516aaca67e455c13a64be1e682002e3d47392958b1a78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->