### PR TITLE
fix(dashboard): Reflect modified line quantities in refund dialog

### DIFF
--- a/packages/dashboard/e2e/tests/sales/orders.spec.ts
+++ b/packages/dashboard/e2e/tests/sales/orders.spec.ts
@@ -65,7 +65,10 @@ test.describe('Orders', () => {
         await filteredRequest;
         // The Regular order survives the matching filter, and an active filter badge appears.
         await lp.expectRowCountGreaterThan(0);
-        const filterBadge = page.getByRole('button').filter({ hasText: 'type' }).filter({ hasText: 'Regular' });
+        const filterBadge = page
+            .getByRole('button')
+            .filter({ hasText: 'type' })
+            .filter({ hasText: 'Regular' });
         await expect(filterBadge).toBeVisible();
         await expect(page.getByText(/An error occurred:/i)).toHaveCount(0);
 
@@ -495,6 +498,51 @@ test.describe('Orders', () => {
             await dialog.getByRole('button', { name: 'Cancel' }).click();
         });
 
+        // #4728 — refund dialog must reflect line quantities changed during order modification.
+        // Increasing a line from 1→2 while Modifying keeps orderPlacedQuantity=1; the dialog
+        // previously capped the refundable quantity at orderPlacedQuantity, so only 1 of the
+        // 2 paid units could be refunded. It must now offer the full modified quantity.
+        test('should reflect a line quantity increased during modification in the refund dialog', async ({
+            page,
+        }) => {
+            test.setTimeout(60_000);
+
+            const client = new VendureAdminClient(page);
+            await client.login();
+            const orderId = await createOrderWithIncreasedLineQuantity(client);
+
+            await page.goto(`/orders/${orderId}`);
+            await expect(page.getByRole('button', { name: /Fulfill order/i })).toBeVisible({
+                timeout: 10_000,
+            });
+
+            // Open the refund dialog via action bar dropdown
+            const actionBarEllipsis = page.getByTestId('action-bar-dropdown-trigger');
+            await expect(actionBarEllipsis).toBeVisible({ timeout: 10_000 });
+            await actionBarEllipsis.click();
+
+            const menu = page.locator('[data-slot="dropdown-menu-content"]');
+            await expect(menu).toBeVisible();
+            await menu
+                .getByText(/Refund/i)
+                .first()
+                .click();
+
+            const dialog = page.locator('[role="dialog"]');
+            await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+            // The line's refund input must allow the full modified quantity (2).
+            // Pre-fix, `max` was orderPlacedQuantity (1) and entering 2 was clamped to 1.
+            const quantityInput = dialog.getByTestId('refund-quantity').first();
+            await expect(quantityInput).toBeVisible();
+            await expect(quantityInput).toHaveAttribute('max', '2');
+
+            await quantityInput.fill('2');
+            await expect(quantityInput).toHaveValue('2');
+
+            await dialog.getByRole('button', { name: 'Cancel' }).click();
+        });
+
         test('should process a refund', async ({ page }) => {
             test.setTimeout(60_000);
 
@@ -721,6 +769,88 @@ async function createPaidOrder(client: VendureAdminClient): Promise<string> {
     `,
         { orderId },
     );
+
+    return orderId;
+}
+
+/**
+ * Creates a paid order, then (while in "Modifying") increases its single line's
+ * quantity from 1 to 2 and settles the additional payment. Returns the order ID in
+ * "PaymentSettled" state with orderPlacedQuantity=1 and current quantity=2.
+ */
+async function createOrderWithIncreasedLineQuantity(client: VendureAdminClient): Promise<string> {
+    const orderId = await createPaidOrder(client);
+
+    // Transition helper that fails loudly at the real boundary, so a broken flow
+    // surfaces here rather than as a confusing later assertion failure.
+    const transition = async (state: string) => {
+        const { transitionOrderToState } = await client.gql(
+            `
+            mutation ($id: ID!, $state: String!) {
+                transitionOrderToState(id: $id, state: $state) {
+                    ... on Order { id state }
+                    ... on OrderStateTransitionError { errorCode message transitionError }
+                }
+            }
+        `,
+            { id: orderId, state },
+        );
+        if (transitionOrderToState?.errorCode) {
+            throw new Error(
+                `transition to ${state} failed: ${String(transitionOrderToState.errorCode)} ${String(transitionOrderToState.message)}`,
+            );
+        }
+    };
+
+    await transition('Modifying');
+
+    const { order } = await client.gql(`query ($id: ID!) { order(id: $id) { lines { id } } }`, {
+        id: orderId,
+    });
+
+    const { modifyOrder } = await client.gql(
+        `
+        mutation ($input: ModifyOrderInput!) {
+            modifyOrder(input: $input) {
+                ... on Order { id }
+                ... on ErrorResult { errorCode message }
+            }
+        }
+    `,
+        {
+            input: {
+                dryRun: false,
+                orderId,
+                adjustOrderLines: [{ orderLineId: order.lines[0].id, quantity: 2 }],
+            },
+        },
+    );
+    if (modifyOrder.errorCode) {
+        throw new Error(
+            `modifyOrder failed: ${String(modifyOrder.errorCode)} ${String(modifyOrder.message)}`,
+        );
+    }
+
+    await transition('ArrangingAdditionalPayment');
+
+    const { addManualPaymentToOrder } = await client.gql(
+        `
+        mutation ($orderId: ID!) {
+            addManualPaymentToOrder(input: {
+                orderId: $orderId, method: "test-payment",
+                transactionId: "e2e-additional-tx-${orderId}", metadata: {}
+            }) { ... on Order { id state } ... on ErrorResult { errorCode message } }
+        }
+    `,
+        { orderId },
+    );
+    if (addManualPaymentToOrder.errorCode) {
+        throw new Error(
+            `addManualPaymentToOrder failed: ${String(addManualPaymentToOrder.errorCode)} ${String(addManualPaymentToOrder.message)}`,
+        );
+    }
+
+    await transition('PaymentSettled');
 
     return orderId;
 }

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/components/refund-order-dialog.tsx
@@ -28,7 +28,11 @@ import { uiConfig } from 'virtual:vendure-ui-config';
 
 import { useRefundOrder } from '../hooks/use-refund-order.js';
 import { Order } from '../utils/order-types.js';
-import { getMaxRefundableQuantity, lineCanBeRefunded } from '../utils/order-utils.js';
+import {
+    getMaxRefundableQuantity,
+    getRefundableQuantity,
+    lineCanBeRefunded,
+} from '../utils/order-utils.js';
 
 interface RefundOrderDialogProps {
     readonly order: Order;
@@ -110,6 +114,7 @@ export const RefundOrderDialog = forwardRef<RefundOrderDialogRef, RefundOrderDia
                                         {order.lines.map(line => {
                                             const canRefund = lineCanBeRefunded(order, line);
                                             const maxRefundable = getMaxRefundableQuantity(order, line);
+                                            const refundableQuantity = getRefundableQuantity(line);
                                             const selection = refund.lineSelections[line.id];
 
                                             if (!canRefund) return null;
@@ -138,8 +143,8 @@ export const RefundOrderDialog = forwardRef<RefundOrderDialogRef, RefundOrderDia
                                                         )}
                                                     </td>
                                                     <td className="p-2 text-center">
-                                                        {line.orderPlacedQuantity}
-                                                        {maxRefundable < line.orderPlacedQuantity && (
+                                                        {refundableQuantity}
+                                                        {maxRefundable < refundableQuantity && (
                                                             <div className="text-xs text-muted-foreground">
                                                                 <Trans>({maxRefundable} refundable)</Trans>
                                                             </div>

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/utils/order-utils.spec.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/utils/order-utils.spec.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+
+import { Order } from './order-types.js';
+import { getMaxRefundableQuantity, getRefundableQuantity, lineCanBeRefunded } from './order-utils.js';
+
+// #4728 — refund dialog must reflect quantities/items changed during order modification.
+// Lines added or increased while the order is in `Modifying` keep `orderPlacedQuantity` at
+// its placement value (0 for new lines), so the effective refundable quantity is
+// Math.max(orderPlacedQuantity, quantity), matching how core distributes discounts/prices.
+
+function orderWithRefunds(refunds: Array<{ orderLineId: string; quantity: number; state?: string }>): Order {
+    return {
+        payments: [
+            {
+                state: 'Settled',
+                refunds: refunds.map(r => ({
+                    state: r.state ?? 'Settled',
+                    lines: [{ orderLineId: r.orderLineId, quantity: r.quantity }],
+                })),
+            },
+        ],
+    } as any;
+}
+
+function line(opts: { id?: string; orderPlacedQuantity: number; quantity: number }) {
+    return {
+        id: opts.id ?? 'L1',
+        orderPlacedQuantity: opts.orderPlacedQuantity,
+        quantity: opts.quantity,
+    } as Order['lines'][number];
+}
+
+describe('getRefundableQuantity', () => {
+    it('uses orderPlacedQuantity when it is the greater value', () => {
+        expect(getRefundableQuantity(line({ orderPlacedQuantity: 3, quantity: 1 }))).toBe(3);
+    });
+
+    it('uses the current quantity when a line was increased or added after placement', () => {
+        expect(getRefundableQuantity(line({ orderPlacedQuantity: 1, quantity: 2 }))).toBe(2);
+        expect(getRefundableQuantity(line({ orderPlacedQuantity: 0, quantity: 1 }))).toBe(1);
+    });
+});
+
+describe('lineCanBeRefunded', () => {
+    it('allows refunding a line added after the order was placed (orderPlacedQuantity 0)', () => {
+        const order = orderWithRefunds([]);
+        expect(lineCanBeRefunded(order, line({ orderPlacedQuantity: 0, quantity: 1 }))).toBe(true);
+    });
+
+    it('allows refunding units added by increasing a line during modification', () => {
+        const order = orderWithRefunds([]);
+        expect(lineCanBeRefunded(order, line({ orderPlacedQuantity: 1, quantity: 2 }))).toBe(true);
+    });
+
+    it('still allows refunding remaining units after a partial cancel+refund (#2608)', () => {
+        // Placed qty 3, then 2 cancelled+refunded → quantity reduced to 1, refundedCount 2.
+        const order = orderWithRefunds([{ orderLineId: 'L1', quantity: 2 }]);
+        expect(lineCanBeRefunded(order, line({ orderPlacedQuantity: 3, quantity: 1 }))).toBe(true);
+    });
+
+    it('does not allow refunding a fully refunded line', () => {
+        const order = orderWithRefunds([{ orderLineId: 'L1', quantity: 2 }]);
+        expect(lineCanBeRefunded(order, line({ orderPlacedQuantity: 2, quantity: 0 }))).toBe(false);
+    });
+});
+
+describe('getMaxRefundableQuantity', () => {
+    it('returns the current quantity for a line added after placement', () => {
+        const order = orderWithRefunds([]);
+        expect(getMaxRefundableQuantity(order, line({ orderPlacedQuantity: 0, quantity: 1 }))).toBe(1);
+    });
+
+    it('returns the increased quantity for a line modified during Modifying', () => {
+        const order = orderWithRefunds([]);
+        expect(getMaxRefundableQuantity(order, line({ orderPlacedQuantity: 1, quantity: 2 }))).toBe(2);
+    });
+
+    it('subtracts already-refunded units from the effective quantity (#2608)', () => {
+        const order = orderWithRefunds([{ orderLineId: 'L1', quantity: 2 }]);
+        expect(getMaxRefundableQuantity(order, line({ orderPlacedQuantity: 3, quantity: 1 }))).toBe(1);
+    });
+
+    it('never returns a negative quantity', () => {
+        const order = orderWithRefunds([{ orderLineId: 'L1', quantity: 2 }]);
+        expect(getMaxRefundableQuantity(order, line({ orderPlacedQuantity: 2, quantity: 0 }))).toBe(0);
+    });
+});

--- a/packages/dashboard/src/app/routes/_authenticated/_orders/utils/order-utils.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_orders/utils/order-utils.ts
@@ -185,11 +185,22 @@ export function getRefundedQuantity(order: Order, lineId: string): number {
 }
 
 /**
+ * The quantity of a line that is eligible for refund/cancellation. Uses the greater of
+ * `orderPlacedQuantity` and the current `quantity` so that lines added or increased while
+ * the order was in the `Modifying` state (which keep `orderPlacedQuantity` at their
+ * placement value, 0 for new lines) can still be refunded. Mirrors core's effective-quantity
+ * pattern (see OrderLine price/discount distribution).
+ */
+export function getRefundableQuantity(line: Order['lines'][number]): number {
+    return Math.max(line.orderPlacedQuantity, line.quantity);
+}
+
+/**
  * Checks if an order line can still be refunded (has unrefunded quantity).
  */
 export function lineCanBeRefunded(order: Order, line: Order['lines'][number]): boolean {
     const refundedCount = getRefundedQuantity(order, line.id);
-    return refundedCount < line.orderPlacedQuantity;
+    return refundedCount < getRefundableQuantity(line);
 }
 
 /**
@@ -197,7 +208,7 @@ export function lineCanBeRefunded(order: Order, line: Order['lines'][number]): b
  */
 export function getMaxRefundableQuantity(order: Order, line: Order['lines'][number]): number {
     const refundedCount = getRefundedQuantity(order, line.id);
-    return Math.max(0, line.orderPlacedQuantity - refundedCount);
+    return Math.max(0, getRefundableQuantity(line) - refundedCount);
 }
 
 /**


### PR DESCRIPTION
## Summary

The dashboard **Refund & cancel order** dialog did not reflect line quantities that were added or increased while an order was in the `Modifying` state. Units the customer actually paid for (via an additional payment) could not be refunded, and newly-added lines did not appear at all.

## Root cause

`lineCanBeRefunded` / `getMaxRefundableQuantity` capped the refundable quantity at `OrderLine.orderPlacedQuantity`. That value is set once at order placement — it is `0` for lines added after placement and stays at the pre-increase value for increased lines. It was originally chosen (admin-ui #2608) as a *stable* denominator, because cancelling a line reduces `OrderLine.quantity`.

## Change

Use the effective quantity `Math.max(orderPlacedQuantity, quantity)` (extracted as `getRefundableQuantity`), the same pattern Vendure core already uses for `OrderLine` price/discount distribution. This reflects modified quantities while still preserving the #2608 behaviour (cancelling reduces `quantity`, so `orderPlacedQuantity` remains the upper bound). The dialog's displayed "Qty" now uses the same helper.

## Test plan

**Automated**
- New unit tests `order-utils.spec.ts` (new line `orderPlacedQuantity=0`, increased line, #2608 partial cancel+refund regression guard, fully-refunded, `getRefundableQuantity`).
- New e2e test in `sales/orders.spec.ts`: paid order → `Modifying` → increase line 1→2 → settle additional payment → the refund dialog offers `max=2` and accepts `2`. Confirmed this e2e **fails without the fix** (`max="1"`, input clamps to `1`).
- `bunx vitest run` (dashboard) green; `orders.spec.ts` e2e 18/18 green; typecheck clean on changed files.

**Manual**
- Create a paid order, transition to `Modifying`, increase a line's quantity, settle the additional payment, then open **Refund & cancel** — the increased quantity is shown and fully refundable.

Fixes #4728

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785671328&installation_id=128408429&pr_number=4917&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4917&signature=a1334fdb82df6bf28a9062c2bae70117962111551d89cbc5ed5f77c2f9f647e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->