### PR TITLE
fix(dashboard): Clear asset selection after bulk action completes

### DIFF
--- a/packages/dashboard/src/lib/components/shared/asset/asset-gallery.tsx
+++ b/packages/dashboard/src/lib/components/shared/asset/asset-gallery.tsx
@@ -419,7 +419,14 @@ export function AssetGallery({
 
             {/* Bulk actions bar */}
             {displayBulkActions ? (
-                <AssetBulkActions selection={selected} bulkActions={bulkActions} refetch={refetch} />
+                <AssetBulkActions
+                    selection={selected}
+                    bulkActions={bulkActions}
+                    refetch={() => {
+                        setSelected([]);
+                        refetch();
+                    }}
+                />
             ) : null}
 
             <div


### PR DESCRIPTION
## Description

After performing a bulk action on selected assets (e.g. deleting 18 assets), the "X selected" bar at the bottom of the asset gallery remained visible with the stale selection count. The assets were deleted correctly but the selection state was never cleared, making it appear as if the deleted assets were still selected.

## What changed

When a bulk action calls `refetch()` after completing, the selection is now also cleared via `setSelected([])`. This means the bulk action bar disappears automatically after any bulk action finishes, reflecting the correct state.

## Root cause

The `refetch` function passed to `AssetBulkActions` only refetched the asset list. It never cleared the `selected` state in `AssetGallery`. The fix wraps `refetch` to also reset the selection.

before 

https://github.com/user-attachments/assets/64a6a646-507a-4e8a-b60e-e86490a016ff

after

https://github.com/user-attachments/assets/878b1902-4110-469b-9a24-b0512669d46e

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4941"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786268523&installation_id=128408429&pr_number=4941&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4941&signature=d50c825e9b01a5d4d270c862a96e222c26c9d71be9b1fcb98eb60e22c0824af6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->