### PR TITLE
fix(testing): Move contentTypeOverrides doc off inline type to fix docs build

### DIFF
--- a/docs/docs/reference/typescript-api/services/asset-service.mdx
+++ b/docs/docs/reference/typescript-api/services/asset-service.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## AssetService
 
-<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="93" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/asset.service.ts" sourceLine="161" packageName="@vendure/core" />
 
 Contains methods relating to [Asset](/reference/typescript-api/entities/asset#asset) entities.
 

--- a/docs/docs/reference/typescript-api/testing/simple-graph-qlclient.mdx
+++ b/docs/docs/reference/typescript-api/testing/simple-graph-qlclient.mdx
@@ -22,6 +22,7 @@ class SimpleGraphQLClient {
         mutation: DocumentNode;
         filePaths: string[];
         mapVariables: (filePaths: string[]) => any;
+        contentTypeOverrides?: { [index: number]: string };
     }) => Promise<any>;
 }
 ```
@@ -77,7 +78,7 @@ Logs in as the SuperAdmin user.
 Logs out so that the client is then treated as an anonymous user.
 ### fileUploadMutation
 
-<MemberInfo kind="method" type={`(options: {         mutation: DocumentNode;         filePaths: string[];         mapVariables: (filePaths: string[]) => any;     }) => Promise<any>`}   />
+<MemberInfo kind="method" type={`(options: {         mutation: DocumentNode;         filePaths: string[];         mapVariables: (filePaths: string[]) => any;         contentTypeOverrides?: { [index: number]: string };     }) => Promise<any>`}   />
 
 Perform a file upload mutation.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2844,7 +2844,7 @@
                   "title": "AssetService",
                   "slug": "asset-service",
                   "file": "docs/reference/typescript-api/services/asset-service.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-06-29T20:32:40Z"
                 },
                 {
                   "title": "AuthService",
@@ -3342,7 +3342,7 @@
                   "title": "SimpleGraphQLClient",
                   "slug": "simple-graph-qlclient",
                   "file": "docs/reference/typescript-api/testing/simple-graph-qlclient.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-06-29T20:32:40Z"
                 },
                 {
                   "title": "TestConfig",

--- a/packages/testing/src/simple-graphql-client.ts
+++ b/packages/testing/src/simple-graphql-client.ts
@@ -222,6 +222,9 @@ export class SimpleGraphQLClient {
      * corresponding Upload fields appear in the variables for the mutation.
      * @param mapVariables - Function that must return the variables for the
      * mutation, with `null` as the value for each `Upload` field.
+     * @param contentTypeOverrides - Optional overrides for the `Content-Type` of individual file
+     * parts, keyed by their index in `filePaths`. Used to simulate a client spoofing the
+     * Content-Type header independently of the actual file contents (e.g. via a proxy tool).
      *
      * @example
      * ```ts
@@ -250,11 +253,6 @@ export class SimpleGraphQLClient {
         mutation: DocumentNode;
         filePaths: string[];
         mapVariables: (filePaths: string[]) => any;
-        /**
-         * Overrides the `Content-Type` of individual file parts, keyed by their index in
-         * `filePaths`. Used to simulate a client spoofing the Content-Type header
-         * independently of the actual file contents (e.g. via a proxy tool).
-         */
         contentTypeOverrides?: { [index: number]: string };
     }): Promise<any> {
         const { mutation, filePaths, mapVariables, contentTypeOverrides } = options;


### PR DESCRIPTION
## Problem

The `Generate Docs` workflow fails on `master` at the **Validate generated docs** step (`npm run test:mdx`):

```
[FAIL] docs/docs/reference/typescript-api/testing/simple-graph-qlclient.mdx
Error (line 86:197): Could not parse expression with acorn
✖ 1 error found.
```

## Root cause

The docs generator renders a method's type signature into MDX inside a backtick template literal: `type={`…`}`. The `contentTypeOverrides` property added to `fileUploadMutation`'s inline options type (in GHSA-88rq-mq4v-frmm) carried an **inline JSDoc comment**, which the generator embeds verbatim into that signature. The comment contains backticks (```Content-Type```, ```filePaths```), and the first one prematurely terminates the surrounding template literal — so MDX hands acorn a broken expression.

It is not the `{ … }` of the index-signature type (a literal `{` is fine inside a template literal); only the backticks break it.

## Fix

Move the explanation from the inline-property JSDoc to a `@param contentTypeOverrides` tag on the method. `@param` text is rendered as the member description (markdown, where backticks are fine) rather than embedded into the type signature, so nothing leaks into the `type={`…`}` template literal. No behaviour or type change.

## Verification

Regenerated TypeScript + GraphQL docs locally and ran the validator:

```
✓ MDX Compilation  OK  (819/819 passed)
Total errors: 0
✔ All documentation tests passed!
```

Relates to GHSA-88rq-mq4v-frmm

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4900"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785357105&installation_id=128408429&pr_number=4900&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4900&signature=f19bfe2c8912804720e2039189c0720219c349d989862ad7a767699a2cb2b30a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->