### PR TITLE
docs(core): Fix description for inner workings of DefaultMoneyStrategy

### DIFF
--- a/docs/docs/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy.mdx
+++ b/docs/docs/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## S3AssetStorageStrategy
 
-<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="155" packageName="@vendure/asset-server-plugin" />
+<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="156" packageName="@vendure/asset-server-plugin" />
 
 An [AssetStorageStrategy](/reference/typescript-api/assets/asset-storage-strategy#assetstoragestrategy) which uses [Amazon S3](https://aws.amazon.com/s3/) object storage service.
 To us this strategy you must first have access to an AWS account.
@@ -86,7 +86,7 @@ class S3AssetStorageStrategy implements AssetStorageStrategy {
 </div>
 ## S3Config
 
-<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="19" packageName="@vendure/asset-server-plugin" />
+<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="20" packageName="@vendure/asset-server-plugin" />
 
 Configuration for connecting to AWS S3.
 
@@ -133,7 +133,7 @@ Using type `any` in order to avoid the need to include `aws-sdk` dependency in g
 </div>
 ## configureS3AssetStorage
 
-<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="119" packageName="@vendure/asset-server-plugin" />
+<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="120" packageName="@vendure/asset-server-plugin" />
 
 Returns a configured instance of the [S3AssetStorageStrategy](/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy#s3assetstoragestrategy) which can then be passed to the [AssetServerOptions](/reference/core-plugins/asset-server-plugin/asset-server-options#assetserveroptions)`storageStrategyFactory` property.
 

--- a/docs/docs/reference/typescript-api/money/money-strategy.mdx
+++ b/docs/docs/reference/typescript-api/money/money-strategy.mdx
@@ -94,10 +94,19 @@ UI as to how many decimal places to display.
 <MemberInfo kind="method" type={`(value: number, quantity?: number) => number`}   />
 
 Defines the logic used to round monetary values. For instance, the default behavior
-in the [DefaultMoneyStrategy](/reference/typescript-api/money/default-money-strategy#defaultmoneystrategy) is to multiply, then round the value.
+in the [DefaultMoneyStrategy](/reference/typescript-api/money/default-money-strategy#defaultmoneystrategy) is to multiply the unit value by the
+quantity and then round the result:
 
 ```ts
 return Math.round(value * quantity);
+```
+
+However, it may be desirable to instead round the unit amount _before_
+multiplying (this was the default prior to v3.1). In this case you can
+define a custom strategy with logic like this:
+
+```ts
+return Math.round(value) * quantity;
 ```
 
 

--- a/docs/docs/reference/typescript-api/money/money-strategy.mdx
+++ b/docs/docs/reference/typescript-api/money/money-strategy.mdx
@@ -94,14 +94,7 @@ UI as to how many decimal places to display.
 <MemberInfo kind="method" type={`(value: number, quantity?: number) => number`}   />
 
 Defines the logic used to round monetary values. For instance, the default behavior
-in the [DefaultMoneyStrategy](/reference/typescript-api/money/default-money-strategy#defaultmoneystrategy) is to round the value, then multiply.
-
-```ts
-return Math.round(value * quantity);
-```
-
-However, it may be desirable to instead round only _after_ the unit amount has been
-multiplied. In this case you can define a custom strategy with logic like this:
+in the [DefaultMoneyStrategy](/reference/typescript-api/money/default-money-strategy#defaultmoneystrategy) is to multiply, then round the value.
 
 ```ts
 return Math.round(value * quantity);

--- a/packages/core/src/config/entity/money-strategy.ts
+++ b/packages/core/src/config/entity/money-strategy.ts
@@ -85,10 +85,19 @@ export interface MoneyStrategy extends InjectableStrategy {
     /**
      * @description
      * Defines the logic used to round monetary values. For instance, the default behavior
-     * in the {@link DefaultMoneyStrategy} is to multiply, then round the value.
+     * in the {@link DefaultMoneyStrategy} is to multiply the unit value by the
+     * quantity and then round the result:
      *
      * ```ts
      * return Math.round(value * quantity);
+     * ```
+     *
+     * However, it may be desirable to instead round the unit amount _before_
+     * multiplying (this was the default prior to v3.1). In this case you can
+     * define a custom strategy with logic like this:
+     *
+     * ```ts
+     * return Math.round(value) * quantity;
      * ```
      */
     round(value: number, quantity?: number): number;

--- a/packages/core/src/config/entity/money-strategy.ts
+++ b/packages/core/src/config/entity/money-strategy.ts
@@ -85,14 +85,7 @@ export interface MoneyStrategy extends InjectableStrategy {
     /**
      * @description
      * Defines the logic used to round monetary values. For instance, the default behavior
-     * in the {@link DefaultMoneyStrategy} is to round the value, then multiply.
-     *
-     * ```ts
-     * return Math.round(value * quantity);
-     * ```
-     *
-     * However, it may be desirable to instead round only _after_ the unit amount has been
-     * multiplied. In this case you can define a custom strategy with logic like this:
+     * in the {@link DefaultMoneyStrategy} is to multiply, then round the value.
      *
      * ```ts
      * return Math.round(value * quantity);


### PR DESCRIPTION
# Description

The documentation reflected the change in #3023. However, the related description was outdated.


# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] ~~I have added or updated test cases~~
- [ ] ~~I have updated the README if needed~~

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4929"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786026018&installation_id=128408429&pr_number=4929&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4929&signature=de3bff0354b9798b9a1ed18f8b56ee24e4b118a253b5d118ebfe036fadccb8d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->