### PR TITLE
fix(dashboard): preserve configurable ID args

### DIFF
--- a/packages/dashboard/src/lib/framework/form-engine/value-transformers.spec.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/value-transformers.spec.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+
+import type { ConfigurableFieldDef } from './form-engine-types.js';
+import { jsonStringValueTransformer } from './value-transformers.js';
+
+const fieldDef = (overrides: Partial<ConfigurableFieldDef>): ConfigurableFieldDef =>
+    ({
+        name: 'test',
+        type: 'string',
+        list: false,
+        ...overrides,
+    }) as ConfigurableFieldDef;
+
+describe('jsonStringValueTransformer', () => {
+    it('does not JSON-parse scalar ID values', () => {
+        const def = fieldDef({ type: 'ID' });
+
+        expect(jsonStringValueTransformer.parse('3', def)).toBe('3');
+        expect(jsonStringValueTransformer.parse('001', def)).toBe('001');
+    });
+
+    it('serializes scalar ID values as opaque strings', () => {
+        const def = fieldDef({ type: 'ID' });
+
+        expect(jsonStringValueTransformer.serialize('3', def)).toBe('3');
+        expect(jsonStringValueTransformer.serialize(3, def)).toBe('3');
+    });
+});

--- a/packages/dashboard/src/lib/framework/form-engine/value-transformers.spec.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/value-transformers.spec.ts
@@ -25,4 +25,11 @@ describe('jsonStringValueTransformer', () => {
         expect(jsonStringValueTransformer.serialize('3', def)).toBe('3');
         expect(jsonStringValueTransformer.serialize(3, def)).toBe('3');
     });
+
+    it('preserves JSON array serialization for list ID values', () => {
+        const def = fieldDef({ type: 'ID', list: true });
+
+        expect(jsonStringValueTransformer.serialize(['3', '4'], def)).toBe('["3","4"]');
+        expect(jsonStringValueTransformer.serialize('["3","4"]', def)).toBe('["3","4"]');
+    });
 });

--- a/packages/dashboard/src/lib/framework/form-engine/value-transformers.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/value-transformers.ts
@@ -93,6 +93,9 @@ export const jsonStringValueTransformer: ValueTransformer = {
             case 'string':
                 return typeof value === 'string' ? value : JSON.stringify(value);
             case 'ID':
+                if (fieldDef.list) {
+                    return typeof value === 'string' ? value : JSON.stringify(value);
+                }
                 return typeof value === 'string' ? value : String(value);
             default:
                 // For complex values (arrays, objects), serialize as JSON

--- a/packages/dashboard/src/lib/framework/form-engine/value-transformers.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/value-transformers.ts
@@ -1,4 +1,4 @@
-import { ConfigurableFieldDef } from '@/vdb/framework/form-engine/form-engine-types.js';
+import type { ConfigurableFieldDef } from '@/vdb/framework/form-engine/form-engine-types.js';
 
 export type ValueMode = 'native' | 'json-string';
 
@@ -40,9 +40,10 @@ export const jsonStringValueTransformer: ValueTransformer = {
             return value;
         }
 
-        // For scalar string fields, return the raw value without JSON parsing.
+        // For scalar string-like fields, return the raw value without JSON parsing.
         // This prevents issues like "0" being parsed as number 0, or "-0" becoming -0 which is "0" in the input.
-        if (fieldDef.type === 'string' && !fieldDef.list) {
+        // GraphQL ID values are opaque identifiers, so numeric-looking IDs must stay as strings too.
+        if ((fieldDef.type === 'string' || fieldDef.type === 'ID') && !fieldDef.list) {
             return value;
         }
 
@@ -91,6 +92,8 @@ export const jsonStringValueTransformer: ValueTransformer = {
                     : (Number.parseFloat(value) || 0).toString();
             case 'string':
                 return typeof value === 'string' ? value : JSON.stringify(value);
+            case 'ID':
+                return typeof value === 'string' ? value : String(value);
             default:
                 // For complex values (arrays, objects), serialize as JSON
                 return typeof value === 'string' ? value : JSON.stringify(value);


### PR DESCRIPTION
## What

Fixes #4856.

This updates the dashboard form value transformer so scalar `ID` configurable-operation args are treated like opaque string values instead of being parsed through `JSON.parse`.

## Why

Promotion conditions store their configured arguments as strings. The customer-group condition uses a `customerGroupId` argument whose GraphQL type is `ID`. Since GraphQL IDs are opaque identifiers, a value such as `"3"` should stay a string all the way into custom form inputs.

Before this change, the `jsonStringValueTransformer` only bypassed JSON parsing for scalar `string` fields. Numeric-looking `ID` values could therefore become numbers, which is a poor fit for relation-style inputs and can cause unrelated promotion updates, such as toggling `enabled`, to lose the selected customer group.

The narrowest fix is to preserve scalar `ID` args at the shared transformer boundary, rather than special-casing the promotion page or the customer-group input.

## Verification

- `git diff --check`
- `npx --yes vitest@3.2.4 run packages/dashboard/src/lib/framework/form-engine/value-transformers.spec.ts --environment node`
- `npx --yes prettier@3.2.5 --no-config --single-quote --tab-width 4 --print-width 110 --check packages/dashboard/src/lib/framework/form-engine/value-transformers.ts packages/dashboard/src/lib/framework/form-engine/value-transformers.spec.ts`
- Checked the touched files for common secret/token patterns before pushing.

I did not run the full dashboard test suite locally because this environment does not have the full Bun-installed Vendure dependency tree available.
