### PR TITLE
fix(core): Stop double-encoding non-list ID config args

### DIFF
--- a/packages/core/e2e/order-promotion.e2e-spec.ts
+++ b/packages/core/e2e/order-promotion.e2e-spec.ts
@@ -52,7 +52,9 @@ import {
     deletePromotionDocument,
     getFacetListDocument,
     getProductsWithVariantPricesDocument,
+    getPromotionDocument,
     removeCustomersFromGroupDocument,
+    updatePromotionDocument,
 } from './graphql/shared-definitions';
 import {
     addItemToOrderDocument,
@@ -691,6 +693,64 @@ describe('Promotions applied to Orders', () => {
             expect(adjustOrderLine.totalWithTax).toBe(12000);
             expect(adjustOrderLine.discounts.length).toBe(0);
 
+            await deletePromotion(promotion.id);
+        });
+
+        // https://github.com/vendurehq/vendure/issues/4856
+        // A read → save round-trip (what the dashboard does on any edit) must not
+        // corrupt the customerGroupId. Before the fix, encode re-quoted the id
+        // (`'T_1'` → `'"T_1"'`), which then mis-decoded on the way back in and
+        // silently cleared the customer group. The single-create `customerGroup`
+        // test above never exercises this read → re-encode → save path where the
+        // corruption occurs, so this guards the round-trip explicitly.
+        it('customerGroup id survives a read-back → re-save round-trip', async () => {
+            const { createCustomerGroup } = await adminClient.query(createCustomerGroupDocument, {
+                input: { name: 'Round-trip Group', customerIds: ['T_1'] },
+            });
+
+            const promotion = await createPromotion({
+                enabled: true,
+                name: 'Round-trip promotion',
+                conditions: [
+                    {
+                        code: customerGroup.code,
+                        arguments: [{ name: 'customerGroupId', value: createCustomerGroup.id }],
+                    },
+                ],
+                actions: [freeOrderAction],
+            });
+
+            // Read the promotion back — this encodes the condition args for the client.
+            const { promotion: readBack } = await adminClient.query(getPromotionDocument, {
+                id: promotion.id,
+            });
+            const encodedGroupId = readBack!.conditions[0].args.find(
+                a => a.name === 'customerGroupId',
+            )?.value;
+            // Encode must emit the raw id, not a re-quoted `'"T_1"'`.
+            expect(encodedGroupId).toBe(createCustomerGroup.id);
+
+            // Save it again unchanged, exactly as the dashboard does on edit.
+            const { updatePromotion } = await adminClient.query(updatePromotionDocument, {
+                input: {
+                    id: promotion.id,
+                    conditions: readBack!.conditions.map(c => ({
+                        code: c.code,
+                        arguments: c.args.map(a => ({ name: a.name, value: a.value })),
+                    })),
+                },
+            });
+            const savedGroupId = (updatePromotion as PromotionFragment).conditions[0].args.find(
+                a => a.name === 'customerGroupId',
+            )?.value;
+            // After the round-trip the id is still the original group, not a corrupted
+            // `-1` (AutoIncrement) or a quote-accumulated value.
+            expect(savedGroupId).toBe(createCustomerGroup.id);
+
+            await adminClient.query(removeCustomersFromGroupDocument, {
+                groupId: createCustomerGroup.id,
+                customerIds: ['T_1'],
+            });
             await deletePromotion(promotion.id);
         });
     });

--- a/packages/core/src/api/common/configurable-operation-codec.spec.ts
+++ b/packages/core/src/api/common/configurable-operation-codec.spec.ts
@@ -1,0 +1,114 @@
+import { LanguageCode } from '@vendure/common/lib/generated-types';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ConfigService } from '../../config/config.service';
+import { MockConfigService } from '../../config/config.service.mock';
+import { AutoIncrementIdStrategy } from '../../config/entity/auto-increment-id-strategy';
+import { EntityIdStrategy } from '../../config/entity/entity-id-strategy';
+import { UuidIdStrategy } from '../../config/entity/uuid-id-strategy';
+import { PromotionCondition } from '../../config/promotion/promotion-condition';
+
+import { ConfigurableOperationCodec } from './configurable-operation-codec';
+import { IdCodecService } from './id-codec.service';
+
+/**
+ * A minimal PromotionCondition def exercising all three arg shapes the codec cares
+ * about: a non-list `ID`, a list `ID`, and a non-ID arg (which must be left alone).
+ */
+const testCondition = new PromotionCondition({
+    code: 'test_condition',
+    description: [{ languageCode: LanguageCode.en, value: 'test' }],
+    args: {
+        singleId: { type: 'ID' },
+        manyIds: { type: 'ID', list: true },
+        label: { type: 'string' },
+    },
+    check: () => true,
+});
+
+function createCodec(idStrategy: EntityIdStrategy<any>): ConfigurableOperationCodec {
+    const configService = new MockConfigService() as unknown as ConfigService;
+    (configService as any).entityIdStrategy = idStrategy;
+    (configService as any).entityOptions = {};
+    configService.promotionOptions.promotionConditions = [testCondition];
+    const idCodecService = new IdCodecService(configService);
+    return new ConfigurableOperationCodec(configService, idCodecService);
+}
+
+describe('ConfigurableOperationCodec', () => {
+    describe('encodeConfigurableOperationIds()', () => {
+        // #4886: a non-list ID must be encoded *raw* (no JSON.stringify), so that a
+        // read → save round-trip does not re-quote the id. Decode reads raw since
+        // #2483, so encode must be symmetric.
+        it('encodes a non-list ID as a raw string with AutoIncrementIdStrategy', () => {
+            const codec = createCodec(new AutoIncrementIdStrategy());
+
+            const [result] = codec.encodeConfigurableOperationIds(PromotionCondition, [
+                { code: 'test_condition', args: [{ name: 'singleId', value: '1' }] },
+            ] as any);
+
+            // bare '1', NOT '"1"'
+            expect(result.args[0].value).toBe('1');
+        });
+
+        it('encodes a non-list ID as a raw string with UuidIdStrategy', () => {
+            const codec = createCodec(new UuidIdStrategy());
+            const uuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+
+            const [result] = codec.encodeConfigurableOperationIds(PromotionCondition, [
+                { code: 'test_condition', args: [{ name: 'singleId', value: uuid }] },
+            ] as any);
+
+            // bare uuid, NOT '"<uuid>"' — the pre-fix double-quoting also corrupted uuids
+            expect(result.args[0].value).toBe(uuid);
+        });
+
+        it('still JSON-stringifies a list of IDs', () => {
+            const codec = createCodec(new AutoIncrementIdStrategy());
+
+            const [result] = codec.encodeConfigurableOperationIds(PromotionCondition, [
+                { code: 'test_condition', args: [{ name: 'manyIds', value: JSON.stringify(['1', '2']) }] },
+            ] as any);
+
+            expect(result.args[0].value).toBe(JSON.stringify(['1', '2']));
+        });
+
+        it('leaves non-ID args untouched', () => {
+            const codec = createCodec(new AutoIncrementIdStrategy());
+
+            const [result] = codec.encodeConfigurableOperationIds(PromotionCondition, [
+                { code: 'test_condition', args: [{ name: 'label', value: 'hello' }] },
+            ] as any);
+
+            expect(result.args[0].value).toBe('hello');
+        });
+    });
+
+    describe('encode → decode round-trip', () => {
+        // The regression guard for #4856: a value that has been encoded (as it is when
+        // sent to the client) must decode back to the original raw primary key, with no
+        // quote accumulation. Before the fix, encode produced '"1"' / '"<uuid>"' which
+        // decode then mis-read (AutoIncrement → -1, uuid → still-quoted).
+        function roundTrips(idStrategy: EntityIdStrategy<any>, rawId: string) {
+            const codec = createCodec(idStrategy);
+
+            const [encoded] = codec.encodeConfigurableOperationIds(PromotionCondition, [
+                { code: 'test_condition', args: [{ name: 'singleId', value: rawId }] },
+            ] as any);
+            const [decoded] = codec.decodeConfigurableOperationIds(PromotionCondition, [
+                { code: 'test_condition', arguments: [{ name: 'singleId', value: encoded.args[0].value }] },
+            ] as any);
+
+            return decoded.arguments[0].value;
+        }
+
+        it('round-trips a non-list ID with AutoIncrementIdStrategy', () => {
+            expect(roundTrips(new AutoIncrementIdStrategy(), '1')).toBe(1);
+        });
+
+        it('round-trips a non-list ID with UuidIdStrategy', () => {
+            const uuid = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+            expect(roundTrips(new UuidIdStrategy(), uuid)).toBe(uuid);
+        });
+    });
+});

--- a/packages/core/src/api/common/configurable-operation-codec.ts
+++ b/packages/core/src/api/common/configurable-operation-codec.ts
@@ -72,8 +72,12 @@ export class ConfigurableOperationCodec {
                         const encodedIds = ids.map(id => this.idCodecService.encode(id));
                         arg.value = JSON.stringify(encodedIds);
                     } else {
-                        const encodedId = this.idCodecService.encode(arg.value);
-                        arg.value = JSON.stringify(encodedId);
+                        // Non-list IDs are stored raw (not JSON-stringified) to stay
+                        // symmetric with the decode branch, which reads them raw since
+                        // #2483 (47f606cc). Stringifying here re-quotes the id on a
+                        // read → save round-trip (e.g. `'T_1'` → `'"T_1"'`), which then
+                        // mis-decodes on the way back in — the root cause of #4856.
+                        arg.value = this.idCodecService.encode(arg.value);
                     }
                 }
             }


### PR DESCRIPTION
# Description

Fixes #4856.

The non-list branch of `encodeConfigurableOperationIds` wrapped the encoded id in `JSON.stringify`:

```ts
} else {
    const encodedId = this.idCodecService.encode(arg.value);
    arg.value = JSON.stringify(encodedId);   // ← re-quotes the id
}
```

Since #2483 (`47f606cc`), the matching **decode** branch reads non-list ids *raw* (no `JSON.parse`), and `coerceValueToType` also reads `ID` back raw (`case 'ID': return value`). So the two sides were asymmetric: encode emitted `'"T_1"'` while decode expected `'T_1'`.

A **read → save round-trip** — which the dashboard performs on any edit — therefore takes a raw id out of the DB, re-quotes it on the way to the client, and mis-decodes the quoted value on the way back in. With `AutoIncrementIdStrategy`, `+'"1"'` → `NaN` → `-1`, so the referenced entity id is silently replaced with an invalid one; with opaque (uuid/base64) ids the quotes simply accumulate. This is why a promotion's assigned customer group disappears after editing: the first save already stores the corrupted value, so on the next load the group shows as empty.

The fix makes **encode** symmetric with the raw decode by dropping the `JSON.stringify`:

```ts
} else {
    arg.value = this.idCodecService.encode(arg.value);
}
```

## Why the encode side (not decode)

This started as a decode-side change (re-adding `JSON.parse`/`JSON.stringify` to the non-list decode branch). That was the wrong layer: it reverts #2483 (reintroducing #2019, where quoted uuids break lookups) and throws on the bare values the admin-ui and e2e actually send (`JSON.parse('T_1')` → `Unexpected token 'T'`). Thanks to @grolmus for catching this and pointing at the real culprit — the asymmetry lives on the encode side. Fixing it there resolves #4856 without touching #2483, without breaking bare input, and consistently with the raw read-back in `coerceValueToType`.

## Backward compatibility

No migration needed. The encode output is only ever produced on the way *out* to a client — it is never persisted; the DB stores the decoded bare primary key. So there is no stored data in the old `'"..."'` shape to migrate, and the decode branch is deliberately left untouched (adding a legacy-quoted tolerance there would re-break #2019). The list branch is also unchanged.

Incidentally this also fixes a latent bug the original issue didn't mention: before this change, a non-list uuid id was double-quoted on encode too, so the fix is slightly broader than the customer-group case.

# Breaking changes

None.

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single fix
- [x] I have checked my own PR
- [x] I have added test cases:
  - `configurable-operation-codec.spec.ts` (the codec had no prior unit tests): raw non-list encode for `AutoIncrementIdStrategy` and `UuidIdStrategy`, the encode → decode round-trip, and the unaffected list branch.
  - `order-promotion.e2e-spec.ts`: a `customerGroup` read-back → re-save round-trip guarding #4856 end-to-end.

### 🤖 AI assistance

Investigated and implemented with the help of Claude Code. I reproduced the bug against a local dev server, traced the root cause to the id-codec layer, and verified the fix end-to-end locally (Bun + core build + the e2e suite on sqljs, plus the new unit spec — including confirming the unit tests fail on the un-fixed code and the full `order-promotion` e2e suite stays green). I reviewed every change myself.
