### PR TITLE
fix(core): retain v3.6 migration helpers to avoid breaking committed migrations

### DIFF
--- a/docs/docs/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy.mdx
+++ b/docs/docs/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## S3AssetStorageStrategy
 
-<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="155" packageName="@vendure/asset-server-plugin" />
+<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="156" packageName="@vendure/asset-server-plugin" />
 
 An [AssetStorageStrategy](/reference/typescript-api/assets/asset-storage-strategy#assetstoragestrategy) which uses [Amazon S3](https://aws.amazon.com/s3/) object storage service.
 To us this strategy you must first have access to an AWS account.
@@ -86,7 +86,7 @@ class S3AssetStorageStrategy implements AssetStorageStrategy {
 </div>
 ## S3Config
 
-<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="19" packageName="@vendure/asset-server-plugin" />
+<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="20" packageName="@vendure/asset-server-plugin" />
 
 Configuration for connecting to AWS S3.
 
@@ -133,7 +133,7 @@ Using type `any` in order to avoid the need to include `aws-sdk` dependency in g
 </div>
 ## configureS3AssetStorage
 
-<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="119" packageName="@vendure/asset-server-plugin" />
+<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="120" packageName="@vendure/asset-server-plugin" />
 
 Returns a configured instance of the [S3AssetStorageStrategy](/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy#s3assetstoragestrategy) which can then be passed to the [AssetServerOptions](/reference/core-plugins/asset-server-plugin/asset-server-options#assetserveroptions)`storageStrategyFactory` property.
 

--- a/docs/docs/reference/typescript-api/migration/migrate-asset-translation-data.mdx
+++ b/docs/docs/reference/typescript-api/migration/migrate-asset-translation-data.mdx
@@ -2,7 +2,7 @@
 title: "MigrateAssetTranslationData"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_asset_translations.ts" sourceLine="41" packageName="@vendure/core" since="3.6.0" />
+<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_asset_translations.ts" sourceLine="43" packageName="@vendure/core" since="3.6.0" />
 
 Populates the new `asset_translation` table with data from the existing `name`
 column on `asset`, using the default channel's language code.

--- a/docs/docs/reference/typescript-api/migration/migrate-product-option-group-data.mdx
+++ b/docs/docs/reference/typescript-api/migration/migrate-product-option-group-data.mdx
@@ -2,7 +2,7 @@
 title: "MigrateProductOptionGroupData"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_shared_option_groups.ts" sourceLine="41" packageName="@vendure/core" since="3.6.0" />
+<GenerationInfo sourceFile="packages/core/src/migration-utils/v3_6_shared_option_groups.ts" sourceLine="43" packageName="@vendure/core" since="3.6.0" />
 
 Populates the new join tables for shared, channel-aware ProductOptionGroups
 using data from the existing `productId` FK column on `product_option_group`.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2296,13 +2296,13 @@
                   "title": "MigrateAssetTranslationData",
                   "slug": "migrate-asset-translation-data",
                   "file": "docs/reference/typescript-api/migration/migrate-asset-translation-data.mdx",
-                  "lastModified": "2026-03-30T12:56:43+02:00"
+                  "lastModified": "2026-07-09T17:45:01Z"
                 },
                 {
                   "title": "MigrateProductOptionGroupData",
                   "slug": "migrate-product-option-group-data",
                   "file": "docs/reference/typescript-api/migration/migrate-product-option-group-data.mdx",
-                  "lastModified": "2026-03-06T09:35:25+01:00"
+                  "lastModified": "2026-07-09T17:45:01Z"
                 },
                 {
                   "title": "MigrationOptions",
@@ -3548,7 +3548,7 @@
                   "title": "S3AssetStorageStrategy",
                   "slug": "s3asset-storage-strategy",
                   "file": "docs/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-09T17:45:01Z"
                 },
                 {
                   "title": "SharpAssetPreviewStrategy",

--- a/packages/core/src/migration-utils/v3_6_asset_translations.ts
+++ b/packages/core/src/migration-utils/v3_6_asset_translations.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
-// TODO: Remove this file once v3.6 has been stable for a while. It is a one-time
-// migration helper and will not be needed after all users have upgraded past v3.6.
+// This one-time v3.6 migration helper must remain exported indefinitely: user migrations
+// import it directly, so removing the export would break compilation of any committed
+// migration that calls it. The guard against the already-migrated state makes it a safe no-op
+// once the migration has run.
 import { QueryRunner } from 'typeorm';
 
 /**

--- a/packages/core/src/migration-utils/v3_6_shared_option_groups.ts
+++ b/packages/core/src/migration-utils/v3_6_shared_option_groups.ts
@@ -1,6 +1,8 @@
 /* eslint-disable no-console */
-// TODO: Remove this file once v3.6 has been stable for a while. It is a one-time
-// migration helper and will not be needed after all users have upgraded past v3.6.
+// This one-time v3.6 migration helper must remain exported indefinitely: user migrations
+// import it directly, so removing the export would break compilation of any committed
+// migration that calls it. The guard against the already-migrated state makes it a safe no-op
+// once the migration has run.
 import { QueryRunner } from 'typeorm';
 
 /**


### PR DESCRIPTION
## Summary

Removes the `// TODO: Remove this file once v3.6 has been stable for a while` comment from the two v3.6 migration helpers and documents why they must instead be kept published:

- `packages/core/src/migration-utils/v3_6_shared_option_groups.ts` (`migrateProductOptionGroupData`)
- `packages/core/src/migration-utils/v3_6_asset_translations.ts` (`migrateAssetTranslationData`)

## Why

These helpers are designed to be **imported directly into user migration files** (that's what the docs examples show):

```ts
import { migrateProductOptionGroupData } from '@vendure/core';
```

Migration files are compiled as part of a project's build, and they are immutable historical records. So if a future core release removes the export (as the TODO plans), then **every project that followed the documented v3.6 upgrade path** will have a committed migration whose import no longer resolves — a build-breaking `TS2305` on their next compile, hitting precisely the users who did the right thing.

The two options are mutually exclusive:

- users import the helper → it can never be safely removed, or
- we want to remove it → users must not import it (inline the SQL instead).

Since the helpers already guard against the already-migrated state (`hasColumn(...)`), keeping them exported indefinitely is a cheap no-op and the safe choice. This PR just makes that explicit and drops the plan-to-delete.

No functional change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4939"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786211049&installation_id=128408429&pr_number=4939&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4939&signature=9be1ac1c0a337574da403427ef4fca3407f5c131f19e60bd6474f9eafef913ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->