### PR TITLE
fix(create): install workspace deps from root in monorepo mode

### DIFF
--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -338,19 +338,22 @@ export async function createVendureApp(
     }
 
     if (includeStorefront) {
-        // Install storefront dependencies
-        const storefrontInstalled = await installDependenciesWithSpinner({
+        // Install the whole workspace from the root so that root-level devDependencies
+        // (concurrently, used by the `dev`/`start` scripts) are reified alongside each
+        // app's deps. A child-scoped install only reifies that app's subtree and leaves
+        // the root's own deps out.
+        const workspaceInstalled = await installDependenciesWithSpinner({
             dependencies: [],
             packageManager,
             logLevel,
-            cwd: storefrontRoot,
-            spinnerMessage: 'Installing storefront dependencies...',
-            successMessage: 'Installed storefront dependencies',
-            failureMessage: 'Failed to install storefront dependencies',
+            cwd: root,
+            spinnerMessage: 'Installing workspace dependencies...',
+            successMessage: 'Installed workspace dependencies',
+            failureMessage: 'Failed to install workspace dependencies',
             warnOnFailure: true,
         });
-        if (!storefrontInstalled) {
-            log(`You may need to run ${pmInfo.install} in the storefront directory manually.`, {
+        if (!workspaceInstalled) {
+            log(`You may need to run ${pmInfo.install} in the project root manually.`, {
                 level: 'info',
             });
         }


### PR DESCRIPTION
### Description

When creating a new project with the Next.js storefront (monorepo mode), running `npm run dev` in the generated project fails with:

```
sh: concurrently: command not found
```

…even though `concurrently` is declared as a root `devDependency` and is present in the generated `package-lock.json`.

### Root cause

In monorepo mode, `@vendure/create` runs every dependency install anchored **inside a child workspace** (`apps/server` and `apps/storefront`) — it never runs an install at the workspace root. In npm workspaces, a child-scoped install only reifies (writes to disk) that child's subtree; the root's own devDependencies are never installed.

npm still records `concurrently` in the ideal tree, so `package-lock.json` looks correct while the package is genuinely absent from `node_modules`. The root `dev` / `start` scripts that invoke `concurrently` then fail.

### Fix

Run the "install everything" step at the workspace **root** instead of `apps/storefront`. A plain install at the root reifies the entire workspace — every `apps/*` member plus the root's own deps — in a single pass, which is the idiomatic way to install a workspaces monorepo. This is package-manager agnostic: npm/yarn/pnpm/bun all treat a bare `install` at the root as a full-workspace install.

### Testing

Verified locally by publishing the patched `@vendure/create` to a Verdaccio registry and scaffolding a fresh monorepo project: `concurrently` is installed and `npm run dev` starts both the server and storefront.

### Note

This also affects the `minor` branch (same feature, same code path); the fix is targeted at `master` to be merged down.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785482667&installation_id=128408429&pr_number=4907&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4907&signature=dc24392c2996babbde41be2fcdf2fcfd6df4fcc02fc26e2868c4363f14ffb471"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->