### PR TITLE
test(core): Add unit tests for default shipping line assignment strategy

### DIFF
--- a/packages/core/src/config/shipping-method/default-shipping-line-assignment-strategy.spec.ts
+++ b/packages/core/src/config/shipping-method/default-shipping-line-assignment-strategy.spec.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { RequestContext } from '../../api/common/request-context';
+import { OrderLine } from '../../entity/order-line/order-line.entity';
+import { Order } from '../../entity/order/order.entity';
+import { ShippingLine } from '../../entity/shipping-line/shipping-line.entity';
+
+import { DefaultShippingLineAssignmentStrategy } from './default-shipping-line-assignment-strategy';
+
+/**
+ * Unit tests for the DefaultShippingLineAssignmentStrategy, which assigns every
+ * OrderLine of the order to the given ShippingLine (the common single-shipping-
+ * method scenario). The `ctx` and `shippingLine` arguments do not affect the
+ * result, so partitioning is over the order's line set.
+ */
+describe('DefaultShippingLineAssignmentStrategy', () => {
+    const strategy = new DefaultShippingLineAssignmentStrategy();
+    const ctx = {} as RequestContext;
+    const shippingLine = {} as ShippingLine;
+
+    it('assigns all of the order lines to the shipping line', async () => {
+        const lines = [new OrderLine({ id: 'l1' }), new OrderLine({ id: 'l2' })];
+        const order = new Order({ lines });
+
+        const result = await strategy.assignShippingLineToOrderLines(ctx, shippingLine, order);
+
+        expect(result).toEqual(lines);
+    });
+
+    it('returns an empty array when the order has no lines', async () => {
+        const order = new Order({ lines: [] });
+
+        const result = await strategy.assignShippingLineToOrderLines(ctx, shippingLine, order);
+
+        expect(result).toEqual([]);
+    });
+});


### PR DESCRIPTION
## Description

Part of the Phase 3 work tracked in #4835 — adding direct unit tests for uncovered business-logic strategies in `@vendure/core`.

`DefaultShippingLineAssignmentStrategy.assignShippingLineToOrderLines` was only exercised transitively (0% direct function coverage). This PR adds a small, database-free unit spec covering the two partitions of the order's line set:

- An order with lines → all lines are returned (assigned to the shipping line).
- An order with no lines → an empty array is returned.

Coverage of `default-shipping-line-assignment-strategy.ts` goes to **100%** on all metrics.

## Breaking changes

None. Test-only change — no production code is modified.

Relates to #4835

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785889357&installation_id=128408429&pr_number=4926&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4926&signature=ed10146707a328c9ddab144f9327ac9b03f2ef6e27e557ebd340c3ddcab64aee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->