### PR TITLE
fix(core): Accept SVG uploads rejected by content-type validation

### DIFF
--- a/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
+++ b/packages/asset-server-plugin/e2e/asset-server-plugin.e2e-spec.ts
@@ -264,8 +264,11 @@ describe('AssetServerPlugin', () => {
         let testImages: Array<FragmentOf<typeof assetFragment>> = [];
 
         async function testMimeTypeOfAssetWithExt(ext: string, expectedMimeType: string) {
-            const testImage = testImages.find(i => i.source.endsWith(ext))!;
-            const result = await fetch(testImage.source);
+            // Use optional chaining so a rejected upload (no `source`) does not throw here and
+            // cascade into false failures for the other formats; assert it was accepted instead.
+            const testImage = testImages.find(i => i.source?.endsWith(ext));
+            expect(testImage?.source, `Asset with extension ".${ext}" was not created`).toBeTruthy();
+            const result = await fetch(testImage!.source);
             const contentType = result.headers.get('Content-Type');
 
             expect(contentType).toBe(expectedMimeType);

--- a/packages/core/e2e/asset.e2e-spec.ts
+++ b/packages/core/e2e/asset.e2e-spec.ts
@@ -611,4 +611,30 @@ describe('Asset resolver', () => {
             expect(product.assets.length).toEqual(0);
         });
     });
+
+    // Placed last because creating an asset advances the auto-increment id, which the
+    // hardcoded-id assertions in the tests above rely on.
+    describe('MIME type content validation (GHSA-88rq-mq4v-frmm)', () => {
+        // An SVG that begins with an XML prolog is reported by `file-type` as the generic
+        // `application/xml`, which must not cause the permitted `image/svg+xml` upload to be
+        // rejected as a content/extension mismatch.
+        it('accepts an SVG whose contents are detected as generic XML', async () => {
+            const filesToUpload = [path.join(__dirname, 'fixtures/assets/test.svg')];
+            const { createAssets } = await adminClient.fileUploadMutation({
+                mutation: createAssetsDocument,
+                filePaths: filesToUpload,
+                mapVariables: filePaths => ({
+                    input: filePaths.map(p => ({ file: null })),
+                }),
+            });
+
+            expect(createAssets.length).toBe(1);
+            // An Asset (with name/source), not a MimeTypeError, confirms the SVG was accepted.
+            expect(createAssets[0]).toMatchObject({
+                name: 'test.svg',
+                source: expect.stringContaining('test.svg'),
+            });
+            expect(createAssets[0]).not.toHaveProperty('message');
+        });
+    });
 });

--- a/packages/core/e2e/fixtures/assets/test.svg
+++ b/packages/core/e2e/fixtures/assets/test.svg
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10" viewBox="0 0 10 10">
+    <rect width="10" height="10" fill="#000000" />
+</svg>

--- a/packages/core/src/service/services/asset.service.ts
+++ b/packages/core/src/service/services/asset.service.ts
@@ -630,6 +630,48 @@ export class AssetService {
         return !permissions.includes(false);
     }
 
+    /**
+     * Validates an upload against the permitted MIME types using three independently spoofable
+     * signals (see GHSA-88rq-mq4v-frmm): the declared Content-Type, the file extension, and the
+     * actual content (magic bytes). Returns a {@link MimeTypeError} if any signal identifies a
+     * non-permitted type, or `undefined` if the file is permitted.
+     */
+    private getPermittedMimeTypeError(
+        filename: string,
+        declaredMimeType: string,
+        contentMimeType: string | undefined,
+    ): MimeTypeError | undefined {
+        // 1. The declared Content-Type must be permitted (cheap, header-only check).
+        if (!this.validateMimeType(declaredMimeType)) {
+            return new MimeTypeError({ fileName: filename, mimeType: declaredMimeType });
+        }
+        // 2. The file extension must be permitted: the stored file keeps it, and it is what
+        // determines whether a downstream web server might execute the file (e.g. `.php`).
+        // `mime.lookup` returns `false` for unrecognised extensions, handled by the content check.
+        const extensionMimeType = mime.lookup(filename) || undefined;
+        if (extensionMimeType && !this.validateMimeType(extensionMimeType)) {
+            return new MimeTypeError({ fileName: filename, mimeType: extensionMimeType });
+        }
+        // 3. The actual content must not identify a non-permitted type. Text-based formats have no
+        // binary signature: plain text yields `undefined`, while XML-based formats such as SVG
+        // yield a generic `application/xml`/`text/xml` which is consistent with a permitted `*+xml`
+        // extension and so is not a mismatch.
+        if (contentMimeType && !this.validateMimeType(contentMimeType)) {
+            const contentIsGenericXml =
+                contentMimeType === 'application/xml' || contentMimeType === 'text/xml';
+            const extensionIsXmlBased = !!extensionMimeType && extensionMimeType.endsWith('+xml');
+            if (!(contentIsGenericXml && extensionIsXmlBased)) {
+                return new MimeTypeError({ fileName: filename, mimeType: contentMimeType });
+            }
+        }
+        // A file recognised neither by content nor by a permitted extension cannot be verified as
+        // a permitted type (e.g. a script with an unrecognised extension such as `.phtml`).
+        if (!contentMimeType && !extensionMimeType) {
+            return new MimeTypeError({ fileName: filename, mimeType: 'application/octet-stream' });
+        }
+        return undefined;
+    }
+
     private async createAssetInternal(
         ctx: RequestContext,
         stream: Stream,
@@ -639,53 +681,19 @@ export class AssetService {
         translations?: Array<{ languageCode: LanguageCode; name?: string | null; customFields?: any }>,
     ): Promise<Asset | MimeTypeError> {
         const { assetOptions } = this.configService;
-        // The MIME type validation below is layered because the client-supplied `mimetype`
-        // (taken from the upload's Content-Type header) is trivially spoofable. See
-        // GHSA-88rq-mq4v-frmm. We accept a file only if it can be positively identified as a
-        // permitted type, and reject it if any signal identifies it as a non-permitted type.
+        // Inspect the leading bytes of the uploaded content (magic bytes) so the real content
+        // type can be validated, not just the spoofable declared Content-Type and extension. The
+        // stream is peeked rather than fully buffered so the file can still be written as a stream.
+        const { head, complete } = await peekStreamHead(stream as Readable, CONTENT_DETECTION_SAMPLE_BYTES);
+        const contentMimeType = await detectMimeTypeFromContents(head);
+        const mimeTypeError = this.getPermittedMimeTypeError(filename, mimetype, contentMimeType);
+        if (mimeTypeError) {
+            return mimeTypeError;
+        }
 
-        // 1. The declared Content-Type must be permitted (cheap, header-only check).
-        if (!this.validateMimeType(mimetype)) {
-            return new MimeTypeError({ fileName: filename, mimeType: mimetype });
-        }
-        // 2. The file extension must be permitted. The stored file keeps its original
-        // extension, which is what determines whether a downstream web server might execute
-        // it (e.g. `.php`), so a permitted Content-Type must not smuggle in a dangerous
-        // extension. `mime.lookup` returns `false` for unrecognised extensions; those are
-        // handled by the content check below.
-        const extensionMimeType = mime.lookup(filename) || undefined;
-        if (extensionMimeType && !this.validateMimeType(extensionMimeType)) {
-            return new MimeTypeError({ fileName: filename, mimeType: extensionMimeType });
-        }
         const { assetPreviewStrategy, assetStorageStrategy } = assetOptions;
         const sourceFileName = await this.getSourceFileName(ctx, filename);
         const previewFileName = await this.getPreviewFileName(ctx, sourceFileName);
-
-        // 3. Inspect the leading bytes of the uploaded content (magic bytes) before persisting
-        // it. If the content is recognised but not permitted, the declared type/extension were
-        // misleading. Text-based formats have no binary signature: plain text returns
-        // `undefined`, while XML-based formats such as SVG are reported by their generic
-        // `application/xml`/`text/xml` signature rather than their specific image type. The
-        // stream is peeked rather than fully buffered so the file can still be written as a
-        // stream.
-        const { head, complete } = await peekStreamHead(stream as Readable, CONTENT_DETECTION_SAMPLE_BYTES);
-        const contentMimeType = await detectMimeTypeFromContents(head);
-        if (contentMimeType && !this.validateMimeType(contentMimeType)) {
-            // A generic XML signature is consistent with a permitted XML-based extension (e.g.
-            // `image/svg+xml`), so it is not a content/extension mismatch. Anything else that is
-            // recognised-but-not-permitted is a genuine mismatch and is rejected.
-            const contentIsGenericXml =
-                contentMimeType === 'application/xml' || contentMimeType === 'text/xml';
-            const extensionIsXmlBased = !!extensionMimeType && extensionMimeType.endsWith('+xml');
-            if (!(contentIsGenericXml && extensionIsXmlBased)) {
-                return new MimeTypeError({ fileName: filename, mimeType: contentMimeType });
-            }
-        }
-        // A file recognised neither by content nor by a permitted extension cannot be verified
-        // as a permitted type (e.g. a script with an unrecognised extension such as `.phtml`).
-        if (!contentMimeType && !extensionMimeType) {
-            return new MimeTypeError({ fileName: filename, mimeType: 'application/octet-stream' });
-        }
 
         // If the stream was fully consumed during the peek (a small file), `head` holds the
         // whole content and the stream cannot be replayed; write the buffer directly.

--- a/packages/core/src/service/services/asset.service.ts
+++ b/packages/core/src/service/services/asset.service.ts
@@ -663,17 +663,26 @@ export class AssetService {
 
         // 3. Inspect the leading bytes of the uploaded content (magic bytes) before persisting
         // it. If the content is recognised but not permitted, the declared type/extension were
-        // misleading. If the content is unrecognised (e.g. plain text, SVG) it returns
-        // undefined; in that case the file must have been positively identified by its
-        // permitted extension above, otherwise it cannot be verified as a permitted type and
-        // is rejected (e.g. a script with an unrecognised extension such as `.phtml`). The
+        // misleading. Text-based formats have no binary signature: plain text returns
+        // `undefined`, while XML-based formats such as SVG are reported by their generic
+        // `application/xml`/`text/xml` signature rather than their specific image type. The
         // stream is peeked rather than fully buffered so the file can still be written as a
         // stream.
         const { head, complete } = await peekStreamHead(stream as Readable, CONTENT_DETECTION_SAMPLE_BYTES);
         const contentMimeType = await detectMimeTypeFromContents(head);
         if (contentMimeType && !this.validateMimeType(contentMimeType)) {
-            return new MimeTypeError({ fileName: filename, mimeType: contentMimeType });
+            // A generic XML signature is consistent with a permitted XML-based extension (e.g.
+            // `image/svg+xml`), so it is not a content/extension mismatch. Anything else that is
+            // recognised-but-not-permitted is a genuine mismatch and is rejected.
+            const contentIsGenericXml =
+                contentMimeType === 'application/xml' || contentMimeType === 'text/xml';
+            const extensionIsXmlBased = !!extensionMimeType && extensionMimeType.endsWith('+xml');
+            if (!(contentIsGenericXml && extensionIsXmlBased)) {
+                return new MimeTypeError({ fileName: filename, mimeType: contentMimeType });
+            }
         }
+        // A file recognised neither by content nor by a permitted extension cannot be verified
+        // as a permitted type (e.g. a script with an unrecognised extension such as `.phtml`).
         if (!contentMimeType && !extensionMimeType) {
             return new MimeTypeError({ fileName: filename, mimeType: 'application/octet-stream' });
         }


### PR DESCRIPTION
## Problem

`master` is currently red on the `@vendure/asset-server-plugin` e2e job (all DB/Node combinations). The GHSA-88rq-mq4v-frmm hardening (merged in `b2acf156`, "Merge commit from fork") **rejects legitimate SVG uploads** as a regression.

## Root cause (reproduced locally)

The new content-based MIME validation in `createAssetInternal` inspects magic bytes via `file-type`. Its comment assumes:

> *"If the content is unrecognised (e.g. plain text, SVG) it returns undefined"*

This is **false**. An SVG that begins with an XML prolog (`<?xml …?>` — emitted by Inkscape, Illustrator, and most tooling) is detected by `file-type@19` as `application/xml`:

```
file-type result for test.svg → { ext: 'xml', mime: 'application/xml' }
```

`application/xml` is not in the permitted list (`image/*`, `video/*`, `audio/*`, `.pdf`), so gate 3 returns a `MimeTypeError` and the upload is rejected — even though `image/svg+xml` is permitted by both the declared Content-Type and the `.svg` extension. This affects the **default config**, i.e. any user uploading a standard SVG.

The failing e2e suite reported svg **and** tiff/webp as failures, but only svg is actually rejected — the test helper `testImages.find(i => i.source.endsWith(ext))` threw on the first rejected asset (svg) and cascaded into the unrelated formats.

## Fix

Gate 3 no longer treats a generic XML content signature (`application/xml` / `text/xml`) as a content/extension mismatch **when the extension is XML-based** (`*+xml`, e.g. `image/svg+xml`). Every other recognised-but-not-permitted content type is still rejected, so the security posture is unchanged:

- The 3 GHSA rejection tests (`malicious.php`, `malicious.phtml`, `disguised-gzip.jpg`) still pass.
- Disguised binaries, HTML, scripts, dangerous extensions — all still rejected.

The SVG-borne-XSS risk is orthogonal to upload validation (mitigated at serve time via Content-Disposition / not serving inline) and `image/*` is deliberately permitted.

## Also in this PR

- **Regression test** (`asset.e2e-spec.ts`): uploads an XML-prolog SVG and asserts it is accepted. Placed in its own describe at the end because creating an asset advances the auto-increment id that the hardcoded-id assertions above rely on.
- **Test helper hardening** (`asset-server-plugin.e2e-spec.ts`): `testMimeTypeOfAssetWithExt` now uses optional chaining and asserts the upload succeeded, so a single rejected file no longer cascades into false failures for unrelated formats.

## Verification

- `@vendure/core` `asset.e2e-spec.ts` — 26/26 (incl. the 3 GHSA rejection tests + new regression test), sqljs.
- `@vendure/asset-server-plugin` MIME detection — 6/6 (gif, jpg, png, svg, tiff, webp), sqljs.

Relates to GHSA-88rq-mq4v-frmm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4899"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785355780&installation_id=128408429&pr_number=4899&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4899&signature=4c2fbede61d77a7233ae5b64ec112a5b5d2579b480d2ec262bc3a39263e543a2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->