### PR TITLE
ci: skip docs workflows on draft PRs

### DIFF
--- a/.github/workflows/docs_ci.yml
+++ b/.github/workflows/docs_ci.yml
@@ -11,6 +11,7 @@ on:
             - '!docs/manifest.json'
             - 'lerna.json'
     pull_request:
+        types: [opened, synchronize, reopened, ready_for_review]
         branches:
             - master
             - minor
@@ -27,6 +28,8 @@ concurrency:
 jobs:
     validate:
         name: Validate MDX
+        # Skip draft PRs
+        if: ${{ github.event_name == 'push' || !github.event.pull_request.draft }}
         permissions:
             contents: read
         runs-on: ubuntu-latest
@@ -48,8 +51,8 @@ jobs:
 
     generate-manifest:
         name: Generate & commit manifest
-        # Skip fork PRs — can't push back to fork branches
-        if: ${{ github.event_name == 'push' || !github.event.pull_request.head.repo.fork }}
+        # Skip fork PRs (can't push back to fork branches) and draft PRs
+        if: ${{ github.event_name == 'push' || (!github.event.pull_request.head.repo.fork && !github.event.pull_request.draft) }}
         runs-on: ubuntu-latest
         permissions:
             contents: write

--- a/.github/workflows/generate_docs.yml
+++ b/.github/workflows/generate_docs.yml
@@ -2,6 +2,7 @@ name: Generate Docs
 
 on:
     pull_request:
+        types: [opened, synchronize, reopened, ready_for_review]
         branches:
             - master
             - minor
@@ -17,8 +18,8 @@ concurrency:
 jobs:
     generate:
         name: Generate & commit docs
-        # Skip fork PRs — can't push back to fork branches
-        if: ${{ !github.event.pull_request.head.repo.fork }}
+        # Skip fork PRs (can't push back to fork branches) and draft PRs
+        if: ${{ !github.event.pull_request.head.repo.fork && !github.event.pull_request.draft }}
         runs-on: ubuntu-latest
         permissions:
             contents: write


### PR DESCRIPTION
# Description

Docs CI and Generate Docs currently run on draft PRs, which means the CI bot regenerates and pushes `manifest.json` / generated API docs commits to branches that are still work-in-progress. This PR skips both workflows entirely for draft PRs:

- Added `!github.event.pull_request.draft` guards to all jobs (`validate`, `generate-manifest` in Docs CI; `generate` in Generate Docs). GitHub Actions has no workflow-level `if`, so the condition is applied per job.
- Added `ready_for_review` to the `pull_request` trigger types of both workflows, so validation and doc generation run as soon as a PR leaves draft state (otherwise nothing would fire until the next push).

Push-triggered runs of Docs CI are unaffected.

# Breaking changes

None.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4938"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786200484&installation_id=128408429&pr_number=4938&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4938&signature=8b51e5902bfc7e75963f8206b60893751ea40470c3874a927999e33f514c3b90"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->