### PR TITLE
test(core): Close branch coverage gaps in order tax calculation strategies

### DIFF
--- a/packages/core/src/config/tax/order-tax-calculation-strategy.spec.ts
+++ b/packages/core/src/config/tax/order-tax-calculation-strategy.spec.ts
@@ -1,5 +1,6 @@
 import { beforeAll, describe, expect, it } from 'vitest';
 
+import { Order } from '../../entity/order/order.entity';
 import { ShippingLine } from '../../entity/shipping-line/shipping-line.entity';
 import { Surcharge } from '../../entity/surcharge/surcharge.entity';
 import { createOrder, createRequestContext, taxCategoryStandard } from '../../testing/order-test-utils';
@@ -112,6 +113,51 @@ describe('OrderTaxCalculationStrategy', () => {
             expect(totals.subTotal).toBe(100);
             expect(totals.subTotalWithTax).toBe(100);
             expect(taxSummary).toEqual([]);
+        });
+
+        it('returns zeroed totals and an empty summary when order relations are undefined', () => {
+            // An Order whose `lines`, `surcharges` and `shippingLines` relations have not
+            // been loaded exercises the `?? []` fallbacks in both methods.
+            const order = new Order({});
+
+            const totals = strategy.calculateOrderTotals(order);
+            const taxSummary = strategy.calculateTaxSummary(order);
+
+            expect(totals).toEqual({ subTotal: 0, subTotalWithTax: 0, shipping: 0, shippingWithTax: 0 });
+            expect(taxSummary).toEqual([]);
+        });
+
+        it('skips a line whose taxLines relation is undefined', () => {
+            const ctx = createRequestContext({ pricesIncludeTax: false });
+            const order = createOrder({
+                ctx,
+                lines: [{ listPrice: 100, taxCategory: taxCategoryStandard, quantity: 1 }],
+            });
+            // taxLines undefined (relation not loaded) rather than an empty array:
+            // exercises the optional-chaining branch in `!line.taxLines?.length`.
+            order.lines[0].taxLines = undefined as any;
+
+            const taxSummary = strategy.calculateTaxSummary(order);
+
+            expect(taxSummary).toEqual([]);
+        });
+
+        it('produces a zero-tax summary row for a zero-rate tax line', () => {
+            const ctx = createRequestContext({ pricesIncludeTax: false });
+            const order = createOrder({
+                ctx,
+                lines: [{ listPrice: 300, taxCategory: taxCategoryStandard, quantity: 2 }],
+            });
+            // taxRate 0 -> `proportionOfTotalRate` takes the `: 0` branch, avoiding
+            // a division by the zero total rate.
+            order.lines[0].taxLines = [{ taxRate: 0, description: 'zero-rate' }];
+
+            const totals = strategy.calculateOrderTotals(order);
+            const taxSummary = strategy.calculateTaxSummary(order);
+
+            expect(totals.subTotal).toBe(600);
+            expect(totals.subTotalWithTax).toBe(600);
+            expect(taxSummary).toEqual([{ description: 'zero-rate', taxRate: 0, taxBase: 600, taxTotal: 0 }]);
         });
     });
 
@@ -384,6 +430,18 @@ describe('OrderTaxCalculationStrategy', () => {
             const totals = strategy.calculateOrderTotals(order);
             const taxSummary = strategy.calculateTaxSummary(order);
             expect(totals.subTotal).toBe(100);
+            expect(taxSummary).toEqual([]);
+        });
+
+        it('returns zeroed totals and an empty summary when order relations are undefined', () => {
+            // Undefined `lines`, `surcharges` and `shippingLines` exercise the `?? []`
+            // fallbacks inside `groupOrder`.
+            const order = new Order({});
+
+            const totals = strategy.calculateOrderTotals(order);
+            const taxSummary = strategy.calculateTaxSummary(order);
+
+            expect(totals).toEqual({ subTotal: 0, subTotalWithTax: 0, shipping: 0, shippingWithTax: 0 });
             expect(taxSummary).toEqual([]);
         });
     });


### PR DESCRIPTION
## Description

Part of the Phase 2 work tracked in #4835 — adding direct unit tests for uncovered branches in `@vendure/core` business-logic strategies.

The existing `order-tax-calculation-strategy.spec.ts` (added in #4376) already covers the common paths, but branch coverage measured with `@vitest/coverage-v8` left gaps:

| File | Branch % before | Branch % after |
| --- | :-: | :-: |
| `default-order-tax-calculation-strategy.ts` | 72.4 | **100** |
| `order-level-tax-calculation-strategy.ts` | 88.0 | **100** |

This PR extends the existing spec with 4 targeted tests for the missing branches:

**`DefaultOrderTaxCalculationStrategy`**
- Undefined `lines` / `surcharges` / `shippingLines` relations — the `?? []` fallbacks in both `calculateOrderTotals` and `calculateTaxSummary`.
- A line whose `taxLines` relation is `undefined` (rather than an empty array) — the optional-chaining branch in `!line.taxLines?.length`.
- A zero-rate tax line — the `: 0` branch of `proportionOfTotalRate`, which guards against dividing by a zero total rate.

**`OrderLevelTaxCalculationStrategy`**
- Undefined order relations, exercising the `?? []` fallbacks inside `groupOrder`.

## Breaking changes

None. Test-only change — no production code is modified.

Relates to #4835

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785889184&installation_id=128408429&pr_number=4924&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4924&signature=330d8f7f19663a4015336f80eef097d3b05645d168a05bd9b47c698052dca959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->