### PR TITLE
fix(dashboard): redirect to list when detail entity not found in active channel

### DIFF
--- a/docs/docs/reference/dashboard/detail-views/use-detail-page.mdx
+++ b/docs/docs/reference/dashboard/detail-views/use-detail-page.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## useDetailPage
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="241" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="242" packageName="@vendure/dashboard" since="3.3.0" />
 
 **Status: Developer Preview**
 
@@ -80,7 +80,7 @@ Parameters
 
 ## DetailPageOptions
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="47" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="48" packageName="@vendure/dashboard" since="3.3.0" />
 
 Options used to configure the result of the `useDetailPage` hook.
 
@@ -175,7 +175,7 @@ The function to call when the update is successful.
 </div>
 ## UseDetailPageResult
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="159" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/page/use-detail-page.ts" sourceLine="160" packageName="@vendure/dashboard" since="3.3.0" />
 
 
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3845,7 +3845,7 @@
                   "title": "UseDetailPage",
                   "slug": "use-detail-page",
                   "file": "docs/reference/dashboard/detail-views/use-detail-page.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-06-25T17:34:47Z"
                 },
                 {
                   "title": "UseGeneratedForm",

--- a/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
@@ -30,6 +30,7 @@ import { Page, PageBlock, PageLayout, PageTitle } from '@/vdb/framework/layout-e
 import { api } from '@/vdb/graphql/api.js';
 import { ResultOf } from '@/vdb/graphql/graphql.js';
 import { useChannel } from '@/vdb/hooks/use-channel.js';
+import { useRedirectToListOnNotFound } from '@/vdb/hooks/use-redirect-to-list-on-not-found.js';
 import { z, zodResolver } from '@/vdb/lib/zod.js';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -172,10 +173,14 @@ function ManageProductVariants() {
         Record<string, Record<string, string>>
     >({});
 
-    const { data: productData, refetch } = useQuery({
+    const { data: productData, refetch, isFetching } = useQuery({
         queryFn: () => api.query(productDetailWithVariantsDocument, { id }),
         queryKey: getQueryKey(id),
     });
+
+    // This page fetches its own data rather than using `useDetailPage`, so it
+    // opts into the not-found redirect explicitly (e.g. after a channel switch).
+    useRedirectToListOnNotFound(productData?.product, { isLoading: isFetching });
 
     const updateVariantMutation = useMutation({
         mutationFn: api.mutate(updateProductVariantDocument),

--- a/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id_.variants.tsx
@@ -180,7 +180,7 @@ function ManageProductVariants() {
 
     // This page fetches its own data rather than using `useDetailPage`, so it
     // opts into the not-found redirect explicitly (e.g. after a channel switch).
-    useRedirectToListOnNotFound(productData?.product, { isLoading: isFetching });
+    useRedirectToListOnNotFound(productData?.product, { isFetching });
 
     const updateVariantMutation = useMutation({
         mutationFn: api.mutate(updateProductVariantDocument),

--- a/packages/dashboard/src/lib/framework/page/use-detail-page.ts
+++ b/packages/dashboard/src/lib/framework/page/use-detail-page.ts
@@ -17,6 +17,7 @@ import { NEW_ENTITY_PATH } from '../../constants.js';
 import { api } from '../../graphql/api.js';
 import { useCustomFieldConfig } from '../../hooks/use-custom-field-config.js';
 import { useExtendedDetailQuery } from '../../hooks/use-extended-detail-query.js';
+import { useRedirectToListOnNotFound } from '../../hooks/use-redirect-to-list-on-not-found.js';
 import { addCustomFields } from '../document-introspection/add-custom-fields.js';
 import {
     getEntityName,
@@ -277,6 +278,10 @@ export function useDetailPage<
     const entity = (detailQuery?.data as any)?.[entityQueryField] as
         | DetailPageEntity<T, EntityField>
         | undefined;
+
+    // Redirect to the list if the entity is no longer found in the active
+    // channel (e.g. after a channel switch).
+    useRedirectToListOnNotFound(entity, { isLoading: detailQuery.isFetching, skip: isNew });
 
     const resetForm = () => {
         form.reset(form.getValues());

--- a/packages/dashboard/src/lib/framework/page/use-detail-page.ts
+++ b/packages/dashboard/src/lib/framework/page/use-detail-page.ts
@@ -281,7 +281,7 @@ export function useDetailPage<
 
     // Redirect to the list if the entity is no longer found in the active
     // channel (e.g. after a channel switch).
-    useRedirectToListOnNotFound(entity, { isLoading: detailQuery.isFetching, skip: isNew });
+    useRedirectToListOnNotFound(entity, { isFetching: detailQuery.isFetching, skip: isNew });
 
     const resetForm = () => {
         form.reset(form.getValues());

--- a/packages/dashboard/src/lib/hooks/use-redirect-to-list-on-not-found.ts
+++ b/packages/dashboard/src/lib/hooks/use-redirect-to-list-on-not-found.ts
@@ -1,19 +1,20 @@
-import { NEW_ENTITY_PATH } from '@/vdb/constants.js';
 import { useNavigate, useRouter, useRouterState } from '@tanstack/react-router';
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 
 export interface RedirectToListOnNotFoundOptions {
     /**
      * @description
-     * Whether the underlying query is still in flight. The redirect is only
-     * evaluated once the query has settled, so we don't bounce during the
-     * initial load or a background refetch.
+     * Whether the underlying query is currently fetching. Pass the query's
+     * `isFetching` flag (true on the initial load _and_ on background refetches).
+     * The redirect is only evaluated once the query has settled, so we don't
+     * bounce during the initial load or while a channel-switch refetch is in
+     * flight.
      */
-    isLoading: boolean;
+    isFetching: boolean;
     /**
      * @description
-     * When `true`, the hook is a no-op. Used to skip the check when creating
-     * a new entity, where the absence of an entity is expected.
+     * When `true`, the hook is a no-op. Pass `skip: true` when the absence of an
+     * entity is expected, e.g. when creating a new entity.
      */
     skip?: boolean;
 }
@@ -29,26 +30,31 @@ export interface RedirectToListOnNotFoundOptions {
  * broken, empty detail view. When the entity _does_ exist in the target channel,
  * `entity` stays populated and no redirect occurs.
  *
- * The list path is derived as the first path segment (e.g. `/products/42` and
- * `/products/42/variants` both resolve to `/products`), falling back to the
- * dashboard root if that route does not exist.
+ * The list route is assumed to live at the first path segment (e.g. `/products`),
+ * so `/products/42` and `/products/42/variants` both resolve to `/products`. If
+ * that route does not exist, it falls back to the dashboard root.
  */
 export function useRedirectToListOnNotFound(
     entity: unknown,
-    { isLoading, skip }: RedirectToListOnNotFoundOptions,
+    { isFetching, skip }: RedirectToListOnNotFoundOptions,
 ): void {
     const navigate = useNavigate();
     const router = useRouter();
     const pathname = useRouterState({ select: s => s.location.pathname });
+    // The pathname is read when computing the redirect target, but it must not
+    // trigger the effect: the redirect should fire on a not-found transition,
+    // not on every navigation. A ref keeps the latest value without a dep.
+    const pathnameRef = useRef(pathname);
+    pathnameRef.current = pathname;
 
     useEffect(() => {
-        if (skip || isLoading || entity) {
+        if (skip || isFetching || entity) {
             return;
         }
-        const segments = pathname.split('/').filter(Boolean);
+        const segments = pathnameRef.current.split('/').filter(Boolean);
         // Only redirect from a detail or sub-page (e.g. /products/42 or
-        // /products/42/variants), never from a list page itself.
-        if (segments.length <= 1 || segments[1] === NEW_ENTITY_PATH) {
+        // /products/42/variants), never from a list page (single segment).
+        if (segments.length <= 1) {
             return;
         }
         const listPath = `/${segments[0]}`;
@@ -56,5 +62,5 @@ export function useRedirectToListOnNotFound(
         // `to` is typed against the generated route tree, so a computed path
         // needs the cast.
         void navigate({ to: target as any });
-    }, [entity, isLoading, skip, pathname, navigate, router]);
+    }, [entity, isFetching, skip, navigate, router]);
 }

--- a/packages/dashboard/src/lib/hooks/use-redirect-to-list-on-not-found.ts
+++ b/packages/dashboard/src/lib/hooks/use-redirect-to-list-on-not-found.ts
@@ -1,0 +1,60 @@
+import { NEW_ENTITY_PATH } from '@/vdb/constants.js';
+import { useNavigate, useRouter, useRouterState } from '@tanstack/react-router';
+import { useEffect } from 'react';
+
+export interface RedirectToListOnNotFoundOptions {
+    /**
+     * @description
+     * Whether the underlying query is still in flight. The redirect is only
+     * evaluated once the query has settled, so we don't bounce during the
+     * initial load or a background refetch.
+     */
+    isLoading: boolean;
+    /**
+     * @description
+     * When `true`, the hook is a no-op. Used to skip the check when creating
+     * a new entity, where the absence of an entity is expected.
+     */
+    skip?: boolean;
+}
+
+/**
+ * @description
+ * Redirects to the entity list page when a detail entity is not found in the
+ * active channel.
+ *
+ * This handles the case where a user switches to a channel in which the
+ * currently-viewed entity does not exist: the detail query refetches, resolves
+ * to no entity, and we navigate to the list rather than leaving the user on a
+ * broken, empty detail view. When the entity _does_ exist in the target channel,
+ * `entity` stays populated and no redirect occurs.
+ *
+ * The list path is derived as the first path segment (e.g. `/products/42` and
+ * `/products/42/variants` both resolve to `/products`), falling back to the
+ * dashboard root if that route does not exist.
+ */
+export function useRedirectToListOnNotFound(
+    entity: unknown,
+    { isLoading, skip }: RedirectToListOnNotFoundOptions,
+): void {
+    const navigate = useNavigate();
+    const router = useRouter();
+    const pathname = useRouterState({ select: s => s.location.pathname });
+
+    useEffect(() => {
+        if (skip || isLoading || entity) {
+            return;
+        }
+        const segments = pathname.split('/').filter(Boolean);
+        // Only redirect from a detail or sub-page (e.g. /products/42 or
+        // /products/42/variants), never from a list page itself.
+        if (segments.length <= 1 || segments[1] === NEW_ENTITY_PATH) {
+            return;
+        }
+        const listPath = `/${segments[0]}`;
+        const target = router.matchRoutes(listPath).length > 0 ? listPath : '/';
+        // `to` is typed against the generated route tree, so a computed path
+        // needs the cast.
+        void navigate({ to: target as any });
+    }, [entity, isLoading, skip, pathname, navigate, router]);
+}


### PR DESCRIPTION
## Problem

When viewing an entity detail page and switching to a channel in which that entity does not exist, the detail view breaks: the underlying query refetches with the new channel token, returns no entity, and the user is left on an empty/broken form (or a blank screen, in the case of the hand-rolled Manage Variants page).

## Approach

Rather than pre-emptively redirecting on every channel switch (which also redirects when the entity *does* exist in the target channel), this reacts to the actual not-found state once the query settles.

- New hook `useRedirectToListOnNotFound(entity, { isLoading, skip })`: when a non-new entity resolves to nothing after its query has settled, it navigates to the entity's list route. The list path is derived from the first path segment, so both `/products/42` and `/products/42/variants` correctly resolve to `/products` (never the equally-channel-scoped parent detail).
- Wired into `useDetailPage`, so all standard detail pages (products, orders, etc.) are covered automatically.
- The Manage Variants page fetches its own data rather than using `useDetailPage`, so it opts in explicitly with a single line.

When the entity exists in the target channel, `entity` stays populated and no redirect occurs — so switching channels while viewing an entity present in both channels keeps you on the page.

## Behaviour

| Scenario | Result |
| --- | --- |
| Entity exists in both channels, switch channel | Stays on the detail page |
| Entity only in source channel, on `/products/<id>` | Redirects to `/products` |
| On `/products/<id>/variants`, entity only in source channel | Redirects to `/products` (the list, not the broken parent) |
| Switch to default channel where entity exists | Stays put |
| Creating a new entity (`/products/new`) | No redirect |

## Notes

Alternative approach to #4827, which fixes the same underlying issue but redirects pre-emptively on every channel switch regardless of whether the entity exists in the target channel.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785000844&installation_id=128408429&pr_number=4874&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4874&signature=ab306695536ca73239548ad4d28e118d1bbb3820e904d97886ff1b7c7433e525"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->