### PR TITLE
fix(dashboard): Fix router basepath derivation in experimental bundle mode

### DIFF
--- a/packages/dashboard/src/app/derive-base-url.spec.ts
+++ b/packages/dashboard/src/app/derive-base-url.spec.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveBaseUrl } from './derive-base-url.js';
+
+describe('deriveBaseUrl', () => {
+    const origin = 'http://localhost:5174';
+
+    it('derives the base from the bundle entry file', () => {
+        expect(deriveBaseUrl(`${origin}/admin/dashboard/dist/bundle/main.js`, '/')).toBe('/admin/dashboard');
+    });
+
+    // #4719 — in bundle mode the derivation code is split into a hashed chunk,
+    // so the module URL points at dist/bundle/chunks/main-<hash>.js, not main.js.
+    it('derives the base from a code-split bundle chunk', () => {
+        expect(deriveBaseUrl(`${origin}/admin/dashboard/dist/bundle/chunks/main-abc123.js`, '/')).toBe(
+            '/admin/dashboard',
+        );
+    });
+
+    it('derives the base from the source entry (dev / source-shipping mode)', () => {
+        expect(deriveBaseUrl(`${origin}/admin/dashboard/src/app/main.tsx`, '/')).toBe('/admin/dashboard');
+    });
+
+    it('returns undefined when mounted at the root (bundle)', () => {
+        expect(deriveBaseUrl(`${origin}/dist/bundle/main.js`, '/')).toBeUndefined();
+    });
+
+    it('returns undefined when mounted at the root (source)', () => {
+        expect(deriveBaseUrl(`${origin}/src/app/main.tsx`, '/')).toBeUndefined();
+    });
+
+    // Greedy match must anchor on the LAST marker occurrence, so a deployment
+    // base that itself contains a marker segment is not truncated.
+    it('does not truncate when the deployment base contains a marker segment', () => {
+        expect(deriveBaseUrl(`${origin}/vendor/src/app/my-admin/dist/bundle/chunks/main-abc.js`, '/')).toBe(
+            '/vendor/src/app/my-admin',
+        );
+    });
+
+    it('strips a trailing slash from the fallback base', () => {
+        expect(deriveBaseUrl('', '/admin/dashboard/')).toBe('/admin/dashboard');
+    });
+
+    it('falls back to the provided base when the module URL yields no marker', () => {
+        expect(deriveBaseUrl(`${origin}/something/else/entry.js`, '/admin/dashboard')).toBe(
+            '/admin/dashboard',
+        );
+    });
+
+    it('returns undefined for an invalid module URL with no usable fallback', () => {
+        expect(deriveBaseUrl('not a url', '/')).toBeUndefined();
+    });
+});

--- a/packages/dashboard/src/app/derive-base-url.ts
+++ b/packages/dashboard/src/app/derive-base-url.ts
@@ -1,0 +1,41 @@
+/**
+ * @description
+ * Derives the router `basepath` from the running module's own URL.
+ *
+ * Works in BOTH source-shipping mode (`<base>/src/app/main.tsx`) and the
+ * experimental bundle mode (`<base>/dist/bundle/...`). Using the module URL is
+ * stable regardless of which sub-route the page was first loaded on — reading
+ * `document.baseURI` instead breaks deep-link navigation because it reflects
+ * the current page URL, not the dashboard root (see issue #4719).
+ *
+ * The regex anchors on the marker directory (`src/app` / `dist/bundle`) rather
+ * than the entry filename: in bundle mode Vite code-splits this logic into a
+ * hashed chunk served from `dist/bundle/chunks/main-<hash>.js`, so `moduleUrl`
+ * points at the chunk, not `dist/bundle/main.js`. The match is greedy so it
+ * anchors on the LAST occurrence of the marker — which is always the
+ * dashboard's own entry, since the entry file is the final path segment. This
+ * means an intermediate `/src/app/` or `/dist/bundle/` in the deployment base
+ * cannot truncate the result.
+ *
+ * @param moduleUrl - typically `import.meta.url` of the calling module.
+ * @param fallbackBase - used when the module URL yields no base, typically
+ * `import.meta.env.BASE_URL`.
+ * @returns the normalized base (leading slash, no trailing slash), or
+ * `undefined` when the dashboard is mounted at the root.
+ */
+export function deriveBaseUrl(moduleUrl: string, fallbackBase: string | undefined): string | undefined {
+    let derived: string | undefined;
+    try {
+        if (moduleUrl) {
+            const entryRe = /^(.*)\/(?:src\/app|dist\/bundle)\//;
+            const m = entryRe.exec(new URL(moduleUrl).pathname);
+            if (m) derived = m[1] || '/';
+        }
+    } catch {
+        // Ignore — fall back to `fallbackBase` below.
+    }
+    const baseUrl = derived ?? fallbackBase;
+    if (!baseUrl || baseUrl === '/') return undefined;
+    const normalized = baseUrl.startsWith('/') ? baseUrl : '/' + baseUrl;
+    return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized;
+}

--- a/packages/dashboard/src/app/main.tsx
+++ b/packages/dashboard/src/app/main.tsx
@@ -38,7 +38,12 @@ const processedBaseUrl = (() => {
     try {
         const moduleUrl = typeof import.meta?.url === 'string' ? import.meta.url : '';
         if (moduleUrl) {
-            const entryRe = /^(.*?)\/(?:src\/app\/main|dist\/bundle\/main)\.[a-z]+/;
+            // Anchor on the marker directory, not the entry filename: in bundle
+            // mode Vite code-splits this logic into a hashed chunk served from
+            // `dist/bundle/chunks/main-<hash>.js`, so `import.meta.url` points at
+            // the chunk, not `dist/bundle/main.js`. Matching the directory keeps
+            // the base derivable wherever the code lands.
+            const entryRe = /^(.*?)\/(?:src\/app|dist\/bundle)\//;
             const m = entryRe.exec(new URL(moduleUrl).pathname);
             if (m) derived = m[1] || '/';
         }

--- a/packages/dashboard/src/app/main.tsx
+++ b/packages/dashboard/src/app/main.tsx
@@ -16,46 +16,21 @@ import React, { useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import { createRoot } from 'react-dom/client';
 
+import { DirectionProvider } from '@/vdb/components/ui/direction.js';
 import { useDisplayLocale } from '@/vdb/hooks/use-display-locale.js';
 import { useUiLanguageLoader } from '@/vdb/hooks/use-ui-language-loader.js';
 import { useUserSettings } from '@/vdb/hooks/use-user-settings.js';
-import { DirectionProvider } from '@/vdb/components/ui/direction.js';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import { AppProviders, queryClient } from './app-providers.js';
 import { setDocumentDirection } from './common/set-document-direction.js';
+import { deriveBaseUrl } from './derive-base-url.js';
 import { routeTree } from './routeTree.gen.js';
 import './styles.css';
 
-const processedBaseUrl = (() => {
-    // Derive the base from this module's own URL when possible. This works
-    // in BOTH source-shipping mode (`<base>/src/app/main.tsx`) AND the
-    // experimental bundle mode (`<base>/dist/bundle/main.js` — see
-    // issue #4719). Using `import.meta.url` is stable regardless of what
-    // sub-route the page was first loaded on, which is important: previous
-    // attempts to read `document.baseURI` broke deep-link navigation because
-    // it reflects the CURRENT page URL, not the dashboard root.
-    let derived: string | undefined;
-    try {
-        const moduleUrl = typeof import.meta?.url === 'string' ? import.meta.url : '';
-        if (moduleUrl) {
-            // Anchor on the marker directory, not the entry filename: in bundle
-            // mode Vite code-splits this logic into a hashed chunk served from
-            // `dist/bundle/chunks/main-<hash>.js`, so `import.meta.url` points at
-            // the chunk, not `dist/bundle/main.js`. Matching the directory keeps
-            // the base derivable wherever the code lands.
-            const entryRe = /^(.*?)\/(?:src\/app|dist\/bundle)\//;
-            const m = entryRe.exec(new URL(moduleUrl).pathname);
-            if (m) derived = m[1] || '/';
-        }
-    } catch {
-        // Ignore — fall back to import.meta.env.BASE_URL below.
-    }
-    const baseUrl = derived ?? import.meta.env.BASE_URL;
-    if (!baseUrl || baseUrl === '/') return undefined;
-    // Ensure leading slash, remove trailing slash
-    const normalized = baseUrl.startsWith('/') ? baseUrl : '/' + baseUrl;
-    return normalized.endsWith('/') ? normalized.slice(0, -1) : normalized;
-})();
+const processedBaseUrl = deriveBaseUrl(
+    typeof import.meta?.url === 'string' ? import.meta.url : '',
+    import.meta.env.BASE_URL,
+);
 
 const routerOptions: RouterOptions<AnyRoute, any> = {
     defaultPreload: 'intent' as const,


### PR DESCRIPTION
## Problem

With `useExperimentalBundle: true`, loading the dashboard under a non-root base (e.g. `/dashboard`) renders TanStack Router's generic **"Not Found"** for every route, with the console warning:

> A notFoundError was encountered on the route with ID `__root__` …

## Root cause

The router `basepath` is derived at runtime in `main.tsx` by regex-matching `import.meta.url` against the entry filename and taking everything before it as the base:

```ts
const entryRe = /^(.*?)\/(?:src\/app\/main|dist\/bundle\/main)\.[a-z]+/;
```

In bundle mode, Vite's library build (`vite.lib.config.mts`) code-splits this logic **out** of the entry `dist/bundle/main.js` into a hashed chunk served from `dist/bundle/chunks/main-<hash>.js`. So at runtime `import.meta.url` points at the chunk, not `dist/bundle/main.js`, the filename-anchored regex never matches, `derived` stays `undefined`, and `basepath` resolves to `undefined`.

The router then mounts at `/` while the page is served under `/dashboard` → no route matches → `__root__` not-found → "Not Found".

Source-shipping (dev) mode is unaffected because the entry genuinely is `src/app/main.tsx`, which the old regex matched.

## Fix

Anchor the regex on the marker **directory** (`src/app` / `dist/bundle`) instead of the exact entry file, so the base is derivable wherever the code is split to. The match is **greedy**, anchoring on the last marker occurrence — always the dashboard's own entry (the entry file is the final path segment) — so a deployment base that itself contains a marker segment cannot truncate the result.

The derivation is extracted from the inline IIFE into `deriveBaseUrl()` and unit tested (it's the single most impactful runtime config in the dashboard — get it wrong and every route 404s — and previously had zero coverage).

## Verification

- Reproduced the "Not Found" live against a published `3.7.0-minor` build, patched the regex in the served chunk, confirmed the dashboard loads.
- New unit tests cover bundle entry, code-split chunk, source entry, root-mounted (both modes), the greedy no-truncation case, fallback base, and invalid URL. All green.

Relates to #4719

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785483898&installation_id=128408429&pr_number=4908&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4908&signature=3856126cc7ee3de482ba2ca5268c2a94d64df8d8cf5d7297bd7d929ed7c584d7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->