### PR TITLE
feat(core): Add duplicateOptions support to product duplicator

### DIFF
--- a/packages/core/e2e/duplicate-entity.e2e-spec.ts
+++ b/packages/core/e2e/duplicate-entity.e2e-spec.ts
@@ -29,6 +29,7 @@ import {
     createAdministratorDocument,
     createChannelDocument,
     createCollectionDocument,
+    createProductDocument,
     createPromotionDocument,
     createRoleDocument,
     duplicateEntityDocument,
@@ -38,6 +39,7 @@ import {
     getFacetWithValuesDocument,
     getProductWithVariantsDocument,
     getPromotionDocument,
+    updateProductOptionGroupDocument,
     updateProductVariantsDocument,
 } from './graphql/shared-definitions';
 
@@ -425,6 +427,182 @@ describe('Duplicating entities', () => {
                     'L2201508-copy',
                     'L2201516-copy',
                 ]);
+            });
+
+            it('by default (duplicateOptions unset), option groups are shared with the original', async () => {
+                const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                    id: newProduct2Id,
+                });
+
+                expect(product?.optionGroups.map(g => g.id).sort()).toEqual(
+                    originalProduct.optionGroups.map(g => g.id).sort(),
+                );
+            });
+
+            it('duplicating without variants does not touch option groups regardless of duplicateOptions', async () => {
+                const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                    id: newProduct1Id,
+                });
+
+                expect(product?.optionGroups.length).toBe(0);
+            });
+
+            describe('duplicateOptions arg enabled', () => {
+                let newProduct3Id: string;
+
+                it('duplicates the product with duplicateOptions enabled', async () => {
+                    const { duplicateEntity } = await adminClient.query(duplicateEntityDocument, {
+                        input: {
+                            entityName: 'Product',
+                            entityId: 'T_1',
+                            duplicatorInput: {
+                                code: 'product-duplicator',
+                                arguments: [
+                                    { name: 'includeVariants', value: 'true' },
+                                    { name: 'duplicateOptions', value: 'true' },
+                                ],
+                            },
+                        },
+                    });
+
+                    duplicateEntityGuard.assertSuccess(duplicateEntity);
+                    newProduct3Id = duplicateEntity.newEntityId;
+                });
+
+                it('option groups are duplicated as new entities', async () => {
+                    const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                        id: newProduct3Id,
+                    });
+
+                    expect(product?.optionGroups.length).toBe(originalProduct.optionGroups.length);
+
+                    const originalGroupIds = originalProduct.optionGroups.map(g => g.id);
+                    for (const group of product!.optionGroups) {
+                        expect(originalGroupIds).not.toContain(group.id);
+                    }
+
+                    expect(product?.optionGroups.map(g => g.code).sort()).toEqual(
+                        originalProduct.optionGroups.map(g => `${g.code}-copy`).sort(),
+                    );
+                    expect(product?.optionGroups.map(g => g.name).sort()).toEqual(
+                        originalProduct.optionGroups.map(g => g.name).sort(),
+                    );
+                });
+
+                it('variants reference the duplicated options, not the originals', async () => {
+                    const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                        id: newProduct3Id,
+                    });
+
+                    const newGroupIds = product!.optionGroups.map(g => g.id);
+                    const originalOptionIds = originalProduct.variants.flatMap(v =>
+                        v.options.map(o => o.id),
+                    );
+
+                    for (const variant of product!.variants) {
+                        for (const option of variant.options) {
+                            expect(newGroupIds).toContain(option.groupId);
+                            expect(originalOptionIds).not.toContain(option.id);
+                            expect(option.code.endsWith('-copy')).toBe(true);
+                        }
+                    }
+
+                    expect(product?.variants.flatMap(v => v.options.map(o => o.name)).sort()).toEqual(
+                        originalProduct.variants.flatMap(v => v.options.map(o => o.name)).sort(),
+                    );
+                });
+
+                it('editing a duplicated option group does not affect the original', async () => {
+                    const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                        id: newProduct3Id,
+                    });
+                    const duplicatedGroup = product!.optionGroups[0];
+
+                    await adminClient.query(updateProductOptionGroupDocument, {
+                        input: {
+                            id: duplicatedGroup.id,
+                            translations: [{ languageCode: LanguageCode.en, name: 'Modified Name' }],
+                        },
+                    });
+
+                    const { product: originalReloaded } = await adminClient.query(
+                        getProductWithVariantsDocument,
+                        {
+                            id: 'T_1',
+                        },
+                    );
+
+                    expect(originalReloaded?.optionGroups.map(g => g.name)).not.toContain('Modified Name');
+                });
+
+                it('duplicating the same product twice creates independent option groups', async () => {
+                    const { duplicateEntity } = await adminClient.query(duplicateEntityDocument, {
+                        input: {
+                            entityName: 'Product',
+                            entityId: 'T_1',
+                            duplicatorInput: {
+                                code: 'product-duplicator',
+                                arguments: [
+                                    { name: 'includeVariants', value: 'true' },
+                                    { name: 'duplicateOptions', value: 'true' },
+                                ],
+                            },
+                        },
+                    });
+                    duplicateEntityGuard.assertSuccess(duplicateEntity);
+                    const anotherDuplicateId = duplicateEntity.newEntityId;
+
+                    const { product: firstDuplicate } = await adminClient.query(
+                        getProductWithVariantsDocument,
+                        { id: newProduct3Id },
+                    );
+                    const { product: secondDuplicate } = await adminClient.query(
+                        getProductWithVariantsDocument,
+                        { id: anotherDuplicateId },
+                    );
+
+                    const firstGroupIds = firstDuplicate!.optionGroups.map(g => g.id).sort();
+                    const secondGroupIds = secondDuplicate!.optionGroups.map(g => g.id).sort();
+
+                    expect(firstGroupIds).not.toEqual(secondGroupIds);
+                });
+
+                it('duplicating a product with no option groups succeeds without errors', async () => {
+                    const { createProduct } = await adminClient.query(createProductDocument, {
+                        input: {
+                            translations: [
+                                {
+                                    languageCode: LanguageCode.en,
+                                    name: 'Plain Product',
+                                    slug: 'plain-product',
+                                    description: 'A product with no option groups',
+                                },
+                            ],
+                        },
+                    });
+
+                    const { duplicateEntity } = await adminClient.query(duplicateEntityDocument, {
+                        input: {
+                            entityName: 'Product',
+                            entityId: createProduct.id,
+                            duplicatorInput: {
+                                code: 'product-duplicator',
+                                arguments: [
+                                    { name: 'includeVariants', value: 'true' },
+                                    { name: 'duplicateOptions', value: 'true' },
+                                ],
+                            },
+                        },
+                    });
+
+                    duplicateEntityGuard.assertSuccess(duplicateEntity);
+
+                    const { product } = await adminClient.query(getProductWithVariantsDocument, {
+                        id: duplicateEntity.newEntityId,
+                    });
+
+                    expect(product?.optionGroups.length).toBe(0);
+                });
             });
 
             it('variant assets are preserved', async () => {

--- a/packages/core/src/config/entity/entity-duplicators/product-duplicator.ts
+++ b/packages/core/src/config/entity/entity-duplicators/product-duplicator.ts
@@ -5,6 +5,7 @@ import {
     Permission,
     ProductTranslationInput,
 } from '@vendure/common/lib/generated-types';
+import { ID } from '@vendure/common/lib/shared-types';
 import { IsNull } from 'typeorm';
 
 import { idsAreEqual } from '../../../common';
@@ -12,6 +13,8 @@ import { Injector } from '../../../common/injector';
 import { TransactionalConnection } from '../../../connection/transactional-connection';
 import { ProductVariant } from '../../../entity/product-variant/product-variant.entity';
 import { Product } from '../../../entity/product/product.entity';
+import { ProductOptionGroupService } from '../../../service/services/product-option-group.service';
+import { ProductOptionService } from '../../../service/services/product-option.service';
 import { ProductVariantService } from '../../../service/services/product-variant.service';
 import { ProductService } from '../../../service/services/product.service';
 import { EntityDuplicator } from '../entity-duplicator';
@@ -19,6 +22,8 @@ import { EntityDuplicator } from '../entity-duplicator';
 let connection: TransactionalConnection;
 let productService: ProductService;
 let productVariantService: ProductVariantService;
+let productOptionGroupService: ProductOptionGroupService;
+let productOptionService: ProductOptionService;
 
 /**
  * @description
@@ -40,11 +45,24 @@ export const productDuplicator = new EntityDuplicator({
             defaultValue: true,
             label: [{ languageCode: LanguageCode.en, value: 'Include variants' }],
         },
+        duplicateOptions: {
+            type: 'boolean',
+            defaultValue: false,
+            label: [{ languageCode: LanguageCode.en, value: 'Duplicate options' }],
+            description: [
+                {
+                    languageCode: LanguageCode.en,
+                    value: 'If enabled, new option groups/options are created for the duplicate. Otherwise it shares the original’s option groups.',
+                },
+            ],
+        },
     },
     init(injector: Injector) {
         connection = injector.get(TransactionalConnection);
         productService = injector.get(ProductService);
         productVariantService = injector.get(ProductVariantService);
+        productOptionGroupService = injector.get(ProductOptionGroupService);
+        productOptionService = injector.get(ProductOptionService);
     },
     async duplicate({ ctx, id, args }) {
         const product = await connection.getEntityOrThrow(ctx, Product, id, {
@@ -98,13 +116,63 @@ export const productDuplicator = new EntityDuplicator({
                     taxCategory: true,
                 },
             });
+            const optionIdMap = new Map<ID, ID>();
             if (product.optionGroups?.length) {
                 for (const optionGroup of product.optionGroups) {
-                    await productService.addOptionGroupToProduct(ctx, duplicatedProduct.id, optionGroup.id);
+                    if (args.duplicateOptions) {
+                        // Create a new ProductOptionGroup
+                        const duplicatedGroup = await productOptionGroupService.create(ctx, {
+                            code: `${optionGroup.code}-copy`,
+                            translations: optionGroup.translations.map(translation => ({
+                                languageCode: translation.languageCode,
+                                name: translation.name,
+                                customFields: translation.customFields,
+                            })),
+                            customFields: optionGroup.customFields,
+                        });
+                        await productService.addOptionGroupToProduct(
+                            ctx,
+                            duplicatedProduct.id,
+                            duplicatedGroup.id,
+                        );
+                        // Duplicate every ProductOption
+                        for (const option of optionGroup.options) {
+                            const duplicatedOption = await productOptionService.create(
+                                ctx,
+                                duplicatedGroup.id,
+                                {
+                                    code: `${option.code}-copy`,
+                                    customFields: option.customFields,
+                                    translations: option.translations.map(translation => ({
+                                        languageCode: translation.languageCode,
+                                        name: translation.name,
+                                        customFields: translation.customFields,
+                                    })),
+                                },
+                            );
+                            optionIdMap.set(option.id, duplicatedOption.id);
+                        }
+                    } else {
+                        // Share the original ProductOptionGroup with the duplicate
+                        await productService.addOptionGroupToProduct(
+                            ctx,
+                            duplicatedProduct.id,
+                            optionGroup.id,
+                        );
+                    }
                 }
             }
             const variantInput: CreateProductVariantInput[] = productVariants.map((variant, i) => {
-                const optionIds = variant.options.map(o => o.id);
+                const optionIds = variant.options.map(o => {
+                    if (!args.duplicateOptions) {
+                        return o.id;
+                    }
+                    const duplicatedOptionId = optionIdMap.get(o.id);
+                    if (!duplicatedOptionId) {
+                        throw new Error(`Failed to locate duplicated ProductOption for option ${o.id}`);
+                    }
+                    return duplicatedOptionId;
+                });
                 const price =
                     variant.productVariantPrices.find(p => idsAreEqual(p.channelId, ctx.channelId))?.price ??
                     variant.productVariantPrices[0]?.price;


### PR DESCRIPTION
# Description

## Summary

This PR adds a new `duplicateOptions` argument to the default product duplicator.

When enabled, the duplicator creates new `ProductOptionGroup` and `ProductOption` entities for the duplicated product instead of reusing the original option groups and options. Product variants are then recreated using the duplicated options, ensuring the duplicated product is independent of the original.

When the option is disabled, the existing behavior is preserved.

## Related issue

N/A

# Breaking changes

None.

# Screenshots

N/A

# Checklist

📌 Always:

* [x] I have set a clear title
* [x] My PR is small and contains a single feature
* [x] I have checked my own PR

👍 Most of the time:

* [x] I have added or updated test cases
* [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786103428&installation_id=128408429&pr_number=4934&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4934&signature=c8924b69d0cd06df3cab03f96f0359324e65b3507001caf5a8ed96008f7325d2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->