### PR TITLE
docs: Fix broken Admin UI guide links after legacy-apis move

### DIFF
--- a/docs/docs/guides/deployment/deploying-admin-ui.mdx
+++ b/docs/docs/guides/deployment/deploying-admin-ui.mdx
@@ -9,7 +9,7 @@ metaDescription: "Compile and deploy the Vendure Admin UI with custom extensions
 If you have customized the Admin UI with extensions, you should compile your custom Admin UI app ahead of time
 before deploying it. This will bundle the app into a set of static files which are then served by the AdminUiPlugin.
 
-- [Guide: Compiling the Admin UI as a deployment step](/extending-the-admin-ui/getting-started/#compiling-as-a-deployment-step).
+- [Guide: Compiling the Admin UI as a deployment step](/legacy-apis/extending-the-admin-ui/getting-started/#compiling-as-a-deployment-step).
 
 :::warning
 

--- a/docs/docs/guides/developer-guide/custom-fields/index.mdx
+++ b/docs/docs/guides/developer-guide/custom-fields/index.mdx
@@ -1141,7 +1141,7 @@ This table shows the default form input component used for each custom field typ
 
 The Dashboard app has built-in selection components for "relation" custom fields that reference certain common entity types, such as Asset, Product, ProductVariant and Customer. If you are relating to an entity not covered by the built-in selection components, you will see a generic relation component which allows you to manually enter the ID of the entity you wish to select.
 
-If the generic selector is not suitable, or is you wish to replace one of the built-in selector components, you can create a UI extension that defines a custom field control for that custom field. You can read more about this in the [custom form input guide](/extending-the-admin-ui/custom-form-inputs/)
+If the generic selector is not suitable, or is you wish to replace one of the built-in selector components, you can create a UI extension that defines a custom field control for that custom field. You can read more about this in the [custom form input guide](/legacy-apis/extending-the-admin-ui/custom-form-inputs/)
 :::
 
 ### Specifying the input component
@@ -1226,7 +1226,7 @@ The various configuration options for each of the built-in form input  (e.g. `su
 
 ### Custom form input components
 
-If none of the built-in form input components are suitable, you can create your own. This is a more advanced topic which is covered in detail in the [Custom Form Input Components](/extending-the-admin-ui/custom-form-inputs/) guide.
+If none of the built-in form input components are suitable, you can create your own. This is a more advanced topic which is covered in detail in the [Custom Form Input Components](/legacy-apis/extending-the-admin-ui/custom-form-inputs/) guide.
 
 ## Tabbed custom fields
 

--- a/docs/docs/guides/developer-guide/translations/index.mdx
+++ b/docs/docs/guides/developer-guide/translations/index.mdx
@@ -92,7 +92,7 @@ export class MyService {
 ```
 ## Admin UI translations
 
-See the [Adding Admin UI Translations guide](/extending-the-admin-ui/adding-ui-translations/).
+See the [Adding Admin UI Translations guide](/legacy-apis/extending-the-admin-ui/adding-ui-translations/).
 
 ## Server message translations
 

--- a/docs/docs/guides/extending-the-admin-ui/creating-detail-views/index.mdx
+++ b/docs/docs/guides/extending-the-admin-ui/creating-detail-views/index.mdx
@@ -15,7 +15,7 @@ in that case you won't be able to use the built-in Angular-specific components.
 
 ## Example: Creating a Product Detail View
 
-Let's say you have a plugin which adds a new entity to the database called `ProductReview`. You have already created a [list view](/extending-the-admin-ui/creating-list-views/), and
+Let's say you have a plugin which adds a new entity to the database called `ProductReview`. You have already created a [list view](/legacy-apis/extending-the-admin-ui/creating-list-views/), and
 now you need a detail view which can be used to view and edit individual reviews.
 
 ### Extend the TypedBaseDetailComponent class

--- a/docs/docs/guides/extending-the-admin-ui/custom-form-inputs/index.mdx
+++ b/docs/docs/guides/extending-the-admin-ui/custom-form-inputs/index.mdx
@@ -130,7 +130,7 @@ export default [
 
 ### 3. Register the providers
 
-The `providers.ts` is then passed to the `compileUiExtensions()` function as described in the [UI Extensions Getting Started guide](/extending-the-admin-ui/getting-started/):
+The `providers.ts` is then passed to the `compileUiExtensions()` function as described in the [UI Extensions Getting Started guide](/legacy-apis/extending-the-admin-ui/getting-started/):
 
 ```ts title="src/vendure-config.ts"
 import * as path from 'path';

--- a/docs/docs/guides/extending-the-admin-ui/custom-timeline-components/index.mdx
+++ b/docs/docs/guides/extending-the-admin-ui/custom-timeline-components/index.mdx
@@ -77,5 +77,5 @@ export default [
 ];
 ```
 
-Then we need to add the `providers.ts` file to the `uiExtensions` array as described in the [UI Extensions Getting Started guide](/extending-the-admin-ui/getting-started/).
+Then we need to add the `providers.ts` file to the `uiExtensions` array as described in the [UI Extensions Getting Started guide](/legacy-apis/extending-the-admin-ui/getting-started/).
 

--- a/docs/docs/guides/extending-the-admin-ui/dashboard-widgets/index.mdx
+++ b/docs/docs/guides/extending-the-admin-ui/dashboard-widgets/index.mdx
@@ -76,7 +76,7 @@ We also need to define an `NgModule` for this component. This is because we will
 
 ### Register the widget
 
-Our widget now needs to be registered in our [providers file](/extending-the-admin-ui/getting-started/#providers):
+Our widget now needs to be registered in our [providers file](/legacy-apis/extending-the-admin-ui/getting-started/#providers):
 
 ```ts title="src/plugins/reviews/ui/providers.ts"
 import { registerDashboardWidget } from '@vendure/admin-ui/core';

--- a/docs/docs/guides/extending-the-admin-ui/defining-routes/index.mdx
+++ b/docs/docs/guides/extending-the-admin-ui/defining-routes/index.mdx
@@ -8,7 +8,7 @@ Routes allow you to mount entirely custom components at a given URL in the Admin
 
 ![Route area](./route-area.webp)
 
-Routes can be defined natively using either **Angular** or **React**. It is also possible to [use other frameworks](/extending-the-admin-ui/using-other-frameworks/) in a more limited capacity.
+Routes can be defined natively using either **Angular** or **React**. It is also possible to [use other frameworks](/legacy-apis/extending-the-admin-ui/using-other-frameworks/) in a more limited capacity.
 
 ## Example: Creating a "Greeter" route
 
@@ -539,7 +539,7 @@ export default [
 ];
 ```
 
-A more powerful way to set the breadcrumbs is by using the `getBreadcrumbs` property. This is a function that receives any resolved detail data and returns an array of link/label pairs. An example of its use can be seen in the [Creating detail views guide](/extending-the-admin-ui/creating-detail-views/#route-config).
+A more powerful way to set the breadcrumbs is by using the `getBreadcrumbs` property. This is a function that receives any resolved detail data and returns an array of link/label pairs. An example of its use can be seen in the [Creating detail views guide](/legacy-apis/extending-the-admin-ui/creating-detail-views/#route-config).
 
 ### Dynamically from the component
 

--- a/docs/docs/guides/extending-the-admin-ui/getting-started/index.mdx
+++ b/docs/docs/guides/extending-the-admin-ui/getting-started/index.mdx
@@ -245,7 +245,7 @@ Routes allow you to define completely custom views in the Admin UI.
 
 Your `routes.ts` file exports an array of objects which define new routes in the Admin UI. For example, imagine you have created a plugin which implements a simple content management system. You can define a route for the list of articles, and another for the detail view of an article.
 
-For a detailed instructions, see the [Defining Routes guide](/extending-the-admin-ui/defining-routes/).
+For a detailed instructions, see the [Defining Routes guide](/legacy-apis/extending-the-admin-ui/defining-routes/).
 
 ## Dev vs Prod mode
 
@@ -347,7 +347,7 @@ npm install copyfiles
 
 ## Using other frameworks
 
-While the Admin UI natively supports extensions written with Angular or React, it is still possible to create extensions using other front-end frameworks such as Vue or Solid. Note that creating extensions in this way is much more limited, with only the ability to define new routes, and limited access to internal services such as data fetching and notifications. See [UI extensions in other frameworks](/extending-the-admin-ui/using-other-frameworks/).
+While the Admin UI natively supports extensions written with Angular or React, it is still possible to create extensions using other front-end frameworks such as Vue or Solid. Note that creating extensions in this way is much more limited, with only the ability to define new routes, and limited access to internal services such as data fetching and notifications. See [UI extensions in other frameworks](/legacy-apis/extending-the-admin-ui/using-other-frameworks/).
 
 ## IDE Support
 
@@ -398,7 +398,7 @@ Angular uses the concept of modules ([NgModules](https://angular.io/guide/ngmodu
 
 When creating your UI extensions, you can set your module to be either `lazy` or `shared`. Shared modules are loaded _eagerly_, i.e. their code is bundled up with the main app and loaded as soon as the app loads.
 
-As a rule, modules defining new routes should be lazily loaded (so that the code is only loaded once that route is activated), and modules defining [new navigations items](/extending-the-admin-ui/nav-menu/) and [custom form input](/extending-the-admin-ui/custom-form-inputs/) should be set to `shared`.
+As a rule, modules defining new routes should be lazily loaded (so that the code is only loaded once that route is activated), and modules defining [new navigations items](/legacy-apis/extending-the-admin-ui/nav-menu/) and [custom form input](/legacy-apis/extending-the-admin-ui/custom-form-inputs/) should be set to `shared`.
 
 :::info
 "lazy" modules are equivalent to the new "routes" API, and "shared" modules are equivalent to the new "providers" API. In fact, behind the scenes,

--- a/docs/docs/guides/extending-the-admin-ui/nav-menu/index.mdx
+++ b/docs/docs/guides/extending-the-admin-ui/nav-menu/index.mdx
@@ -12,7 +12,7 @@ access to routes in the app, and can be extended and modified by UI extensions.
 
 Once you have defined some custom routes, you need some way for the administrator to access them. For this you will use the [addNavMenuItem](/reference/admin-ui-api/nav-menu/add-nav-menu-item/) and [addNavMenuSection](/reference/admin-ui-api/nav-menu/add-nav-menu-section) functions.
 
-Let's add a new section to the Admin UI main nav bar containing a link to the "greeter" module from the [Getting Started guide](/extending-the-admin-ui/getting-started/#routes) example:
+Let's add a new section to the Admin UI main nav bar containing a link to the "greeter" module from the [Getting Started guide](/legacy-apis/extending-the-admin-ui/getting-started/#routes) example:
 
 ```ts title="src/plugins/greeter/ui/providers.ts"
 import { addNavMenuSection } from '@vendure/admin-ui/core';

--- a/docs/docs/guides/extending-the-admin-ui/using-other-frameworks/index.mdx
+++ b/docs/docs/guides/extending-the-admin-ui/using-other-frameworks/index.mdx
@@ -204,4 +204,4 @@ If your extension does not have a build step, you can still include the UiDevkit
 
 ## Next Steps
 
-Now you have created your extension, you need a way for your admin to access it. See [Adding Navigation Items](/extending-the-admin-ui/nav-menu/)
+Now you have created your extension, you need a way for your admin to access it. See [Adding Navigation Items](/legacy-apis/extending-the-admin-ui/nav-menu/)


### PR DESCRIPTION
## Summary

Fixes broken internal documentation links to the Angular Admin UI ("extending the Admin UI") guides. The originally reported case was the "Adding Admin UI Translations" link (OSS-514), but the same breakage affects every link to those pages — 15 links across 11 manual guide files.

## Root cause

The Angular Admin UI guides were moved under a new **`legacy-apis`** parent in `docs/manifest.json`. Guide URLs are derived from the manifest slug chain, so these pages now live at `/legacy-apis/extending-the-admin-ui/<slug>/`. The internal markdown links were never updated and still pointed at the old `/extending-the-admin-ui/<slug>/` paths, which now return 404.

## Change

Mechanical link-prefix update in manual guides only (`docs/docs/guides/**`):

```
](/extending-the-admin-ui/  ->  ](/legacy-apis/extending-the-admin-ui/
```

Path anchors (`#providers`, `#route-config`, `#routes`, `#compiling-as-a-deployment-step`) and sub-slugs are preserved. All 8 referenced target slugs were verified to exist under `legacy-apis > extending-the-admin-ui` in the manifest, so every new URL resolves.

## Test plan

- **`bun run test:mdx`** (docs validator) passes: 830 files, MDX compilation OK, 0 errors.
- Verified against `docs/manifest.json` that each new path matches the manifest-derived navigation URL.
- `grep` confirms zero remaining `](/extending-the-admin-ui/` links in `docs/docs/guides/`.

## Out of scope (follow-up)

3 further occurrences of the same stale path exist in **auto-generated** reference docs (`docs/docs/reference/...`) and are intentionally not edited here — they are regenerated from JSDoc and would be overwritten. The real source lives in:
- `packages/core/src/service/services/history.service.ts` (custom-timeline-components)
- `packages/ui-devkit/src/compiler/types.ts` (getting-started)
- `packages/common/src/shared-types.ts` (adding-ui-translations)

Tracked separately from this docs-guides PR.

Relates to OSS-514 (no linked GitHub issue; original report came via the docs bug-report form).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4912"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785519034&installation_id=128408429&pr_number=4912&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4912&signature=c1cd50a8ca4f799848c842aef065e84d125e1edb8fbf543c93b3f946a9ad7947"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->