### PR TITLE
fix(core): validate minimum threshold in promotion conditions

### DIFF
--- a/packages/core/e2e/order-promotion.e2e-spec.ts
+++ b/packages/core/e2e/order-promotion.e2e-spec.ts
@@ -598,6 +598,57 @@ describe('Promotions applied to Orders', () => {
             await deletePromotion(promotion.id);
         });
 
+        // #4889 — minimum of 0 must not create an unconditional discount
+        it('containsProducts does not apply when minimum is 0', async () => {
+            const item5000 = getVariantBySlug('item-5000')!;
+            const promotion = await createPromotion({
+                enabled: true,
+                name: 'Contains products, minimum 0',
+                conditions: [{
+                    code: containsProducts.code,
+                    arguments: [
+                        { name: 'minimum', value: '0' },
+                        { name: 'productVariantIds', value: JSON.stringify([item5000.id]) },
+                    ],
+                }],
+                actions: [freeOrderAction],
+            });
+            // add an item that is NOT in productVariantIds
+            const { addItemToOrder } = await shopClient.query(addItemToOrderDocument, {
+                productVariantId: getVariantBySlug('item-1000').id,
+                quantity: 1,
+            });
+            orderResultGuard.assertSuccess(addItemToOrder);
+            expect(addItemToOrder.discounts.length).toBe(0);
+            await deletePromotion(promotion.id);
+        });
+
+        // #4889 — same guard for the facet-based condition
+        it('atLeastNWithFacets does not apply when minimum is 0', async () => {
+            const { facets } = await adminClient.query(getFacetListDocument);
+            const saleFacetValue = facets.items[0].values[0];
+            const promotion = await createPromotion({
+                enabled: true,
+                name: 'Facets, minimum 0',
+                conditions: [{
+                    code: hasFacetValues.code,
+                    arguments: [
+                        { name: 'minimum', value: '0' },
+                        { name: 'facets', value: `["${saleFacetValue.id}"]` },
+                    ],
+                }],
+                actions: [freeOrderAction],
+            });
+            // add an item WITHOUT the Sale facet
+            const { addItemToOrder } = await shopClient.query(addItemToOrderDocument, {
+                productVariantId: getVariantBySlug('item-1000').id,
+                quantity: 1,
+            });
+            orderResultGuard.assertSuccess(addItemToOrder);
+            expect(addItemToOrder.discounts.length).toBe(0);
+            await deletePromotion(promotion.id);
+        });
+
         it('customerGroup', async () => {
             const { createCustomerGroup } = await adminClient.query(createCustomerGroupDocument, {
                 input: { name: 'Test Group', customerIds: ['T_1'] },

--- a/packages/core/src/config/promotion/conditions/buy-x-get-y-free-condition.ts
+++ b/packages/core/src/config/promotion/conditions/buy-x-get-y-free-condition.ts
@@ -16,7 +16,7 @@ export const buyXGetYFreeCondition = new PromotionCondition({
         amountX: {
             type: 'int',
             defaultValue: 2,
-            ui: { component: '', min: 0 },
+            ui: { component: '', min: 1 },
         },
         variantIdsX: {
             type: 'ID',
@@ -39,6 +39,7 @@ export const buyXGetYFreeCondition = new PromotionCondition({
     async check(ctx, order, args) {
         const xIds = createIdentityMap(args.variantIdsX);
         const yIds = createIdentityMap(args.variantIdsY);
+        if (args.amountX < 1) return false;
         let matches = 0;
         const freeItemCandidates: OrderLine[] = [];
         for (const line of order.lines) {

--- a/packages/core/src/config/promotion/conditions/contains-products-condition.ts
+++ b/packages/core/src/config/promotion/conditions/contains-products-condition.ts
@@ -14,7 +14,7 @@ export const containsProducts = new PromotionCondition({
         minimum: {
             type: 'int',
             defaultValue: 1,
-            ui: { component: '', min: 0 },
+            ui: { component: '', min: 1 },
         },
         productVariantIds: {
             type: 'ID',
@@ -25,6 +25,7 @@ export const containsProducts = new PromotionCondition({
     },
     async check(ctx, order, args) {
         const ids = args.productVariantIds;
+        if (args.minimum < 1) return false;
         let matches = 0;
         for (const line of order.lines) {
             if (lineContainsIds(ids, line)) {

--- a/packages/core/src/config/promotion/conditions/has-facet-values-condition.ts
+++ b/packages/core/src/config/promotion/conditions/has-facet-values-condition.ts
@@ -14,7 +14,7 @@ export const hasFacetValues = new PromotionCondition({
         minimum: {
             type: 'int',
             defaultValue: 1,
-            ui: { component: '', min: 0 },
+            ui: { component: '', min: 1 },
         },
         facets: { type: 'ID', list: true, ui: { component: 'facet-value-form-input' } },
     },
@@ -24,6 +24,7 @@ export const hasFacetValues = new PromotionCondition({
     // eslint-disable-next-line no-shadow,@typescript-eslint/no-shadow
     async check(ctx, order, args) {
         let matches = 0;
+        if (args.minimum < 1) return false;
         for (const line of order.lines) {
             if (await facetValueChecker.hasFacetValues(line, args.facets, ctx)) {
                 matches += line.quantity;


### PR DESCRIPTION
# Description

This PR fixes a boundary-value bug in the `contains_products` and `at_least_n_with_facets` promotion conditions.

## Changes

- Added server-side validation to reject minimum < 1 in the affected promotion conditions and updated the Admin UI hint to use a minimum value of 1.

Fixes #4889.

# Breaking changes

None.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [X ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785834622&installation_id=128408429&pr_number=4922&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4922&signature=6026144375d8f6a39e34500938a23a31d96a44143f9910901fd8283c334a6422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->