### PR TITLE
feat(dashboard): Allow user stylesheets to be passed to Dashboard build

### DIFF
--- a/docs/docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx
+++ b/docs/docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## vendureDashboardPlugin
 
-<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="225" packageName="@vendure/dashboard" since="3.4.0" />
+<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="241" packageName="@vendure/dashboard" since="3.4.0" />
 
 This is the Vite plugin which powers the Vendure Dashboard, including:
 
@@ -188,8 +188,24 @@ type VitePluginVendureDashboardOptions = {
      * @since 3.7.0
      */
     useExperimentalBundle?: boolean;
-} & UiConfigPluginOptions &
-    ThemeVariablesPluginOptions
+    /**
+     * @description
+     * Customizes the dashboard's appearance. Override design-token colours for
+     * the `light` and `dark` themes, and/or layer in additional stylesheets via
+     * `additionalStylesheets`.
+     *
+     * @example
+     * ```ts
+     * vendureDashboardPlugin({
+     *     theme: {
+     *         light: { brand: '#1a1a1a' },
+     *         additionalStylesheets: [resolve(__dirname, 'src/dashboard.css')],
+     *     },
+     * })
+     * ```
+     */
+    theme?: DashboardThemeOptions;
+} & UiConfigPluginOptions
 ```
 ## PathAdapter
 
@@ -269,6 +285,56 @@ the base `tsconfig.json` lives), so that a config file at
 
 Defaults to the directory containing the `vendureConfigPath` file,
 which places the compiled config at the output root.
+
+
+</div>
+## DashboardThemeOptions
+
+<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-theme.ts" sourceLine="23" packageName="@vendure/dashboard" since="3.5.1" />
+
+Appearance options for the dashboard. Extends `ThemeVariables` (the
+`light`/`dark` colour-token overrides) with the ability to layer in
+additional stylesheets.
+
+```ts title="Signature"
+interface DashboardThemeOptions extends ThemeVariables {
+    additionalStylesheets?: string | string[];
+}
+```
+* Extends: ThemeVariables
+
+
+
+<div className="members-wrapper">
+
+### additionalStylesheets
+
+<MemberInfo kind="property" type={`string | string[]`}   />
+
+One or more paths to additional CSS files that should be imported into
+the dashboard's main stylesheet. Each path is injected as an `@import`
+statement at a dedicated insertion point among the stylesheet's other
+imports, so the file participates in Tailwind's build pipeline — you can
+use `@source`, `@theme`, `@apply`, `@utility`, custom variants, etc.
+inside it.
+
+Paths may be absolute or relative to the current working directory;
+relative paths are resolved against `process.cwd()`. Backslashes are
+normalized to forward slashes so the resulting `@import` statement is
+valid on Windows.
+
+To override design tokens (e.g. brand colors), prefer the `light`/`dark`
+theme options — `additionalStylesheets` is for layering custom CSS rules.
+
+*Example*
+
+```ts
+vendureDashboardPlugin({
+    theme: {
+        additionalStylesheets: [path.resolve(__dirname, 'src/dashboard.css')],
+    },
+})
+```
 
 
 </div>

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -4271,7 +4271,7 @@
                   "title": "VendureDashboardPlugin",
                   "slug": "vendure-dashboard-plugin",
                   "file": "docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-06-30T07:07:50Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"

--- a/packages/dashboard/src/app/styles.css
+++ b/packages/dashboard/src/app/styles.css
@@ -29,6 +29,15 @@ html[dir="rtl"] * {
  */
 @import 'virtual:admin-theme-inline';
 
+/*
+ * Replaced at build time by the themeVariablesPlugin with the @import
+ * statements for any stylesheets passed via the `theme.additionalStylesheets`
+ * option. Placed here so user styles participate in Tailwind's build pipeline.
+ * When no stylesheets are configured, this placeholder is removed.
+ */
+/* stylelint-disable-next-line no-invalid-position-at-import-rule */
+@import 'virtual:vendure-user-styles';
+
 @layer base {
     * {
         @apply border-border outline-ring/50;

--- a/packages/dashboard/vite/tests/plugin-hooks.spec.ts
+++ b/packages/dashboard/vite/tests/plugin-hooks.spec.ts
@@ -174,6 +174,73 @@ describe('themeVariablesPlugin', () => {
         const result = callTransform(plugin, css, '/app/styles.css');
         expect(result).toContain('@theme inline');
     });
+
+    it('replaces virtual:vendure-user-styles with additionalStylesheets (single path)', () => {
+        const plugin = themeVariablesPlugin({
+            additionalStylesheets: '/abs/project/src/dashboard.css',
+        });
+        const css = `@import 'tailwindcss';\n@import 'virtual:vendure-user-styles';\n@import 'tw-animate-css';`;
+        const result = callTransform(plugin, css, '/app/styles.css');
+        expect(result).toContain(
+            `@import 'tailwindcss';\n@import '/abs/project/src/dashboard.css';\n@import 'tw-animate-css';`,
+        );
+        expect(result).not.toContain('virtual:vendure-user-styles');
+    });
+
+    it('replaces virtual:vendure-user-styles with multiple stylesheets in order', () => {
+        const plugin = themeVariablesPlugin({
+            additionalStylesheets: ['/abs/project/a.css', '/abs/project/b.css'],
+        });
+        const css = `@import 'tailwindcss';\n@import 'virtual:vendure-user-styles';`;
+        const result = callTransform(plugin, css, '/app/styles.css');
+        expect(result).toContain(
+            `@import 'tailwindcss';\n@import '/abs/project/a.css';\n@import '/abs/project/b.css';`,
+        );
+    });
+
+    it('replaces double-quoted virtual:vendure-user-styles', () => {
+        const plugin = themeVariablesPlugin({
+            additionalStylesheets: '/abs/project/custom.css',
+        });
+        const css = `@import "virtual:vendure-user-styles";`;
+        const result = callTransform(plugin, css, '/app/styles.css');
+        expect(result).toContain(`@import '/abs/project/custom.css';`);
+        expect(result).not.toContain('virtual:vendure-user-styles');
+    });
+
+    it('resolves relative additionalStylesheets paths against cwd', () => {
+        const plugin = themeVariablesPlugin({
+            additionalStylesheets: 'src/dashboard.css',
+        });
+        const css = `@import 'virtual:vendure-user-styles';`;
+        const result = callTransform(plugin, css, '/app/styles.css');
+        const expected = path.resolve('src/dashboard.css').replace(/\\/g, '/');
+        expect(result).toContain(`@import '${expected}';`);
+    });
+
+    it('removes the virtual:vendure-user-styles placeholder when no stylesheets are configured', () => {
+        const plugin = themeVariablesPlugin({ additionalStylesheets: [] });
+        const css = `@import 'tailwindcss';\n@import 'virtual:vendure-user-styles';\nbody { color: red; }`;
+        const result = callTransform(plugin, css, '/app/styles.css');
+        expect(result).not.toContain('virtual:vendure-user-styles');
+        expect(result).toContain('body { color: red; }');
+    });
+
+    it('also removes the placeholder when additionalStylesheets is omitted entirely', () => {
+        const plugin = themeVariablesPlugin({});
+        const css = `@import 'virtual:vendure-user-styles';`;
+        const result = callTransform(plugin, css, '/app/styles.css');
+        expect(result).not.toContain('virtual:vendure-user-styles');
+    });
+
+    it('leaves the file untouched when the placeholder is absent', () => {
+        const plugin = themeVariablesPlugin({
+            additionalStylesheets: '/abs/project/custom.css',
+        });
+        const css = `@import 'tailwindcss';\nbody { color: red; }`;
+        const result = callTransform(plugin, css, '/app/styles.css');
+        expect(result).toBeNull();
+    });
 });
 
 // ─── transformIndexHtmlPlugin ────────────────────────────────────────────────

--- a/packages/dashboard/vite/vite-plugin-theme.ts
+++ b/packages/dashboard/vite/vite-plugin-theme.ts
@@ -1,3 +1,5 @@
+import path from 'node:path';
+
 import { brand, darkTheme, fontFamily, lightTheme, radii, shadows } from '@vendure-io/design-tokens';
 import { Plugin } from 'vite';
 
@@ -6,6 +8,46 @@ type ThemeColors = Record<string, string | undefined>;
 export interface ThemeVariables {
     light?: ThemeColors;
     dark?: ThemeColors;
+}
+
+/**
+ * @description
+ * Appearance options for the dashboard. Extends {@link ThemeVariables} (the
+ * `light`/`dark` colour-token overrides) with the ability to layer in
+ * additional stylesheets.
+ *
+ * @docsCategory vite-plugin
+ * @docsPage vendureDashboardPlugin
+ * @since 3.5.1
+ */
+export interface DashboardThemeOptions extends ThemeVariables {
+    /**
+     * @description
+     * One or more paths to additional CSS files that should be imported into
+     * the dashboard's main stylesheet. Each path is injected as an `@import`
+     * statement at a dedicated insertion point among the stylesheet's other
+     * imports, so the file participates in Tailwind's build pipeline — you can
+     * use `@source`, `@theme`, `@apply`, `@utility`, custom variants, etc.
+     * inside it.
+     *
+     * Paths may be absolute or relative to the current working directory;
+     * relative paths are resolved against `process.cwd()`. Backslashes are
+     * normalized to forward slashes so the resulting `@import` statement is
+     * valid on Windows.
+     *
+     * To override design tokens (e.g. brand colors), prefer the `light`/`dark`
+     * theme options — `additionalStylesheets` is for layering custom CSS rules.
+     *
+     * @example
+     * ```ts
+     * vendureDashboardPlugin({
+     *     theme: {
+     *         additionalStylesheets: [path.resolve(__dirname, 'src/dashboard.css')],
+     *     },
+     * })
+     * ```
+     */
+    additionalStylesheets?: string | string[];
 }
 
 /**
@@ -41,9 +83,22 @@ const defaultVariables: ThemeVariables = {
     dark: { ...darkTheme, ...dashboardDarkExtensions },
 };
 
+/**
+ * Internal options for {@link themeVariablesPlugin}. Kept flat — the public
+ * surface nests `additionalStylesheets` under the `theme` option (see
+ * {@link DashboardThemeOptions}); the dashboard plugin maps the nested field
+ * onto this flat shape.
+ */
 export type ThemeVariablesPluginOptions = {
     theme?: ThemeVariables;
+    additionalStylesheets?: string | string[];
 };
+
+function normalizeStylesheetPaths(input: string | string[] | undefined): string[] {
+    if (!input) return [];
+    const list = Array.isArray(input) ? input : [input];
+    return list.map(p => path.resolve(p).replace(/\\/g, '/'));
+}
 
 /**
  * Generates the `@theme inline` block from design-token JS exports,
@@ -81,8 +136,7 @@ function generateThemeInlineBlock(): string {
 }
 
 export function themeVariablesPlugin(options: ThemeVariablesPluginOptions): Plugin {
-    const virtualModuleId = 'virtual:admin-theme';
-    const resolvedVirtualModuleId = `\0${virtualModuleId}`;
+    const additionalStylesheets = normalizeStylesheetPaths(options.additionalStylesheets);
 
     return {
         name: 'vendure:admin-theme',
@@ -97,6 +151,22 @@ export function themeVariablesPlugin(options: ThemeVariablesPluginOptions): Plug
 
             let result = code;
             let modified = false;
+
+            // Replace the `virtual:vendure-user-styles` placeholder with the
+            // user-supplied stylesheets as @import statements. The placeholder
+            // marks a deliberate insertion point among the @import statements in
+            // styles.css, so the CSS stays valid (imports must precede rules) and
+            // the imported files contribute @source, @theme, @apply, etc. to the
+            // dashboard build. When no stylesheets are configured, the placeholder
+            // is simply removed.
+            if (
+                result.includes('@import "virtual:vendure-user-styles";') ||
+                result.includes("@import 'virtual:vendure-user-styles';")
+            ) {
+                const userImports = additionalStylesheets.map(p => `@import '${p}';`).join('\n');
+                result = result.replace(/@import ['"]virtual:vendure-user-styles['"];?/, userImports);
+                modified = true;
+            }
 
             // Replace @import 'virtual:admin-theme' with :root / .dark CSS custom properties
             if (

--- a/packages/dashboard/vite/vite-plugin-vendure-dashboard.ts
+++ b/packages/dashboard/vite/vite-plugin-vendure-dashboard.ts
@@ -21,7 +21,7 @@ import { gqlTadaPlugin } from './vite-plugin-gql-tada.js';
 import { hmrPlugin } from './vite-plugin-hmr.js';
 import { linguiBabelPlugin } from './vite-plugin-lingui-babel.js';
 import { dashboardTailwindSourcePlugin } from './vite-plugin-tailwind-source.js';
-import { themeVariablesPlugin, ThemeVariablesPluginOptions } from './vite-plugin-theme.js';
+import { DashboardThemeOptions, themeVariablesPlugin } from './vite-plugin-theme.js';
 import { transformIndexHtmlPlugin } from './vite-plugin-transform-index.js';
 import { translationsPlugin } from './vite-plugin-translations.js';
 import { uiConfigPlugin, UiConfigPluginOptions } from './vite-plugin-ui-config.js';
@@ -195,8 +195,24 @@ export type VitePluginVendureDashboardOptions = {
      * @since 3.7.0
      */
     useExperimentalBundle?: boolean;
-} & UiConfigPluginOptions &
-    ThemeVariablesPluginOptions;
+    /**
+     * @description
+     * Customizes the dashboard's appearance. Override design-token colours for
+     * the `light` and `dark` themes, and/or layer in additional stylesheets via
+     * `additionalStylesheets`.
+     *
+     * @example
+     * ```ts
+     * vendureDashboardPlugin({
+     *     theme: {
+     *         light: { brand: '#1a1a1a' },
+     *         additionalStylesheets: [resolve(__dirname, 'src/dashboard.css')],
+     *     },
+     * })
+     * ```
+     */
+    theme?: DashboardThemeOptions;
+} & UiConfigPluginOptions;
 
 /**
  * @description
@@ -271,7 +287,11 @@ export function vendureDashboardPlugin(options: VitePluginVendureDashboardOption
         },
         {
             key: 'themeVariables',
-            plugin: () => themeVariablesPlugin({ theme: options.theme }),
+            plugin: () =>
+                themeVariablesPlugin({
+                    theme: options.theme,
+                    additionalStylesheets: options.theme?.additionalStylesheets,
+                }),
         },
         {
             key: 'tailwindSource',


### PR DESCRIPTION
Re-targets #4765 at `minor` (where features belong). The original PR was merged into `master` by mistake; it is being reverted there in #4904.

This is a cherry-pick of the original squashed commit onto `minor`, with the one conflict in `vite-plugin-vendure-dashboard.ts` resolved: the new nested `theme?: DashboardThemeOptions` option is kept alongside `minor`'s `useExperimentalBundle` flag, and the old top-level `& ThemeVariablesPluginOptions` intersection is dropped (theme config now lives under the `theme` property, matching the plugin consumption code).

Original author: @tbouliere-datasolution

Relates to #4765

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4905"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785395226&installation_id=128408429&pr_number=4905&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4905&signature=45d226b9b8c18075af7c58cd9242d976d62994e9afe080b357c90165cb672eaa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->