### PR TITLE
fix(email-plugin): Move @types/nodemailer to dependencies

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -456,6 +456,7 @@
       "name": "@vendure/email-plugin",
       "version": "3.7.0",
       "dependencies": {
+        "@types/nodemailer": "^8.0.1",
         "dateformat": "^3.0.3",
         "express": "^5.1.0",
         "fs-extra": "^11.2.0",
@@ -468,7 +469,6 @@
         "@types/express": "^5.0.1",
         "@types/fs-extra": "^11.0.4",
         "@types/mjml": "^5.0.0",
-        "@types/nodemailer": "^8.0.1",
         "@vendure/common": "3.6.4",
         "@vendure/core": "3.6.4",
         "rimraf": "^5.0.5",

--- a/packages/email-plugin/package.json
+++ b/packages/email-plugin/package.json
@@ -25,6 +25,7 @@
         "access": "public"
     },
     "dependencies": {
+        "@types/nodemailer": "^8.0.1",
         "dateformat": "^3.0.3",
         "express": "^5.1.0",
         "fs-extra": "^11.2.0",
@@ -37,7 +38,6 @@
         "@types/express": "^5.0.1",
         "@types/fs-extra": "^11.0.4",
         "@types/mjml": "^5.0.0",
-        "@types/nodemailer": "^8.0.1",
         "@vendure/common": "3.7.0",
         "@vendure/core": "3.7.0",
         "rimraf": "^5.0.5",

--- a/packages/email-plugin/src/package-dependencies.spec.ts
+++ b/packages/email-plugin/src/package-dependencies.spec.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+import { describe, expect, it } from 'vitest';
+
+// https://github.com/vendurehq/vendure/issues/4920
+//
+// The public transport-option types re-exported from `types.ts` extend types from
+// `@types/nodemailer` (e.g. `SMTPTransportOptions extends SMTPTransport.Options`), and
+// nodemailer@9 ships no types of its own. `@types/nodemailer` is therefore part of the
+// plugin's PUBLISHED `.d.ts` surface. If it is only a devDependency, consumer projects
+// don't receive it, so `SMTPTransportOptions` loses `host`/`port`/... and their config
+// fails to compile (TS2353) — the reported bug. It must be a runtime `dependency`.
+//
+// Note: this can only be guarded at the packaging level. A type-level test (see
+// `transport-options.spec-d.ts`) passes regardless of the dev/prod classification because
+// `@types/nodemailer` is always resolvable inside this repo; the failure only manifests in
+// an external consumer's install. This test is the invariant that actually flips between
+// the buggy and fixed states.
+describe('email-plugin published type dependencies (#4920)', () => {
+    const packageRoot = path.join(__dirname, '..');
+    const pkg = JSON.parse(fs.readFileSync(path.join(packageRoot, 'package.json'), 'utf-8')) as {
+        dependencies?: Record<string, string>;
+        devDependencies?: Record<string, string>;
+    };
+    const typesLeakNodemailer = fs
+        .readFileSync(path.join(__dirname, 'types.ts'), 'utf-8')
+        .includes("from 'nodemailer/");
+
+    it('re-exports nodemailer types from its public API', () => {
+        // Guards the premise below: if a future refactor inlines these types, this fails
+        // and the runtime-dependency requirement should be revisited rather than assumed.
+        expect(typesLeakNodemailer).toBe(true);
+    });
+
+    it('declares @types/nodemailer as a runtime dependency, not a devDependency', () => {
+        expect(pkg.dependencies?.['@types/nodemailer']).toBeTruthy();
+        expect(pkg.devDependencies?.['@types/nodemailer']).toBeUndefined();
+    });
+});


### PR DESCRIPTION
## Summary

`@vendure/email-plugin`'s SMTP config stopped type-checking out of the box in consumer projects after 3.7.0, failing with:

```
error TS2353: Object literal may only specify known properties, and 'host' does not exist in type 'SMTPTransportOptions'.
```

This moves `@types/nodemailer` from `devDependencies` to `dependencies` so the types the plugin's public API depends on are delivered to consumers.

## Root cause

The plugin's public transport-option types extend types from `@types/nodemailer`:

- `SMTPTransportOptions extends SMTPTransport.Options`
- `SESTransportOptions extends SESTransport.Options`
- `SMTPPool.Options[...]` (pooled options), `Attachment` (`EmailAttachment`)

`nodemailer@9` ships **no type definitions of its own**, so `@types/nodemailer` is part of the plugin's **published `.d.ts` surface**. It was declared only as a `devDependency`, which is not delivered transitively to consumers. In a consumer project without `@types/nodemailer`, `SMTPTransportOptions` loses `host`/`port`/etc. and the SMTP config fails to compile (`TS2353`).

This matches the reported workaround (add `@types/nodemailer` to the app's own `devDependencies`).

## Change

- `packages/email-plugin/package.json`: move `@types/nodemailer` (`^8.0.1`, version unchanged) `devDependencies` → `dependencies`.
- `bun.lock`: mirror the move in the email-plugin manifest block.
- New `packages/email-plugin/src/package-dependencies.spec.ts`: regression guard.

This follows existing repo convention — the dashboard package already ships `@types/react`/`@types/react-dom` in `dependencies` for the same reason (types that leak into the published API belong in `dependencies`).

## Test plan

**Automated (in this PR):**
- `packages/email-plugin/src/package-dependencies.spec.ts` asserts `@types/nodemailer` is a runtime `dependency` (and not a `devDependency`), plus a premise guard that `types.ts` still re-exports nodemailer types. This is the **in-repo guard**: it **fails on `master`** and **passes on this branch**.
- Existing `transport-options.spec-d.ts` continues to assert the type shape (`host`, `port`, pooled options compile).
- Full email-plugin suite green: **50 tests, no type errors**.

> Note: a purely in-repo *type-level* test cannot flip on this fix — `@types/nodemailer` is always resolvable inside the monorepo regardless of the dev/prod classification. The failure only manifests in an external consumer's install, which is why the guard is at the packaging level.

**Manual — end-to-end consumer reproduction:**
- Packed both variants (`master` and this branch) via `npm pack`, installed each into a clean project (realistic Vendure `tsconfig`: `strict`, `esModuleInterop`, `skipLibCheck`), and type-checked a real SMTP config:
  - `master` (no `@types/nodemailer` delivered) → reproduces `TS2353: 'host' does not exist` (tsc exit 2).
  - this branch (`@types/nodemailer@8.0.1` delivered transitively) → **tsc exit 0, clean**.

## Out of scope (follow-up)

The repo root still pins a stale `@types/nodemailer@^6.4.22` (`package.json`, `bun.lock`) from the pre-nodemailer-9 era — a v6/v8 skew. Verified no code outside `packages/email-plugin` imports nodemailer types, so there is no active breakage; leaving it untouched here and tracked separately in #4943.

Fixes #4920