### PR TITLE
feat: pass nullable into many-to-one custom relations

### DIFF
--- a/docs/docs/guides/developer-guide/custom-fields/index.mdx
+++ b/docs/docs/guides/developer-guide/custom-fields/index.mdx
@@ -988,6 +988,9 @@ In addition to the common properties, the `relation` custom fields have some typ
 - [`eager`](#eager)
 - [`graphQLType`](#graphqltype)
 - [`inverseSide`](#inverseside)
+- [`cascade`](#cascade)
+- [`onDelete`](#ondelete)
+- [`onUpdate`](#onupdate)
 
 #### entity
 
@@ -1100,6 +1103,82 @@ const { productReviews } = await this.connection.getRepository(ProductReview).fi
     where: { id: 1 },
     relations: ['product'],
 });
+```
+
+#### cascade
+
+<CustomFieldProperty required={false} type="boolean | ('insert' | 'update' | 'remove' | 'soft-remove' | 'recover')[]" />
+
+Whether to [cascade](https://typeorm.io/docs/relations/relations#cascade-options) operations on the relation. Defaults to `false`.
+
+```ts title="src/vendure-config.ts"
+import { Product } from '\@vendure/core';
+import { ProductReview } from './entities/product-review.entity';
+
+const config = {
+    // ...
+    customFields: {
+        Product: [
+            {
+                name: 'reviews',
+                list: true,
+                type: 'relation',
+                entity: ProductReview,
+                cascade: ['insert', 'update'], // [!code highlight]
+            },
+        ]
+    }
+};
+```
+
+#### onDelete
+<CustomFieldProperty required={false} type="'RESTRICT' | 'CASCADE' | 'SET NULL' | 'NO ACTION' | 'SET DEFAULT'" />
+
+The [onDelete](https://typeorm.io/docs/relations/relations/) behavior for the relation. Defaults to `RESTRICT`.
+
+```ts title="src/vendure-config.ts"
+import { Product } from '\@vendure/core';
+import { ProductReview } from './entities/product-review.entity';
+
+const config = {
+    // ...
+    customFields: {
+        Product: [
+            {
+                name: 'reviews',
+                list: true,
+                type: 'relation',
+                entity: ProductReview,
+                onDelete: 'SET NULL', // [!code highlight]
+            },
+        ]
+    }
+};
+```
+
+#### onUpdate
+<CustomFieldProperty required={false} type="'RESTRICT' | 'CASCADE' | 'SET NULL' | 'NO ACTION' | 'SET DEFAULT'" />
+
+The [onUpdate](https://typeorm.io/docs/relations/relations/) behavior for the relation. Defaults to `RESTRICT`.
+
+```ts title="src/vendure-config.ts"
+import { Product } from '\@vendure/core';
+import { ProductReview } from './entities/product-review.entity';
+
+const config = {
+    // ...
+    customFields: {
+        Product: [
+            {
+                name: 'reviews',
+                list: true,
+                type: 'relation',
+                entity: ProductReview,
+                onUpdate: 'CASCADE', // [!code highlight]
+            },
+        ]
+    }
+};
 ```
 
 ## Custom Field UI

--- a/docs/docs/guides/developer-guide/custom-fields/index.mdx
+++ b/docs/docs/guides/developer-guide/custom-fields/index.mdx
@@ -1136,6 +1136,13 @@ const config = {
 
 The [onDelete](https://typeorm.io/docs/relations/relations/) behavior for the relation. Defaults to `RESTRICT`.
 
+:::note
+
+Setting `onDelete` to `CASCADE` will cause related entities to be deleted when the owning entity is deleted.
+This can have unintended consequences especially if the related entity is a core Vendure entity.
+For example, if you have a relation to `ProductVariant` and you set `onDelete: 'CASCADE'`, then deleting the owning entity will cause the related `ProductVariant` to be deleted.
+Use with caution.
+
 ```ts title="src/vendure-config.ts"
 import { Product } from '\@vendure/core';
 import { ProductReview } from './entities/product-review.entity';

--- a/docs/docs/guides/developer-guide/custom-fields/index.mdx
+++ b/docs/docs/guides/developer-guide/custom-fields/index.mdx
@@ -1138,9 +1138,9 @@ The [onDelete](https://typeorm.io/docs/relations/relations/) behavior for the re
 
 :::note
 
-Setting `onDelete` to `CASCADE` will cause related entities to be deleted when the owning entity is deleted.
-This can have unintended consequences especially if the related entity is a core Vendure entity.
-For example, if you have a relation to `ProductVariant` and you set `onDelete: 'CASCADE'`, then deleting the owning entity will cause the related `ProductVariant` to be deleted.
+Setting `onDelete` to `CASCADE` means that if the referenced entity is deleted, rows owning this relation may also be deleted by the database.
+This can have unintended consequences, especially when referencing core Vendure entities.
+For example, if you have a relation to `ProductVariant` and set `onDelete: 'CASCADE'`, deleting that `ProductVariant` can cascade to rows that reference it.
 Use with caution.
 
 ```ts title="src/vendure-config.ts"

--- a/docs/docs/guides/developer-guide/custom-fields/index.mdx
+++ b/docs/docs/guides/developer-guide/custom-fields/index.mdx
@@ -1134,7 +1134,7 @@ const config = {
 #### onDelete
 <CustomFieldProperty required={false} type="'RESTRICT' | 'CASCADE' | 'SET NULL' | 'NO ACTION' | 'SET DEFAULT'" />
 
-The [onDelete](https://typeorm.io/docs/relations/relations/) behavior for the relation. Defaults to `RESTRICT`.
+The [onDelete](https://typeorm.io/docs/relations/relations/) behavior for the relation. Defaults to `NO ACTION`.
 
 :::note
 
@@ -1142,6 +1142,8 @@ Setting `onDelete` to `CASCADE` means that if the referenced entity is deleted, 
 This can have unintended consequences, especially when referencing core Vendure entities.
 For example, if you have a relation to `ProductVariant` and set `onDelete: 'CASCADE'`, deleting that `ProductVariant` can cascade to rows that reference it.
 Use with caution.
+
+Setting `onDelete` on a `ManyToMany` (`list: true`) relation will affect the join table, but not the related entity.
 
 ```ts title="src/vendure-config.ts"
 import { Product } from '\@vendure/core';
@@ -1153,7 +1155,7 @@ const config = {
         Product: [
             {
                 name: 'reviews',
-                list: true,
+                list: false,
                 type: 'relation',
                 entity: ProductReview,
                 onDelete: 'SET NULL', // [!code highlight]
@@ -1166,7 +1168,10 @@ const config = {
 #### onUpdate
 <CustomFieldProperty required={false} type="'RESTRICT' | 'CASCADE' | 'SET NULL' | 'NO ACTION' | 'SET DEFAULT'" />
 
-The [onUpdate](https://typeorm.io/docs/relations/relations/) behavior for the relation. Defaults to `RESTRICT`.
+The [onUpdate](https://typeorm.io/docs/relations/relations/) behavior for the relation. If not set, the database default (`NO ACTION`) applies.
+`onUpdate` is not supported by SQLite and will be ignored if you are using SQLite as your database.
+
+Setting `onUpdate` on a `ManyToMany` (`list: true`) relation will affect the join table, but not the related entity.
 
 ```ts title="src/vendure-config.ts"
 import { Product } from '\@vendure/core';
@@ -1178,7 +1183,7 @@ const config = {
         Product: [
             {
                 name: 'reviews',
-                list: true,
+                list: false,
                 type: 'relation',
                 entity: ProductReview,
                 onUpdate: 'CASCADE', // [!code highlight]

--- a/docs/docs/guides/developer-guide/custom-fields/index.mdx
+++ b/docs/docs/guides/developer-guide/custom-fields/index.mdx
@@ -1138,7 +1138,7 @@ The [onDelete](https://typeorm.io/docs/relations/relations/) behavior for the re
 
 :::note
 
-Setting `onDelete` to `CASCADE` means that if the referenced entity is deleted, rows owning this relation may also be deleted by the database.
+Setting `onDelete` to `CASCADE` or `cascade: ['remove']` means that if the referenced entity is deleted, rows owning this relation may also be deleted.
 This can have unintended consequences, especially when referencing core Vendure entities.
 For example, if you have a relation to `ProductVariant` and set `onDelete: 'CASCADE'`, deleting that `ProductVariant` can cascade to rows that reference it.
 Use with caution.

--- a/docs/docs/reference/typescript-api/custom-fields/typed-custom-single-field-config.mdx
+++ b/docs/docs/reference/typescript-api/custom-fields/typed-custom-single-field-config.mdx
@@ -2,7 +2,7 @@
 title: "TypedCustomSingleFieldConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/custom-field/custom-field-types.ts" sourceLine="101" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/custom-field/custom-field-types.ts" sourceLine="102" packageName="@vendure/core" />
 
 Configures a custom field on an entity in the [CustomFields](/reference/typescript-api/custom-fields/#customfields) config object.
 

--- a/packages/core/src/config/custom-field/custom-field-types.ts
+++ b/packages/core/src/config/custom-field/custom-field-types.ts
@@ -28,6 +28,7 @@ import {
     Type,
     UiComponentConfig,
 } from '@vendure/common/lib/shared-types';
+import { RelationOptions } from 'typeorm';
 
 import { RequestContext } from '../../api/common/request-context';
 import { Injector } from '../../common/injector';
@@ -149,9 +150,8 @@ export type RelationCustomFieldConfig = TypedCustomFieldConfig<
 > & {
     entity: Type<VendureEntity>;
     graphQLType?: string;
-    eager?: boolean;
     inverseSide?: string | ((object: any) => any);
-};
+} & Pick<RelationOptions, 'cascade' | 'onDelete' | 'onUpdate' | 'eager'>;
 
 // Struct field definitions
 export type BaseTypedStructFieldConfig<T extends StructFieldType, C extends GraphQLStructField> = Omit<

--- a/packages/core/src/config/custom-field/custom-field-types.ts
+++ b/packages/core/src/config/custom-field/custom-field-types.ts
@@ -115,9 +115,10 @@ export type TypedCustomSingleFieldConfig<
 export type TypedCustomListFieldConfig<
     T extends CustomFieldType,
     C extends CustomField,
-> = BaseTypedCustomFieldConfig<T, C> & {
+> = Omit<BaseTypedCustomFieldConfig<T, C>, 'nullable'> & {
     list?: true;
     defaultValue?: Array<DefaultValueType<T>>;
+    nullable?: never;
     validate?: (
         value: Array<DefaultValueType<T>>,
     ) => string | LocalizedString[] | void | Promise<string | LocalizedString[] | void>;

--- a/packages/core/src/entity/register-custom-entity-fields.spec.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.spec.ts
@@ -1,0 +1,124 @@
+import { getMetadataArgsStorage } from 'typeorm';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { CustomFields } from '../config/custom-field/custom-field-types';
+import { VendureConfig } from '../config/vendure-config';
+
+import { Asset } from './asset/asset.entity';
+import { registerCustomEntityFields } from './register-custom-entity-fields';
+
+const SINGLE_RELATION_FIELD = '__testRelationOptionsSingle__';
+const LIST_RELATION_FIELD = '__testRelationOptionsList__';
+const NON_RELATION_FIELD = '__testRelationOptionsNonRelation__';
+
+describe('registerCustomEntityFields() relation options', () => {
+    beforeEach(() => {
+        removeTestMetadata();
+    });
+    it('applies cascade/onDelete/onUpdate/eager on many-to-one relation custom fields', () => {
+        registerCustomEntityFields(
+            createConfig({
+                Product: [
+                    { name: NON_RELATION_FIELD, type: 'string' },
+                    {
+                        name: SINGLE_RELATION_FIELD,
+                        type: 'relation',
+                        entity: Asset,
+                        cascade: true,
+                        onDelete: 'SET NULL',
+                        onUpdate: 'CASCADE',
+                        eager: true,
+                    },
+                ],
+            }),
+        );
+
+        const relation = getMetadataArgsStorage()
+            .filterRelations(getProductCustomFieldsClass())
+            .find(r => r.propertyName === SINGLE_RELATION_FIELD);
+
+        expect(relation?.relationType).toBe('many-to-one');
+        expect(relation?.options).toMatchObject({
+            cascade: true,
+            onDelete: 'SET NULL',
+            onUpdate: 'CASCADE',
+            eager: true,
+        });
+    });
+
+    it('applies cascade/onDelete/onUpdate/eager on many-to-many relation custom fields', () => {
+        registerCustomEntityFields(
+            createConfig({
+                Product: [
+                    { name: NON_RELATION_FIELD, type: 'string' },
+                    {
+                        name: LIST_RELATION_FIELD,
+                        type: 'relation',
+                        list: true,
+                        entity: Asset,
+                        cascade: ['insert', 'update'],
+                        onDelete: 'CASCADE',
+                        onUpdate: 'RESTRICT',
+                        eager: false,
+                    },
+                ],
+            }),
+        );
+
+        const relation = getMetadataArgsStorage()
+            .filterRelations(getProductCustomFieldsClass())
+            .find(r => r.propertyName === LIST_RELATION_FIELD);
+
+        expect(relation?.relationType).toBe('many-to-many');
+        expect(relation?.options).toMatchObject({
+            cascade: ['insert', 'update'],
+            onDelete: 'CASCADE',
+            onUpdate: 'RESTRICT',
+            eager: false,
+        });
+    });
+});
+
+function createConfig(customFields: CustomFields): VendureConfig {
+    return {
+        customFields,
+        dbConnectionOptions: {
+            type: 'sqlite',
+        },
+    } as VendureConfig;
+}
+
+function getProductCustomFieldsClass() {
+    const customFieldsEmbedded = getMetadataArgsStorage().embeddeds.find(item => {
+        if (item.propertyName !== 'customFields') {
+            return false;
+        }
+        const targetName = typeof item.target === 'string' ? item.target : item.target.name;
+        return targetName === 'Product';
+    });
+    if (!customFieldsEmbedded) {
+        throw new Error('Could not find Product customFields embedded metadata');
+    }
+    const customFieldsClass = customFieldsEmbedded.type();
+    if (typeof customFieldsClass === 'string') {
+        throw new Error('Expected Product customFields embedded type to be a class');
+    }
+    return customFieldsClass;
+}
+
+/**
+ * Removes the metadata added by the tests in this file, to prevent pollution of other tests which use the same entity.
+ */
+function removeTestMetadata() {
+    const metadata = getMetadataArgsStorage();
+    const fieldNames = [SINGLE_RELATION_FIELD, LIST_RELATION_FIELD, NON_RELATION_FIELD];
+
+    // @ts-ignore - accessing protected properties for test cleanup
+    metadata.relations = metadata.relations.filter(r => !fieldNames.includes(r.propertyName));
+    // @ts-ignore - accessing protected properties for test cleanup
+    metadata.columns = metadata.columns.filter(c => !fieldNames.includes(c.propertyName));
+    // @ts-ignore - accessing protected properties for test cleanup
+    metadata.joinTables = metadata.joinTables.filter(jt => !fieldNames.includes(jt.propertyName));
+    // @ts-ignore - accessing protected properties for test cleanup
+    metadata.joinColumns = metadata.joinColumns.filter(jc => !fieldNames.includes(jc.propertyName));
+}

--- a/packages/core/src/entity/register-custom-entity-fields.spec.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.spec.ts
@@ -1,20 +1,37 @@
 import { getMetadataArgsStorage } from 'typeorm';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
 
 import { CustomFields } from '../config/custom-field/custom-field-types';
 import { VendureConfig } from '../config/vendure-config';
 
 import { Asset } from './asset/asset.entity';
 import { registerCustomEntityFields } from './register-custom-entity-fields';
+import { VendureEntity } from './base/base.entity';
+import { DeepPartial } from '@vendure/common/lib/shared-types';
+import { Logger } from '../config';
 
 const SINGLE_RELATION_FIELD = '__testRelationOptionsSingle__';
 const LIST_RELATION_FIELD = '__testRelationOptionsList__';
 const NON_RELATION_FIELD = '__testRelationOptionsNonRelation__';
 
+class TestEntity extends VendureEntity {
+        constructor(input?: DeepPartial<TestEntity>) {
+            super(input);
+        }
+    customFields: any;
+}
+
 describe('registerCustomEntityFields() relation options', () => {
-    beforeEach(() => {
+    const mockLoggerWarn = vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+
+    afterEach(() => {
         removeTestMetadata();
     });
+
+    afterAll(() => {
+        mockLoggerWarn.mockRestore();
+    });
+
     it('applies cascade/onDelete/onUpdate/eager on many-to-one relation custom fields', () => {
         registerCustomEntityFields(
             createConfig({
@@ -23,7 +40,7 @@ describe('registerCustomEntityFields() relation options', () => {
                     {
                         name: SINGLE_RELATION_FIELD,
                         type: 'relation',
-                        entity: Asset,
+                        entity: TestEntity,
                         cascade: true,
                         onDelete: 'SET NULL',
                         onUpdate: 'CASCADE',
@@ -38,7 +55,7 @@ describe('registerCustomEntityFields() relation options', () => {
             .find(r => r.propertyName === SINGLE_RELATION_FIELD);
 
         expect(relation?.relationType).toBe('many-to-one');
-        expect(relation?.options).toMatchObject({
+        expect(relation?.options).toEqual({
             cascade: true,
             onDelete: 'SET NULL',
             onUpdate: 'CASCADE',
@@ -55,7 +72,7 @@ describe('registerCustomEntityFields() relation options', () => {
                         name: LIST_RELATION_FIELD,
                         type: 'relation',
                         list: true,
-                        entity: Asset,
+                        entity: TestEntity,
                         cascade: ['insert', 'update'],
                         onDelete: 'CASCADE',
                         onUpdate: 'RESTRICT',
@@ -70,12 +87,143 @@ describe('registerCustomEntityFields() relation options', () => {
             .find(r => r.propertyName === LIST_RELATION_FIELD);
 
         expect(relation?.relationType).toBe('many-to-many');
-        expect(relation?.options).toMatchObject({
+        expect(relation?.options).toEqual({
             cascade: ['insert', 'update'],
             onDelete: 'CASCADE',
             onUpdate: 'RESTRICT',
             eager: false,
         });
+    });
+
+    it('applies default options on relation custom fields', () => {
+        registerCustomEntityFields(
+            createConfig({
+                Product: [
+                    { name: NON_RELATION_FIELD, type: 'string' },
+                    {
+                        name: LIST_RELATION_FIELD,
+                        type: 'relation',
+                        entity: TestEntity,
+                    },
+                ],
+            }),
+        );
+
+        const relation = getMetadataArgsStorage()
+            .filterRelations(getProductCustomFieldsClass())
+            .find(r => r.propertyName === LIST_RELATION_FIELD);
+
+        expect(relation?.relationType).toBe('many-to-one');
+        expect(relation?.options).toEqual({
+            cascade: undefined,
+            onDelete: undefined,
+            onUpdate: undefined,
+            eager: undefined,
+        });
+    });
+
+    it('warns if onDelete: \'CASCADE\' is affecting core Vendure entities', () => {
+        registerCustomEntityFields(
+            createConfig({
+                Product: [
+                    { name: NON_RELATION_FIELD, type: 'string' },
+                    {
+                        name: LIST_RELATION_FIELD,
+                        type: 'relation',
+                        list: false,
+                        entity: Asset,
+                        onDelete: 'CASCADE',
+                        eager: false,
+                    },
+                ],
+            }),
+        );
+
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+            [
+                `WARNING: You have set "onDelete: 'CASCADE'" on a custom field relation to the "Asset" entity.`,
+                `With this FK behavior, deleting a "Asset" row can delete owning rows that reference it.`,
+                `Please verify this is intended, especially when targeting core Vendure entities.`,
+            ].join('\n'),
+        );
+    });
+
+    it('warns if cascade: ["remove"] is affecting core Vendure entities', () => {
+        registerCustomEntityFields(
+            createConfig({
+                Product: [
+                    { name: NON_RELATION_FIELD, type: 'string' },
+                    {
+                        name: LIST_RELATION_FIELD,
+                        type: 'relation',
+                        list: false,
+                        entity: Asset,
+                        cascade: ['remove'],
+                        eager: false,
+                    },
+                ],
+            }),
+        );
+
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+            [
+                `WARNING: You have set "cascade: ['remove' | 'soft-remove']" on a custom field relation to the "Asset" entity.`,
+                `With this behavior, deleting a "Asset" row can delete owning rows that reference it.`,
+                `Please verify this is intended, especially when targeting core Vendure entities.`,
+            ].join('\n'),
+        );
+    });
+
+    it('warns if cascade: ["soft-remove"] is affecting core Vendure entities', () => {
+        registerCustomEntityFields(
+            createConfig({
+                Product: [
+                    { name: NON_RELATION_FIELD, type: 'string' },
+                    {
+                        name: LIST_RELATION_FIELD,
+                        type: 'relation',
+                        list: false,
+                        entity: Asset,
+                        cascade: ['soft-remove'],
+                        eager: false,
+                    },
+                ],
+            }),
+        );
+
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+            [
+                `WARNING: You have set "cascade: ['remove' | 'soft-remove']" on a custom field relation to the "Asset" entity.`,
+                `With this behavior, deleting a "Asset" row can delete owning rows that reference it.`,
+                `Please verify this is intended, especially when targeting core Vendure entities.`,
+            ].join('\n'),
+        );
+    });
+
+    it('warns if cascade: true is affecting core Vendure entities', () => {
+        registerCustomEntityFields(
+            createConfig({
+                Product: [
+                    { name: NON_RELATION_FIELD, type: 'string' },
+                    {
+                        name: LIST_RELATION_FIELD,
+                        type: 'relation',
+                        list: false,
+                        entity: Asset,
+                        cascade: true,
+                        eager: false,
+                    },
+                ],
+            }),
+        );
+
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
+            [
+                `WARNING: You have set "cascade: ['remove' | 'soft-remove']" on a custom field relation to the "Asset" entity.`,
+                `With this behavior, deleting a "Asset" row can delete owning rows that reference it.`,
+                `Please verify this is intended, especially when targeting core Vendure entities.`,
+            ].join('\n'),
+        );
     });
 });
 

--- a/packages/core/src/entity/register-custom-entity-fields.spec.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.spec.ts
@@ -1,14 +1,14 @@
+import { DeepPartial } from '@vendure/common/lib/shared-types';
 import { getMetadataArgsStorage } from 'typeorm';
-import { afterAll, afterEach, describe, expect, it, vi } from 'vitest';
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import { Logger } from '../config';
 import { CustomFields } from '../config/custom-field/custom-field-types';
 import { VendureConfig } from '../config/vendure-config';
 
 import { Asset } from './asset/asset.entity';
-import { registerCustomEntityFields } from './register-custom-entity-fields';
 import { VendureEntity } from './base/base.entity';
-import { DeepPartial } from '@vendure/common/lib/shared-types';
-import { Logger } from '../config';
+import { registerCustomEntityFields } from './register-custom-entity-fields';
 
 const SINGLE_RELATION_FIELD = '__testRelationOptionsSingle__';
 const LIST_RELATION_FIELD = '__testRelationOptionsList__';
@@ -22,13 +22,14 @@ class TestEntity extends VendureEntity {
 }
 
 describe('registerCustomEntityFields() relation options', () => {
-    const mockLoggerWarn = vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+    let mockLoggerWarn: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+        mockLoggerWarn = vi.spyOn(Logger, 'warn').mockImplementation(() => undefined);
+    });
 
     afterEach(() => {
         removeTestMetadata();
-    });
-
-    afterAll(() => {
         mockLoggerWarn.mockRestore();
     });
 
@@ -224,6 +225,48 @@ describe('registerCustomEntityFields() relation options', () => {
                 `Please verify this is intended, especially when targeting core Vendure entities.`,
             ].join('\n'),
         );
+    });
+
+    it('should not warn if cascading is not affecting core entities', () => {
+        registerCustomEntityFields(
+            createConfig({
+                Product: [
+                    { name: NON_RELATION_FIELD, type: 'string' },
+                    {
+                        name: LIST_RELATION_FIELD,
+                        type: 'relation',
+                        list: false,
+                        entity: TestEntity,
+                        cascade: true,
+                        onDelete: 'CASCADE',
+                        eager: false,
+                    },
+                ],
+            }),
+        );
+
+        expect(mockLoggerWarn).toBeCalledTimes(0);
+    });
+
+    it('should not warn if cascading is affecting join tables', () => {
+        registerCustomEntityFields(
+            createConfig({
+                Product: [
+                    { name: NON_RELATION_FIELD, type: 'string' },
+                    {
+                        name: LIST_RELATION_FIELD,
+                        type: 'relation',
+                        list: true,
+                        entity: Asset,
+                        cascade: true,
+                        onDelete: 'CASCADE',
+                        eager: false,
+                    },
+                ],
+            }),
+        );
+
+        expect(mockLoggerWarn).toBeCalledTimes(0);
     });
 });
 

--- a/packages/core/src/entity/register-custom-entity-fields.spec.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.spec.ts
@@ -33,7 +33,7 @@ describe('registerCustomEntityFields() relation options', () => {
         mockLoggerWarn.mockRestore();
     });
 
-    it('applies cascade/onDelete/onUpdate/eager on many-to-one relation custom fields', () => {
+    it('applies cascade/onDelete/onUpdate/eager/nullable on many-to-one relation custom fields', () => {
         registerCustomEntityFields(
             createConfig({
                 Product: [
@@ -46,6 +46,7 @@ describe('registerCustomEntityFields() relation options', () => {
                         onDelete: 'SET NULL',
                         onUpdate: 'CASCADE',
                         eager: true,
+                        nullable: true,
                     },
                 ],
             }),
@@ -61,6 +62,7 @@ describe('registerCustomEntityFields() relation options', () => {
             onDelete: 'SET NULL',
             onUpdate: 'CASCADE',
             eager: true,
+            nullable: true,
         });
     });
 
@@ -267,6 +269,30 @@ describe('registerCustomEntityFields() relation options', () => {
         );
 
         expect(mockLoggerWarn).toBeCalledTimes(0);
+    });
+
+    it('should ignore nullable on list relation fields', () => {
+        registerCustomEntityFields(
+            createConfig({
+                Product: [
+                    // @ts-expect-error -- nullable is not a valid option for many-to-many relations
+                    {
+                        name: LIST_RELATION_FIELD,
+                        type: 'relation',
+                        list: true,
+                        entity: Asset,
+                        nullable: true,
+                    },
+                ],
+            }),
+        );
+
+        const relation = getMetadataArgsStorage()
+            .filterRelations(getProductCustomFieldsClass())
+            .find(r => r.propertyName === LIST_RELATION_FIELD);
+
+        expect(relation?.relationType).toBe('many-to-many');
+        expect(relation?.options.nullable).toBeUndefined();
     });
 });
 

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -43,14 +43,23 @@ function registerCustomFieldsForEntity(
             const instance = new ctor();
             const registerColumn = () => {
                 if (customField.type === 'relation') {
+                    const { cascade, onDelete, onUpdate, eager } = customField;
                     if (customField.list) {
                         ManyToMany(type => customField.entity, customField.inverseSide, {
-                            eager: customField.eager,
+                            nullable,
+                            cascade,
+                            onDelete,
+                            onUpdate,
+                            eager,
                         })(instance, name);
                         JoinTable()(instance, name);
                     } else {
                         ManyToOne(type => customField.entity, customField.inverseSide, {
-                            eager: customField.eager,
+                            nullable,
+                            cascade,
+                            onDelete,
+                            onUpdate,
+                            eager,
                         })(instance, name);
                         JoinColumn()(instance, name);
                     }

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -51,10 +51,9 @@ function registerCustomFieldsForEntity(
                     if (onDelete === 'CASCADE' && relatedEntityName in coreEntitiesMap) {
                         Logger.warn(
                             [
-                                `WARNING: You have set "onDelete: 'CASCADE'" on a custom field relation to the "${relatedEntityName}" entity. `,
-                                `This is not recommended as it may cause unexpected data loss. The "${relatedEntityName}" entity is a core Vendure entity,` +
-                                    `and cascading deletes from a custom entity to a core entity may have unintended consequences. `,
-                                `Please reconsider whether you really want to use "CASCADE" in this case.`,
+                                `WARNING: You have set "onDelete: 'CASCADE'" on a custom field relation to the "${relatedEntityName}" entity.`,
+                                `With this FK behavior, deleting a "${relatedEntityName}" row can delete owning rows that reference it.`,
+                                `Please verify this is intended, especially when targeting core Vendure entities.`,
                             ].join('\n'),
                         );
                     }

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -20,6 +20,8 @@ import { CustomFieldConfig, CustomFields } from '../config/custom-field/custom-f
 import { Logger } from '../config/logger/vendure-logger';
 import { VendureConfig } from '../config/vendure-config';
 
+import { coreEntitiesMap } from './entities';
+
 /**
  * The maximum length of the "length" argument of a MySQL varchar column.
  */
@@ -44,6 +46,18 @@ function registerCustomFieldsForEntity(
             const registerColumn = () => {
                 if (customField.type === 'relation') {
                     const { cascade, onDelete, onUpdate, eager } = customField;
+                    const relatedEntityName = customField.entity.name;
+
+                    if (onDelete === 'CASCADE' && relatedEntityName in coreEntitiesMap) {
+                        Logger.warn(
+                            [
+                                `WARNING: You have set "onDelete: 'CASCADE'" on a custom field relation to the "${relatedEntityName}" entity. `,
+                                `This is not recommended as it may cause unexpected data loss. The "${relatedEntityName}" entity is a core Vendure entity,` +
+                                    `and cascading deletes from a custom entity to a core entity may have unintended consequences. `,
+                                `Please reconsider whether you really want to use "CASCADE" in this case.`,
+                            ].join('\n'),
+                        );
+                    }
                     if (customField.list) {
                         ManyToMany(type => customField.entity, customField.inverseSide, {
                             cascade,

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -41,7 +41,7 @@ function registerCustomFieldsForEntity(
     const dbEngine = config.dbConnectionOptions.type;
     if (customFields) {
         for (const customField of customFields) {
-            const { name, list, defaultValue, nullable } = customField;
+            const { name, list, nullable } = customField;
             const instance = new ctor();
             const registerColumn = () => {
                 if (customField.type === 'relation') {

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -46,7 +46,6 @@ function registerCustomFieldsForEntity(
                     const { cascade, onDelete, onUpdate, eager } = customField;
                     if (customField.list) {
                         ManyToMany(type => customField.entity, customField.inverseSide, {
-                            nullable,
                             cascade,
                             onDelete,
                             onUpdate,

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -48,7 +48,7 @@ function registerCustomFieldsForEntity(
                     const { cascade, onDelete, onUpdate, eager } = customField;
                     const relatedEntityName = customField.entity.name;
 
-                    if (onDelete === 'CASCADE' && relatedEntityName in coreEntitiesMap) {
+                    if (onDelete === 'CASCADE' && relatedEntityName in coreEntitiesMap && list !== true) {
                         Logger.warn(
                             [
                                 `WARNING: You have set "onDelete: 'CASCADE'" on a custom field relation to the "${relatedEntityName}" entity.`,
@@ -58,9 +58,11 @@ function registerCustomFieldsForEntity(
                         );
                     }
                     if (
-                        cascade === true ||
-                        (Array.isArray(cascade) && (cascade.includes('remove') || cascade.includes('soft-remove'))) &&
-                        relatedEntityName in coreEntitiesMap
+                        (cascade === true ||
+                            (Array.isArray(cascade) && (cascade.includes('remove') || cascade.includes('soft-remove')))) &&
+                        relatedEntityName in coreEntitiesMap &&
+                        list !== true
+
                     ) {
                         Logger.warn(
                             [

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -86,6 +86,7 @@ function registerCustomFieldsForEntity(
                             onDelete,
                             onUpdate,
                             eager,
+                            nullable,
                         })(instance, name);
                         JoinColumn()(instance, name);
                     }

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -67,7 +67,6 @@ function registerCustomFieldsForEntity(
                         JoinTable()(instance, name);
                     } else {
                         ManyToOne(type => customField.entity, customField.inverseSide, {
-                            nullable,
                             cascade,
                             onDelete,
                             onUpdate,

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -57,6 +57,19 @@ function registerCustomFieldsForEntity(
                             ].join('\n'),
                         );
                     }
+                    if (
+                        cascade === true ||
+                        (Array.isArray(cascade) && (cascade.includes('remove') || cascade.includes('soft-remove'))) &&
+                        relatedEntityName in coreEntitiesMap
+                    ) {
+                        Logger.warn(
+                            [
+                                `WARNING: You have set "cascade: ['remove' | 'soft-remove']" on a custom field relation to the "${relatedEntityName}" entity.`,
+                                `With this behavior, deleting a "${relatedEntityName}" row can delete owning rows that reference it.`,
+                                `Please verify this is intended, especially when targeting core Vendure entities.`,
+                            ].join('\n'),
+                        );
+                    }
                     if (customField.list) {
                         ManyToMany(type => customField.entity, customField.inverseSide, {
                             cascade,


### PR DESCRIPTION
# Description

Adds the `nullable` option to ManyToOne relational custom fields.

Please see @grolmus comments in https://github.com/vendurehq/vendure/pull/4448 regarding the nullable behaviour. the changes of the nullable options were removed from #4448 and moved into this PR as a separate change set.

# Breaking changes

This can be seen as breaking because it was already possible to set `nullable: true` on custom fields of type "relation", but the option was silently ignore. There is a risk that users have already set `nullable: true` on custom fields which will change DB behaviour after an upgrade.

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [ ] My PR is small and contains a single feature
- [ ] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4895"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785322443&installation_id=128408429&pr_number=4895&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4895&signature=6c3d256a9fa4efedc0d970b4a8dc7eddf72dae63519ca1f35e7ba6113999b401"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->