### PR TITLE
docs(core): document verified-email contract for external auth strategies

### DIFF
--- a/docs/docs/guides/core-concepts/auth/index.mdx
+++ b/docs/docs/guides/core-concepts/auth/index.mdx
@@ -194,6 +194,14 @@ export class GoogleAuthenticationStrategy implements AuthenticationStrategy<Goog
 }
 ```
 
+:::warning Security: only set `verified: true` for provider-verified emails
+The `verified` flag passed to `createCustomerAndUser` does more than mark the account as verified — it also controls **account linking**. If a `User` already exists with the same email address, Vendure links the new external authentication method to that existing account **only when `verified: true`**.
+
+An `AuthenticationStrategy` must therefore set `verified: true` **only** when the external provider has proven that the authenticating user owns the email address — for example, Google's `email_verified` claim (as used above). Setting `verified: true` for an email the provider has not verified would allow an attacker to register a victim's email at the provider and have their external login bound to the victim's existing Vendure account — an account takeover.
+
+Since Vendure v3.7.0, attempting to link an **unverified** external identity to a pre-existing account throws an [`UnverifiedExternalEmailError`](/reference/typescript-api/errors/error-types). Creating a brand-new account (no existing account shares the email) is unaffected.
+:::
+
 ### Facebook authentication
 
 #### Storefront setup
@@ -349,6 +357,10 @@ export class FacebookAuthenticationStrategy implements AuthenticationStrategy<Fa
         const user = await this.externalAuthenticationService.createCustomerAndUser(ctx, {
             strategy: this.name,
             externalIdentifier: uresult.id,
+            // NOTE: Facebook generally returns a verified email, but this is not guaranteed for
+            // every account type. Only pass `verified: true` if you are confident the email is
+            // provider-verified — otherwise this login could be linked to a pre-existing account
+            // with the same email. See the security warning above.
             verified: true,
             emailAddress: uresult.email,
             firstName: uresult.first_name,

--- a/docs/docs/guides/how-to/github-oauth-authentication/index.mdx
+++ b/docs/docs/guides/how-to/github-oauth-authentication/index.mdx
@@ -100,7 +100,26 @@ export class GitHubAuthenticationStrategy implements AuthenticationStrategy<GitH
       throw new Error('Unable to retrieve user information from GitHub');
     }
 
-    // Step 3: Check if this GitHub user already has a Vendure account
+    // Step 3: Fetch the user's email addresses to determine the primary, verified email.
+    // This requires the `user:email` OAuth scope. GitHub does NOT guarantee that a user's
+    // email is verified, so we must read the `verified` flag rather than assume it.
+    const emailsResponse = await fetch('https://api.github.com/user/emails', {
+      headers: {
+        'Authorization': `Bearer ${tokenData.access_token}`,
+        'Accept': 'application/vnd.github.v3+json',
+      },
+    });
+    const emails = (await emailsResponse.json()) as Array<{
+      email: string;
+      primary: boolean;
+      verified: boolean;
+    }>;
+    const primaryEmail = Array.isArray(emails) ? emails.find(e => e.primary) : undefined;
+    if (!primaryEmail) {
+      throw new Error('Unable to retrieve a primary email address from GitHub');
+    }
+
+    // Step 4: Check if this GitHub user already has a Vendure account
     const existingCustomer = await this.externalAuthenticationService.findCustomerUser(
       ctx,
       this.name,
@@ -112,12 +131,16 @@ export class GitHubAuthenticationStrategy implements AuthenticationStrategy<GitH
       return existingCustomer;
     }
 
-    // Step 4: Create a new customer account for first-time GitHub users
+    // Step 5: Create a new customer account for first-time GitHub users.
+    // We pass `verified: primaryEmail.verified` so that this external identity is only
+    // linked to a pre-existing account (one with the same email) when GitHub has actually
+    // verified that the user owns the email. Passing `verified: true` unconditionally here
+    // would risk account takeover — see the security note in the Authentication guide.
     const newCustomer = await this.externalAuthenticationService.createCustomerAndUser(ctx, {
       strategy: this.name,
       externalIdentifier: user.login, // Store GitHub username
-      verified: true, // GitHub accounts are pre-verified
-      emailAddress: `${user.login}-github@vendure.io`, // Unique email to avoid conflicts
+      verified: primaryEmail.verified,
+      emailAddress: primaryEmail.email,
       firstName: user.name?.split(' ')[0] || user.login,
       lastName: user.name?.split(' ').slice(1).join(' ') || '',
     });
@@ -129,7 +152,7 @@ export class GitHubAuthenticationStrategy implements AuthenticationStrategy<GitH
 
 The strategy uses Vendure's [ExternalAuthenticationService](/reference/typescript-api/auth/external-authentication-service/) to handle customer creation.
 
-It generates a unique email address for each GitHub user to avoid conflicts, and stores the GitHub username as the external identifier for future logins.
+It uses the GitHub account's primary email address and only marks the account as `verified` when GitHub reports that email as verified, and stores the GitHub username as the external identifier for future logins.
 
 ## Registering the Strategy
 
@@ -217,7 +240,8 @@ export function createGitHubSignInUrl(): string {
   // Store state for CSRF protection
   sessionStorage.setItem('github_oauth_state', state);
 
-  return `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user&state=${state}`;
+  // `user:email` is required so the backend can read the primary email and its verified status.
+  return `https://github.com/login/oauth/authorize?client_id=${clientId}&redirect_uri=${redirectUri}&scope=read:user%20user:email&state=${state}`;
 }
 ```
 
@@ -320,7 +344,7 @@ mutation AuthenticateWithGitHub {
   "data": {
     "authenticate": {
       "id": "1",
-      "identifier": "github-user-github@vendure.io",
+      "identifier": "github-user@example.com",
       "channels": [
         {
           "code": "__default_channel__",
@@ -340,8 +364,8 @@ mutation AuthenticateWithGitHub {
 
 GitHub-authenticated customers are managed like any other Vendure [Customer](/reference/typescript-api/entities/customer/):
 
-- **Email**: Generated as `{username}-github@vendure.io` to avoid conflicts
-- **Verification**: Automatically verified (GitHub handles email verification)
+- **Email**: The GitHub account's primary email address
+- **Verification**: Derived from GitHub's `verified` flag on the primary email — only verified emails mark the account as verified
 - **External ID**: GitHub username stored for future authentication
 - **Profile**: Name extracted from GitHub profile when available
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -169,7 +169,7 @@
           "title": "Auth",
           "slug": "auth",
           "file": "docs/guides/core-concepts/auth/index.mdx",
-          "lastModified": "2026-02-12T16:47:03+01:00"
+          "lastModified": "2026-06-26T10:15:15+02:00"
         },
         {
           "title": "Channels",
@@ -446,7 +446,7 @@
           "title": "GitHub OAuth Authentication",
           "slug": "github-oauth-authentication",
           "file": "docs/guides/how-to/github-oauth-authentication/index.mdx",
-          "lastModified": "2026-02-12T16:47:03+01:00"
+          "lastModified": "2026-06-26T10:15:15+02:00"
         },
         {
           "title": "Google OAuth Authentication",


### PR DESCRIPTION
Follow-up docs for the external-auth account-takeover fix (GHSA-6j36-r6pr-59x4), merged to minor as UnverifiedExternalEmailError.

### core-concepts/auth
- Added a security :::warning explaining the `verified` flag controls account **linking** (not just verification status): an external identity links to a pre-existing account only when `verified: true`, so strategies must set it true only for provider-verified emails. Unverified linking now throws `UnverifiedExternalEmailError` (v3.7.0).
- Added a caveat comment to the Facebook example's hardcoded `verified: true`.

### how-to/github-oauth-authentication
- Rewrote the example to fetch `/user/emails` and pass `verified: primaryEmail.verified` with the real primary email, instead of `verified: true // GitHub accounts are pre-verified`.
- Added the required `user:email` OAuth scope to the authorize URL.
- Updated downstream prose, summary bullets and the sample response identifier.

Relates to GHSA-6j36-r6pr-59x4

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785053775&installation_id=128408429&pr_number=4875&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4875&signature=5e4a8ae7d338c1716923f3036df6a3c1457be96a45ef8dd76d055b7e73db9df5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->