### PR TITLE
test(create): Fix stale dev script assertion after master into minor merge

### DIFF
--- a/docs/docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx
+++ b/docs/docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## vendureDashboardPlugin
 
-<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="196" packageName="@vendure/dashboard" since="3.4.0" />
+<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="225" packageName="@vendure/dashboard" since="3.4.0" />
 
 This is the Vite plugin which powers the Vendure Dashboard, including:
 
@@ -23,7 +23,7 @@ Parameters
 
 ## VitePluginVendureDashboardOptions
 
-<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="34" packageName="@vendure/dashboard" since="3.4.0" />
+<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="38" packageName="@vendure/dashboard" since="3.4.0" />
 
 Options for the [vendureDashboardPlugin](/reference/dashboard/vite-plugin/vendure-dashboard-plugin#venduredashboardplugin) Vite plugin.
 
@@ -86,6 +86,31 @@ type VitePluginVendureDashboardOptions = {
      */
     gqlOutputPath?: string;
     tempCompilationDir?: string;
+    /**
+     * @description
+     * Options passed to the underlying TanStack Router Vite plugin (`tanstackRouter()`). These are
+     * merged on top of the Dashboard's own defaults, letting you override most aspects of the router
+     * plugin's configuration. The `routesDirectory`, `generatedRouteTree` and `routeFileIgnorePattern`
+     * settings are managed by the Dashboard and cannot be overridden (attempts are ignored with a warning).
+     *
+     * A common use case is setting `tmpDir` when your deployment's default temp directory is on a
+     * different device than the checked-out code (e.g. `node_modules` on a separate volume), which
+     * otherwise causes the build to fail with `EXDEV: cross-device link not permitted` during
+     * route-tree generation.
+     *
+     * @example
+     * ```ts
+     * vendureDashboardPlugin({
+     *   vendureConfigPath: './vendure-config.ts',
+     *   tanstackRouterPluginOptions: {
+     *     tmpDir: path.join(packageRoot, '.tanstack-tmp'),
+     *   },
+     * })
+     * ```
+     *
+     * @since 3.7.0
+     */
+    tanstackRouterPluginOptions?: TanstackRouterPluginOptions;
     /**
      * @description
      * Allows you to customize the location of node_modules & glob patterns used to scan for potential

--- a/docs/docs/reference/typescript-api/assets/asset-options.mdx
+++ b/docs/docs/reference/typescript-api/assets/asset-options.mdx
@@ -2,7 +2,7 @@
 title: "AssetOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="727" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="738" packageName="@vendure/core" />
 
 The AssetOptions define how assets (images and other files) are named and stored, and how preview images are generated.
 

--- a/docs/docs/reference/typescript-api/auth/auth-options.mdx
+++ b/docs/docs/reference/typescript-api/auth/auth-options.mdx
@@ -2,7 +2,7 @@
 title: "AuthOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="364" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="365" packageName="@vendure/core" />
 
 The AuthOptions define how authentication and authorization is managed.
 

--- a/docs/docs/reference/typescript-api/auth/cookie-options.mdx
+++ b/docs/docs/reference/typescript-api/auth/cookie-options.mdx
@@ -2,7 +2,7 @@
 title: "CookieOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="259" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="260" packageName="@vendure/core" />
 
 Options for the handling of the cookies used to track sessions (only applicable if
 `authOptions.tokenMethod` is set to `'cookie'`). These options are passed directly

--- a/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
+++ b/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
@@ -2,7 +2,7 @@
 title: "SuperadminCredentials"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="903" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="914" packageName="@vendure/core" />
 
 These credentials will be used to create the Superadmin user & administrator
 when Vendure first bootstraps.

--- a/docs/docs/reference/typescript-api/configuration/api-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/api-options.mdx
@@ -2,7 +2,7 @@
 title: "ApiOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="80" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="81" packageName="@vendure/core" />
 
 The ApiOptions define how the Vendure GraphQL APIs are exposed, as well as allowing the API layer
 to be extended with middleware.

--- a/docs/docs/reference/typescript-api/configuration/default-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/default-config.mdx
@@ -2,7 +2,7 @@
 title: "DefaultConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/default-config.ts" sourceLine="73" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/default-config.ts" sourceLine="74" packageName="@vendure/core" />
 
 The default configuration settings which are used if not explicitly overridden in the bootstrap() call.
 

--- a/docs/docs/reference/typescript-api/configuration/entity-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/entity-options.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## EntityOptions
 
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1101" packageName="@vendure/core" since="1.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1112" packageName="@vendure/core" since="1.3.0" />
 
 Options relating to the internal handling of entities.
 

--- a/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "RuntimeVendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1387" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1398" packageName="@vendure/core" />
 
 This interface represents the VendureConfig object available at run-time, i.e. the user-supplied
 config values have been merged with the [defaultConfig](/reference/typescript-api/configuration/default-config#defaultconfig) values.

--- a/docs/docs/reference/typescript-api/configuration/system-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/system-options.mdx
@@ -2,7 +2,7 @@
 title: "SystemOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1199" packageName="@vendure/core" since="1.6.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1210" packageName="@vendure/core" since="1.6.0" />
 
 Options relating to system functions.
 

--- a/docs/docs/reference/typescript-api/configuration/trust-proxy-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/trust-proxy-options.mdx
@@ -2,7 +2,7 @@
 title: "TrustProxyOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="249" packageName="@vendure/core" since="3.4.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="250" packageName="@vendure/core" since="3.4.0" />
 
 Configures Express trust proxy settings when running behind a reverse proxy (usually the case with most hosting services).
 Setting `trustProxy` allows you to retrieve the original IP address from the `X-Forwarded-For` header.

--- a/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "VendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1240" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1251" packageName="@vendure/core" />
 
 All possible configuration options are defined by the
 [`VendureConfig`](https://github.com/vendurehq/vendure/blob/master/packages/core/src/config/vendure-config.ts) interface.

--- a/docs/docs/reference/typescript-api/entities/promotion.mdx
+++ b/docs/docs/reference/typescript-api/entities/promotion.mdx
@@ -2,7 +2,7 @@
 title: "Promotion"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/entity/promotion/promotion.entity.ts" sourceLine="61" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/entity/promotion/promotion.entity.ts" sourceLine="62" packageName="@vendure/core" />
 
 A Promotion is used to define a set of conditions under which promotions actions (typically discounts)
 will be applied to an Order.

--- a/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
+++ b/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
@@ -2,7 +2,7 @@
 title: "ImportExportOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1001" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1012" packageName="@vendure/core" />
 
 Options related to importing & exporting data.
 

--- a/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
+++ b/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
@@ -2,7 +2,7 @@
 title: "JobQueueOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1025" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1036" packageName="@vendure/core" />
 
 Options related to the built-in job queue.
 

--- a/docs/docs/reference/typescript-api/orders/order-options.mdx
+++ b/docs/docs/reference/typescript-api/orders/order-options.mdx
@@ -2,7 +2,7 @@
 title: "OrderOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="573" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="574" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/payment/payment-options.mdx
+++ b/docs/docs/reference/typescript-api/payment/payment-options.mdx
@@ -2,7 +2,7 @@
 title: "PaymentOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="925" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="936" packageName="@vendure/core" />
 
 Defines payment-related options in the [VendureConfig](/reference/typescript-api/configuration/vendure-config#vendureconfig).
 

--- a/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
+++ b/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
@@ -2,7 +2,7 @@
 title: "CatalogOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="774" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="785" packageName="@vendure/core" />
 
 Options related to products and collections.
 

--- a/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
+++ b/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
@@ -2,7 +2,7 @@
 title: "PromotionOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="836" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="847" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
+++ b/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
@@ -2,7 +2,7 @@
 title: "SchedulerOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1064" packageName="@vendure/core" since="3.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1075" packageName="@vendure/core" since="3.3.0" />
 
 Options related to scheduled tasks..
 

--- a/docs/docs/reference/typescript-api/service-helpers/order-modifier.mdx
+++ b/docs/docs/reference/typescript-api/service-helpers/order-modifier.mdx
@@ -2,7 +2,7 @@
 title: "OrderModifier"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/helpers/order-modifier/order-modifier.ts" sourceLine="84" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/order-modifier/order-modifier.ts" sourceLine="85" packageName="@vendure/core" />
 
 This helper is responsible for modifying the contents of an Order.
 

--- a/docs/docs/reference/typescript-api/services/administrator-service.mdx
+++ b/docs/docs/reference/typescript-api/services/administrator-service.mdx
@@ -2,7 +2,7 @@
 title: "AdministratorService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/administrator.service.ts" sourceLine="41" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/administrator.service.ts" sourceLine="42" packageName="@vendure/core" />
 
 Contains methods relating to [Administrator](/reference/typescript-api/entities/administrator#administrator) entities.
 

--- a/docs/docs/reference/typescript-api/services/order-service.mdx
+++ b/docs/docs/reference/typescript-api/services/order-service.mdx
@@ -2,7 +2,7 @@
 title: "OrderService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="142" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/order.service.ts" sourceLine="143" packageName="@vendure/core" />
 
 Contains methods relating to [Order](/reference/typescript-api/entities/order#order) entities.
 

--- a/docs/docs/reference/typescript-api/services/promotion-service.mdx
+++ b/docs/docs/reference/typescript-api/services/promotion-service.mdx
@@ -91,8 +91,9 @@ class PromotionService {
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, couponCode: string, customerId?: <a href='/reference/typescript-api/common/id#id'>ID</a>, excludeOrderId?: <a href='/reference/typescript-api/common/id#id'>ID</a>) => Promise<JustErrorResults<ApplyCouponCodeResult> | <a href='/reference/typescript-api/entities/promotion#promotion'>Promotion</a>>`}   />
 
 Checks the validity of a coupon code, by checking that it is associated with an existing,
-enabled and non-expired Promotion. Additionally, if there is a usage limit on the coupon code,
-this method will enforce that limit against the specified Customer.
+enabled and non-expired Promotion. The comparison is case-insensitive, so e.g. "SUMMER20"
+and "summer20" are treated as the same code. Additionally, if there is a usage limit on the
+coupon code, this method will enforce that limit against the specified Customer.
 ### getActivePromotionsInChannel
 
 <MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>) => `}   />

--- a/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
+++ b/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
@@ -2,7 +2,7 @@
 title: "ShippingOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="852" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="863" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/tax/tax-options.mdx
+++ b/docs/docs/reference/typescript-api/tax/tax-options.mdx
@@ -2,7 +2,7 @@
 title: "TaxOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="965" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="976" packageName="@vendure/core" />
 
 
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -964,7 +964,7 @@
                   "title": "AssetOptions",
                   "slug": "asset-options",
                   "file": "docs/reference/typescript-api/assets/asset-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "AssetPreviewStrategy",
@@ -1008,7 +1008,7 @@
                   "title": "AuthOptions",
                   "slug": "auth-options",
                   "file": "docs/reference/typescript-api/auth/auth-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "BcryptPasswordHashingStrategy",
@@ -1020,7 +1020,7 @@
                   "title": "CookieOptions",
                   "slug": "cookie-options",
                   "file": "docs/reference/typescript-api/auth/cookie-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "CustomerChannelAssignmentStrategy",
@@ -1104,7 +1104,7 @@
                   "title": "SuperadminCredentials",
                   "slug": "superadmin-credentials",
                   "file": "docs/reference/typescript-api/auth/superadmin-credentials.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "VerificationTokenStrategy",
@@ -1366,7 +1366,7 @@
                   "title": "ApiOptions",
                   "slug": "api-options",
                   "file": "docs/reference/typescript-api/configuration/api-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "CollectionFilter",
@@ -1378,7 +1378,7 @@
                   "title": "DefaultConfig",
                   "slug": "default-config",
                   "file": "docs/reference/typescript-api/configuration/default-config.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "DefaultSlugStrategy",
@@ -1408,7 +1408,7 @@
                   "title": "EntityOptions",
                   "slug": "entity-options",
                   "file": "docs/reference/typescript-api/configuration/entity-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "MergeConfig",
@@ -1432,7 +1432,7 @@
                   "title": "RuntimeVendureConfig",
                   "slug": "runtime-vendure-config",
                   "file": "docs/reference/typescript-api/configuration/runtime-vendure-config.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "SettingsStoreFields",
@@ -1450,19 +1450,19 @@
                   "title": "SystemOptions",
                   "slug": "system-options",
                   "file": "docs/reference/typescript-api/configuration/system-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "TrustProxyOptions",
                   "slug": "trust-proxy-options",
                   "file": "docs/reference/typescript-api/configuration/trust-proxy-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "VendureConfig",
                   "slug": "vendure-config",
                   "file": "docs/reference/typescript-api/configuration/vendure-config.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -1794,7 +1794,7 @@
                   "title": "Promotion",
                   "slug": "promotion",
                   "file": "docs/reference/typescript-api/entities/promotion.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "Province",
@@ -2134,7 +2134,7 @@
                   "title": "ImportExportOptions",
                   "slug": "import-export-options",
                   "file": "docs/reference/typescript-api/import-export/import-export-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "ImportParser",
@@ -2214,7 +2214,7 @@
                   "title": "JobQueueOptions",
                   "slug": "job-queue-options",
                   "file": "docs/reference/typescript-api/job-queue/job-queue-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "JobQueueService",
@@ -2474,7 +2474,7 @@
                   "title": "OrderOptions",
                   "slug": "order-options",
                   "file": "docs/reference/typescript-api/orders/order-options.mdx",
-                  "lastModified": "2026-06-29T14:58:47+02:00"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "OrderPlacedStrategy",
@@ -2554,7 +2554,7 @@
                   "title": "PaymentOptions",
                   "slug": "payment-options",
                   "file": "docs/reference/typescript-api/payment/payment-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "PaymentProcess",
@@ -2648,7 +2648,7 @@
                   "title": "CatalogOptions",
                   "slug": "catalog-options",
                   "file": "docs/reference/typescript-api/products-stock/catalog-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "DefaultProductVariantPriceCalculationStrategy",
@@ -2722,7 +2722,7 @@
                   "title": "PromotionOptions",
                   "slug": "promotion-options",
                   "file": "docs/reference/typescript-api/promotions/promotion-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2816,7 +2816,7 @@
                   "title": "SchedulerOptions",
                   "slug": "scheduler-options",
                   "file": "docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "SchedulerService",
@@ -2854,7 +2854,7 @@
                   "title": "OrderModifier",
                   "slug": "order-modifier",
                   "file": "docs/reference/typescript-api/service-helpers/order-modifier.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "ProductPriceApplicator",
@@ -2892,7 +2892,7 @@
                   "title": "AdministratorService",
                   "slug": "administrator-service",
                   "file": "docs/reference/typescript-api/services/administrator-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "AssetService",
@@ -2988,7 +2988,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-04-29T16:04:40+02:00"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3036,7 +3036,7 @@
                   "title": "PromotionService",
                   "slug": "promotion-service",
                   "file": "docs/reference/typescript-api/services/promotion-service.mdx",
-                  "lastModified": "2026-04-29T16:04:40+02:00"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "ProvinceService",
@@ -3238,7 +3238,7 @@
                   "title": "ShippingOptions",
                   "slug": "shipping-options",
                   "file": "docs/reference/typescript-api/shipping/shipping-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "ShouldRunCheckFn",
@@ -3314,7 +3314,7 @@
                   "title": "TaxOptions",
                   "slug": "tax-options",
                   "file": "docs/reference/typescript-api/tax/tax-options.mdx",
-                  "lastModified": "2026-06-24T09:45:17Z"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 },
                 {
                   "title": "TaxZoneStrategy",
@@ -4271,7 +4271,7 @@
                   "title": "VendureDashboardPlugin",
                   "slug": "vendure-dashboard-plugin",
                   "file": "docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx",
-                  "lastModified": "2026-06-02T07:50:38+02:00"
+                  "lastModified": "2026-06-29T21:17:55Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"

--- a/packages/create/src/helpers.spec.ts
+++ b/packages/create/src/helpers.spec.ts
@@ -390,11 +390,11 @@ describe('getMonorepoRootPackageJson', () => {
 });
 
 describe('getSingleProjectPackageJson', () => {
-    it('writes manager-specific scripts and stays private', () => {
+    it('writes the unified vendure CLI scripts and stays private', () => {
         const pkg = getSingleProjectPackageJson('my-shop', getPackageManagerInfo('npm'), 'postgres');
         expect(pkg.name).toBe('my-shop');
         expect(pkg.private).toBe(true);
-        expect((pkg.scripts as Record<string, string>).dev).toBe('concurrently --kill-others npm:dev:*');
+        expect((pkg.scripts as Record<string, string>).dev).toBe('vendure dev all');
     });
 
     // #4891 — the single-project root package.json is where pnpm reads onlyBuiltDependencies.


### PR DESCRIPTION
## Problem

`minor` is currently red on the `unit tests` job across all Node versions (20.x / 22.x / 24.x). This in turn fails CI on every open PR targeting `minor` (e.g. #4862), since PR CI tests the prospective merge with `minor`.

## Root cause

The back-merge `7233adf77` ("Merge remote-tracking branch 'origin/master' into minor") produced a **semantic merge conflict** in `@vendure/create` — textually clean, logically broken:

| | `helpers.ts` (impl) | `helpers.spec.ts` (test) |
|---|---|---|
| minor side | `dev: 'vendure dev all'` | expects `'vendure dev all'` ✓ |
| master side | `dev: 'concurrently --kill-others ${pm}:dev:*'` | expects `'concurrently --kill-others npm:dev:*'` ✓ |
| **merge result** | `'vendure dev all'` (took minor) | expects `'concurrently...'` (took master) ✗ |

Git merged each file independently, so the implementation resolved to minor's unified `vendure dev all` CLI command while one assertion in `getSingleProjectPackageJson` retained master's expectation. No conflict markers, clean merge, failing test.

## Fix

`minor` is the source of truth (the `vendure dev all` unified CLI command is a minor-branch feature), so the implementation is correct and the test was the casualty. Updates the stale assertion to expect `'vendure dev all'`, and renames the test — "manager-specific scripts" was itself now inaccurate, since `getSingleProjectPackageJson` delegates to `getServerPackageScripts()` which returns the same scripts regardless of package manager.

Verified: `packages/create` `helpers.spec.ts` — 36/36 passing.

Relates to #4862

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785353801&installation_id=128408429&pr_number=4898&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4898&signature=4c4413b22b1867d4f48c1e153bab334a57a466070c55ff1efdf70be0eaa67bbb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->