### PR TITLE
test(core): Add unit tests for default shipping calculator

### DIFF
--- a/packages/core/src/config/shipping-method/default-shipping-calculator.spec.ts
+++ b/packages/core/src/config/shipping-method/default-shipping-calculator.spec.ts
@@ -1,0 +1,84 @@
+import { ConfigArg } from '@vendure/common/lib/generated-types';
+import { describe, expect, it } from 'vitest';
+
+import { RequestContext } from '../../api/common/request-context';
+import { Order } from '../../entity/order/order.entity';
+import { ShippingMethod } from '../../entity/shipping-method/shipping-method.entity';
+import { createRequestContext } from '../../testing/order-test-utils';
+
+import { defaultShippingCalculator, TaxSetting } from './default-shipping-calculator';
+
+/**
+ * Unit tests for the `default-shipping-calculator`.
+ *
+ * The calculator echoes the configured `rate`/`taxRate` and resolves
+ * `priceIncludesTax` from the `includesTax` argument. Test cases are derived by
+ * equivalence partitioning over the three `TaxSetting` values, with the `auto`
+ * partition split into its two sub-cases (channel prices include tax or not) to
+ * cover both branches of `ctx.channel.pricesIncludeTax`.
+ */
+
+/** Build the serialized `ConfigArg[]` the way the framework passes them to `calculate()`. */
+function buildArgs(input: { rate: number; includesTax: TaxSetting; taxRate: number }): ConfigArg[] {
+    return [
+        { name: 'rate', value: String(input.rate) },
+        { name: 'includesTax', value: input.includesTax },
+        { name: 'taxRate', value: String(input.taxRate) },
+    ] as ConfigArg[];
+}
+
+function calculate(ctx: RequestContext, args: ConfigArg[]) {
+    // The `order` and `method` arguments are unused by this calculator.
+    return defaultShippingCalculator.calculate(
+        ctx,
+        undefined as unknown as Order,
+        args,
+        undefined as unknown as ShippingMethod,
+    );
+}
+
+describe('defaultShippingCalculator', () => {
+    it('echoes the configured rate and taxRate', () => {
+        const ctx = createRequestContext({ pricesIncludeTax: false });
+        const result = calculate(ctx, buildArgs({ rate: 500, includesTax: TaxSetting.exclude, taxRate: 20 }));
+
+        expect(result.price).toBe(500);
+        expect(result.taxRate).toBe(20);
+    });
+
+    describe('includesTax resolution (equivalence partitioning over TaxSetting)', () => {
+        it('returns priceIncludesTax = true when includesTax is "include"', () => {
+            const ctx = createRequestContext({ pricesIncludeTax: false });
+            const result = calculate(
+                ctx,
+                buildArgs({ rate: 500, includesTax: TaxSetting.include, taxRate: 0 }),
+            );
+
+            expect(result.priceIncludesTax).toBe(true);
+        });
+
+        it('returns priceIncludesTax = false when includesTax is "exclude"', () => {
+            const ctx = createRequestContext({ pricesIncludeTax: true });
+            const result = calculate(
+                ctx,
+                buildArgs({ rate: 500, includesTax: TaxSetting.exclude, taxRate: 0 }),
+            );
+
+            expect(result.priceIncludesTax).toBe(false);
+        });
+
+        it('follows the channel when includesTax is "auto" and channel prices include tax', () => {
+            const ctx = createRequestContext({ pricesIncludeTax: true });
+            const result = calculate(ctx, buildArgs({ rate: 500, includesTax: TaxSetting.auto, taxRate: 0 }));
+
+            expect(result.priceIncludesTax).toBe(true);
+        });
+
+        it('follows the channel when includesTax is "auto" and channel prices exclude tax', () => {
+            const ctx = createRequestContext({ pricesIncludeTax: false });
+            const result = calculate(ctx, buildArgs({ rate: 500, includesTax: TaxSetting.auto, taxRate: 0 }));
+
+            expect(result.priceIncludesTax).toBe(false);
+        });
+    });
+});


### PR DESCRIPTION
## Description

Part of the Phase 3 work tracked in #4835 — adding direct unit tests for uncovered business-logic strategies in `@vendure/core`.

The `default-shipping-calculator`'s `calculate` function was only exercised transitively (0% direct function coverage). This PR adds a small, database-free unit spec:

- Equivalence partitioning over the three `TaxSetting` values (`include` / `exclude` / `auto`) resolved by `getPriceIncludesTax`.
- The `auto` partition is split into its two sub-cases so both branches of `ctx.channel.pricesIncludeTax` are covered.
- One case asserts the configured `rate` / `taxRate` are echoed through unchanged.

Coverage of `default-shipping-calculator.ts` goes from 0% function / partial branch to **100%** on all metrics.

## Breaking changes

None. Test-only change — no production code is modified.

Relates to #4835

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4925"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785889263&installation_id=128408429&pr_number=4925&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4925&signature=9b750f27c9cb93cbe59e879508e86075f164ee08b02c070b34263284c17b04f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->