### PR TITLE
Fix typo in channel-aware entities description

### DIFF
--- a/docs/docs/guides/core-concepts/channels/index.mdx
+++ b/docs/docs/guides/core-concepts/channels/index.mdx
@@ -29,7 +29,7 @@ Every Vendure server always has a **default Channel**, which contains _all_ enti
 
 ## Channel-aware entities
 
-Many entities are channel-aware, meaning that they can be associated with a multiple channels. The following entities are channel-aware:
+Many entities are channel-aware, meaning that they can be associated with multiple channels. The following entities are channel-aware:
 
 - [`Asset`](/reference/typescript-api/entities/asset/)
 - [`Collection`](/reference/typescript-api/entities/collection/)


### PR DESCRIPTION
# Description

Please include a summary of the changes and the related issue.
Just a typo in the docs

# Breaking changes

Does this PR include any breaking changes we should be aware of? 
No.

# Screenshots

You can add screenshots here if applicable.

# Checklist

📌 Always:
- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1785923582&installation_id=128408429&pr_number=4927&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4927&signature=d4e6e1eaeb8cc42d1b337f7b80ebbdd148e692368bc54981450038874e4d1b45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->