### PR TITLE
fix(create): Fix Quick Start hangs and package-manager install failures

### DIFF
--- a/.github/workflows/publish_and_install.yml
+++ b/.github/workflows/publish_and_install.yml
@@ -354,12 +354,25 @@ jobs:
                   TOKEN=$(echo "$TOKEN_RES" | jq -r '.token')
                   npm set registry=http://localhost:4873
                   npm set //localhost:4873/:_authToken $TOKEN
+            # The install directory deliberately contains a space: file URLs percent-encode
+            # it (%20), which used to leak into filesystem paths in the dashboard's vite
+            # plugins and break `npm run dev` (#4931).
             - name: Quick Start with Postgres (single project)
               timeout-minutes: 15
               run: |
-                  mkdir -p $HOME/install
-                  cd $HOME/install
+                  mkdir -p "$HOME/install dir"
+                  cd "$HOME/install dir"
                   npx @vendure/create@ci shop-pg --ci --db postgres --use-npm --log-level info
+            - name: Dev server smoke test from a path containing a space
+              timeout-minutes: 15
+              run: |
+                  cd "$HOME/install dir/shop-pg"
+                  npm run dev &
+                  wait-on http://localhost:3000/health --timeout 120000
+                  # The dashboard Vite server failed to start when the project path
+                  # percent-encoded (#4931), so it becoming reachable is the regression check.
+                  wait-on http://localhost:5173/dashboard --timeout 180000
+                  lsof -ti:3000,5173 | xargs kill 2>/dev/null || true
             - name: Stop containers so the next project can bind port 6543
               run: docker ps -q | xargs -r docker stop
             - name: Quick Start with Postgres (monorepo, first)
@@ -367,7 +380,7 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: |
-                  cd $HOME/install
+                  cd "$HOME/install dir"
                   npx @vendure/create@ci shop-mono-a --ci --db postgres --with-storefront --use-npm --log-level info
             - name: Stop containers so the next project can bind port 6543
               run: docker ps -q | xargs -r docker stop
@@ -380,7 +393,7 @@ jobs:
               env:
                   GITHUB_TOKEN: ${{ github.token }}
               run: |
-                  cd $HOME/install
+                  cd "$HOME/install dir"
                   npx @vendure/create@ci shop-mono-b --ci --db postgres --with-storefront --use-npm --log-level info
             - name: Assert each project got its own Compose project
               run: |

--- a/.github/workflows/publish_and_install.yml
+++ b/.github/workflows/publish_and_install.yml
@@ -87,9 +87,12 @@ jobs:
             contents: read
         strategy:
             matrix:
-                # For PRs: run minimal matrix (1 job). For push: run full matrix (9 jobs)
+                # For PRs: run minimal matrix (1 job). For push: run full matrix (9 jobs).
+                # Only non-EOL Node versions are tested: native deps (e.g. better-sqlite3)
+                # stop publishing prebuilt binaries for EOL versions, and the node-gyp
+                # bundled with an EOL Node cannot drive newer Visual Studio releases.
                 os: ${{ github.event_name == 'pull_request' && fromJSON('["ubuntu-latest"]') || fromJSON('["ubuntu-latest", "windows-latest", "macos-latest"]') }}
-                node-version: ${{ github.event_name == 'pull_request' && fromJSON('["22.x"]') || fromJSON('["20.x", "22.x", "24.x"]') }}
+                node-version: ${{ github.event_name == 'pull_request' && fromJSON('["22.x"]') || fromJSON('["22.x", "24.x", "26.x"]') }}
             fail-fast: false
         steps:
             - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1

--- a/.github/workflows/publish_and_install.yml
+++ b/.github/workflows/publish_and_install.yml
@@ -298,6 +298,9 @@ jobs:
                   npm_config_registry: http://localhost:4873/
                   YARN_NPM_REGISTRY_SERVER: http://localhost:4873/
                   YARN_UNSAFE_HTTP_WHITELIST: localhost
+                  # Yarn quarantines versions published less than npmMinimalAgeGate ago
+                  # (default 1d, YN0016) — the packages under test are seconds old.
+                  YARN_NPM_MINIMAL_AGE_GATE: 0
               run: |
                   mkdir -p $HOME/install
                   cd $HOME/install

--- a/.github/workflows/publish_and_install.yml
+++ b/.github/workflows/publish_and_install.yml
@@ -230,12 +230,16 @@ jobs:
         strategy:
             matrix:
                 include:
+                    # $CREATE_VERSION is resolved from the ci dist-tag at run time. The tag
+                    # itself is not passed to dlx because Verdaccio serves pnpm's abbreviated
+                    # metadata requests a stale/merged tag map, resolving @ci to an upstream
+                    # nightly instead of the locally published version.
                     - pm: bun
-                      scaffold: bunx @vendure/create@ci test-app --ci --log-level info
+                      scaffold: bunx @vendure/create@$CREATE_VERSION test-app --ci --log-level info
                     - pm: pnpm
-                      scaffold: pnpm dlx @vendure/create@ci test-app --ci --log-level info
+                      scaffold: pnpm dlx @vendure/create@$CREATE_VERSION test-app --ci --log-level info
                     - pm: yarn
-                      scaffold: yarn dlx @vendure/create@ci test-app --ci --log-level info
+                      scaffold: yarn dlx @vendure/create@$CREATE_VERSION test-app --ci --log-level info
             fail-fast: false
         steps:
             - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -248,6 +252,9 @@ jobs:
                   bun-version: '1.3.10'
             - name: Enable pnpm and yarn via corepack
               run: |
+                  # The runner's bundled corepack maps yarn@stable to an outdated release;
+                  # updating corepack first gives the current one that users actually get.
+                  npm install -g corepack@latest
                   corepack enable
                   corepack prepare pnpm@latest --activate
                   corepack prepare yarn@stable --activate
@@ -295,6 +302,8 @@ jobs:
                   mkdir -p $HOME/install
                   cd $HOME/install
                   npm dist-tag ls @vendure/create
+                  CREATE_VERSION=$(npm view @vendure/create@ci version)
+                  echo "Resolved @vendure/create@ci -> $CREATE_VERSION"
                   # No --use-npm: the manager is detected from the invoking bunx / pnpm dlx.
                   ${{ matrix.scaffold }}
             - name: Assert the generated project used ${{ matrix.pm }}

--- a/.github/workflows/publish_and_install.yml
+++ b/.github/workflows/publish_and_install.yml
@@ -34,6 +34,7 @@ jobs:
     # Job 1: Build all packages and publish to Verdaccio (runs once)
     build_and_publish:
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         permissions:
             contents: read
         steps:
@@ -83,6 +84,7 @@ jobs:
     test:
         needs: build_and_publish
         runs-on: ${{ matrix.os }}
+        timeout-minutes: 45
         permissions:
             contents: read
         strategy:
@@ -213,13 +215,16 @@ jobs:
                 path: /tmp/dashboard-test-*.png
                 retention-days: 28
 
-    # Job 3: Verify `@vendure/create` works end-to-end when invoked via bun and pnpm.
-    # The package manager is detected from npm_config_user_agent (which bunx / pnpm dlx
-    # set), so the install step and generated project must use that manager rather than
-    # hard-coding npm (#4390).
+    # Job 3: Verify `@vendure/create` works end-to-end when invoked via bun, pnpm and yarn.
+    # The package manager is detected from npm_config_user_agent (which bunx / pnpm dlx /
+    # yarn dlx set), so the install step and generated project must use that manager rather
+    # than hard-coding npm (#4390). pnpm and yarn are deliberately NOT pinned: their current
+    # releases are what users get, and policy changes in new majors (e.g. pnpm 11 ignoring
+    # the package.json pnpm field, yarn 4.14 disabling build scripts) must fail here (#4932).
     test_package_managers:
         needs: build_and_publish
         runs-on: ubuntu-latest
+        timeout-minutes: 30
         permissions:
             contents: read
         strategy:
@@ -229,6 +234,8 @@ jobs:
                       scaffold: bunx @vendure/create@ci test-app --ci --log-level info
                     - pm: pnpm
                       scaffold: pnpm dlx @vendure/create@ci test-app --ci --log-level info
+                    - pm: yarn
+                      scaffold: yarn dlx @vendure/create@ci test-app --ci --log-level info
             fail-fast: false
         steps:
             - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
@@ -239,11 +246,13 @@ jobs:
             - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
               with:
                   bun-version: '1.3.10'
-            - name: Enable pnpm via corepack
+            - name: Enable pnpm and yarn via corepack
               run: |
                   corepack enable
-                  corepack prepare pnpm@9.15.9 --activate
+                  corepack prepare pnpm@latest --activate
+                  corepack prepare yarn@stable --activate
                   pnpm --version
+                  yarn --version
             - name: Download Verdaccio storage
               uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
               with:
@@ -274,9 +283,14 @@ jobs:
               # up to a parent .npmrc/bunfig, but it DOES honour the npm_config_registry env
               # var — and so does the scaffolded project's nested install (it inherits the
               # env). This is the one mechanism that reaches both bunx and the nested install.
+              # Yarn Berry reads neither ~/.npmrc nor npm_config_registry: it needs its own
+              # YARN_NPM_REGISTRY_SERVER env var, plus the http whitelist since Verdaccio
+              # is plain http.
               env:
                   CI: true
                   npm_config_registry: http://localhost:4873/
+                  YARN_NPM_REGISTRY_SERVER: http://localhost:4873/
+                  YARN_UNSAFE_HTTP_WHITELIST: localhost
               run: |
                   mkdir -p $HOME/install
                   cd $HOME/install
@@ -289,6 +303,7 @@ jobs:
                   case "${{ matrix.pm }}" in
                     bun) test -f bun.lock || { echo "Expected bun.lock to exist"; ls -la; exit 1; } ;;
                     pnpm) test -f pnpm-lock.yaml || { echo "Expected pnpm-lock.yaml to exist"; ls -la; exit 1; } ;;
+                    yarn) test -f yarn.lock || { echo "Expected yarn.lock to exist"; ls -la; exit 1; } ;;
                   esac
                   echo "Lockfile for ${{ matrix.pm }} present ✓"
             - name: Server smoke tests
@@ -300,3 +315,77 @@ jobs:
               if: always()
               run: |
                   lsof -ti:3000,5173 | xargs kill 2>/dev/null || true
+
+    # Job 4: Exercise the Quick Start PostgreSQL path (docker compose up + readiness wait
+    # + populate against postgres), which `--ci` alone never touches. Runs three creates on
+    # the same runner — two of them monorepo — because the compose project-name collision
+    # that motivated this job (#4932) only bites from the second monorepo project onwards.
+    test_quickstart_postgres:
+        needs: build_and_publish
+        runs-on: ubuntu-latest
+        timeout-minutes: 45
+        permissions:
+            contents: read
+        steps:
+            - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
+            - name: Use Node.js 22.x
+              uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+              with:
+                  node-version: 22.x
+            - name: Download Verdaccio storage
+              uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+              with:
+                  name: verdaccio-storage
+                  path: ~/verdaccio-download
+            - name: Setup Verdaccio with pre-built packages
+              run: |
+                  npm install -g verdaccio
+                  npm install -g wait-on
+                  mkdir -p $HOME/.config/verdaccio
+                  cp -v ./.github/workflows/verdaccio/config.yaml $HOME/.config/verdaccio/config.yaml
+                  cd $HOME/.config/verdaccio
+                  tar -xzf ~/verdaccio-download/verdaccio-storage.tar.gz
+                  nohup verdaccio --config $HOME/.config/verdaccio/config.yaml &
+                  wait-on http://localhost:4873
+                  TOKEN_RES=$(curl -XPUT \
+                    -H "Content-type: application/json" \
+                    -d '{ "name": "test", "password": "test" }' \
+                    'http://localhost:4873/-/user/org.couchdb.user:test')
+                  TOKEN=$(echo "$TOKEN_RES" | jq -r '.token')
+                  npm set registry=http://localhost:4873
+                  npm set //localhost:4873/:_authToken $TOKEN
+            - name: Quick Start with Postgres (single project)
+              timeout-minutes: 15
+              run: |
+                  mkdir -p $HOME/install
+                  cd $HOME/install
+                  npx @vendure/create@ci shop-pg --ci --db postgres --use-npm --log-level info
+            - name: Stop containers so the next project can bind port 6543
+              run: docker ps -q | xargs -r docker stop
+            - name: Quick Start with Postgres (monorepo, first)
+              timeout-minutes: 15
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: |
+                  cd $HOME/install
+                  npx @vendure/create@ci shop-mono-a --ci --db postgres --with-storefront --use-npm --log-level info
+            - name: Stop containers so the next project can bind port 6543
+              run: docker ps -q | xargs -r docker stop
+            - name: Quick Start with Postgres (monorepo, second — compose collision regression)
+              timeout-minutes: 15
+              # Deliberately runs with the previous monorepo project's stopped containers and
+              # volumes still present: before the fix, Compose derived the project name from
+              # the apps/server directory for BOTH projects and hung forever on an
+              # unanswerable "Recreate volume?" prompt.
+              env:
+                  GITHUB_TOKEN: ${{ github.token }}
+              run: |
+                  cd $HOME/install
+                  npx @vendure/create@ci shop-mono-b --ci --db postgres --with-storefront --use-npm --log-level info
+            - name: Assert each project got its own Compose project
+              run: |
+                  docker ps -a --format '{{.Names}}' | sort
+                  for project in shop-pg shop-mono-a shop-mono-b; do
+                      docker ps -a --format '{{.Names}}' | grep -q "^${project}-postgres_db-1$" \
+                        || { echo "Expected container ${project}-postgres_db-1 to exist"; exit 1; }
+                  done

--- a/.github/workflows/scripts/dashboard-tests.js
+++ b/.github/workflows/scripts/dashboard-tests.js
@@ -17,9 +17,21 @@ async function runDashboardTests() {
     try {
         page = await browser.newPage();
 
-        // Navigate to the dashboard
+        // Navigate to the dashboard. The first load makes the Vite dev server compile
+        // the dashboard's whole module graph, which on slow runners can far exceed the
+        // default 30s navigation timeout — so allow more time and retry.
         console.log('Navigating to dashboard...');
-        await page.goto('http://localhost:5173/dashboard');
+        for (let attempt = 1; ; attempt++) {
+            try {
+                await page.goto('http://localhost:5173/dashboard', { timeout: 120_000 });
+                break;
+            } catch (e) {
+                if (attempt >= 3) {
+                    throw e;
+                }
+                console.log(`Navigation failed (${e.message}), retrying (${attempt}/3)...`);
+            }
+        }
 
         // Wait for the page to load
         await page.waitForLoadState('networkidle');

--- a/.github/workflows/scripts/smoke-tests.js
+++ b/.github/workflows/scripts/smoke-tests.js
@@ -69,8 +69,23 @@ async function runTests() {
     process.exit(0);
 }
 
-function gqlRequest(url, body) {
-    return request(url, 'POST', body).catch(e => console.log(e));
+/**
+ * The server can drop the first connections while it is still warming up (ECONNRESET),
+ * even after /health responds — so transient network errors are retried rather than
+ * surfacing as an undefined response.
+ */
+async function gqlRequest(url, body, attempts = 5) {
+    for (let i = 1; ; i++) {
+        try {
+            return await request(url, 'POST', body);
+        } catch (e) {
+            if (i >= attempts) {
+                throw e;
+            }
+            console.log(`Request to ${url} failed (${e.message}), retrying (${i}/${attempts})...`);
+            await new Promise(resolve => setTimeout(resolve, 2000));
+        }
+    }
 }
 
 /**

--- a/docs/docs/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy.mdx
+++ b/docs/docs/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## S3AssetStorageStrategy
 
-<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="155" packageName="@vendure/asset-server-plugin" />
+<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="156" packageName="@vendure/asset-server-plugin" />
 
 An [AssetStorageStrategy](/reference/typescript-api/assets/asset-storage-strategy#assetstoragestrategy) which uses [Amazon S3](https://aws.amazon.com/s3/) object storage service.
 To us this strategy you must first have access to an AWS account.
@@ -86,7 +86,7 @@ class S3AssetStorageStrategy implements AssetStorageStrategy {
 </div>
 ## S3Config
 
-<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="19" packageName="@vendure/asset-server-plugin" />
+<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="20" packageName="@vendure/asset-server-plugin" />
 
 Configuration for connecting to AWS S3.
 
@@ -133,7 +133,7 @@ Using type `any` in order to avoid the need to include `aws-sdk` dependency in g
 </div>
 ## configureS3AssetStorage
 
-<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="119" packageName="@vendure/asset-server-plugin" />
+<GenerationInfo sourceFile="packages/asset-server-plugin/src/config/s3-asset-storage-strategy.ts" sourceLine="120" packageName="@vendure/asset-server-plugin" />
 
 Returns a configured instance of the [S3AssetStorageStrategy](/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy#s3assetstoragestrategy) which can then be passed to the [AssetServerOptions](/reference/core-plugins/asset-server-plugin/asset-server-options#assetserveroptions)`storageStrategyFactory` property.
 

--- a/docs/docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx
+++ b/docs/docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## vendureDashboardPlugin
 
-<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="241" packageName="@vendure/dashboard" since="3.4.0" />
+<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="242" packageName="@vendure/dashboard" since="3.4.0" />
 
 This is the Vite plugin which powers the Vendure Dashboard, including:
 
@@ -23,7 +23,7 @@ Parameters
 
 ## VitePluginVendureDashboardOptions
 
-<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="38" packageName="@vendure/dashboard" since="3.4.0" />
+<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="39" packageName="@vendure/dashboard" since="3.4.0" />
 
 Options for the [vendureDashboardPlugin](/reference/dashboard/vite-plugin/vendure-dashboard-plugin#venduredashboardplugin) Vite plugin.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3548,7 +3548,7 @@
                   "title": "S3AssetStorageStrategy",
                   "slug": "s3asset-storage-strategy",
                   "file": "docs/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-10T11:12:38Z"
                 },
                 {
                   "title": "SharpAssetPreviewStrategy",
@@ -4271,7 +4271,7 @@
                   "title": "VendureDashboardPlugin",
                   "slug": "vendure-dashboard-plugin",
                   "file": "docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx",
-                  "lastModified": "2026-06-30T09:24:24+02:00"
+                  "lastModified": "2026-07-10T11:12:38Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -2296,13 +2296,13 @@
                   "title": "MigrateAssetTranslationData",
                   "slug": "migrate-asset-translation-data",
                   "file": "docs/reference/typescript-api/migration/migrate-asset-translation-data.mdx",
-                  "lastModified": "2026-03-30T12:56:43+02:00"
+                  "lastModified": "2026-07-10T09:53:10+02:00"
                 },
                 {
                   "title": "MigrateProductOptionGroupData",
                   "slug": "migrate-product-option-group-data",
                   "file": "docs/reference/typescript-api/migration/migrate-product-option-group-data.mdx",
-                  "lastModified": "2026-03-06T09:35:25+01:00"
+                  "lastModified": "2026-07-10T09:53:10+02:00"
                 },
                 {
                   "title": "MigrationOptions",
@@ -3548,7 +3548,7 @@
                   "title": "S3AssetStorageStrategy",
                   "slug": "s3asset-storage-strategy",
                   "file": "docs/reference/core-plugins/asset-server-plugin/s3asset-storage-strategy.mdx",
-                  "lastModified": "2026-07-10T11:12:38Z"
+                  "lastModified": "2026-07-10T09:53:10+02:00"
                 },
                 {
                   "title": "SharpAssetPreviewStrategy",

--- a/packages/create/src/constants.ts
+++ b/packages/create/src/constants.ts
@@ -35,6 +35,14 @@ export const PORT_SCAN_RANGE = 20;
  */
 export const SOCKET_TIMEOUT_MS = 2_000;
 
+/**
+ * How long to wait for the dockerized PostgreSQL container to accept connections.
+ * A first boot runs `initdb`, which alone can take well over 10 seconds on slower
+ * machines, so the budget must comfortably exceed that.
+ */
+export const PG_READY_MAX_ATTEMPTS = 120;
+export const PG_READY_POLL_INTERVAL_MS = 500;
+
 // Timing constants (milliseconds)
 export const SCAFFOLD_DELAY_MS = 500;
 export const TIP_INTERVAL_MS = 10_000;

--- a/packages/create/src/constants.ts
+++ b/packages/create/src/constants.ts
@@ -1,4 +1,10 @@
 export const REQUIRED_NODE_VERSION = '>=20.0.0';
+/**
+ * Oldest Node.js major release that has not reached end-of-life. Used to warn (not block)
+ * users on EOL versions, for which native deps often stop publishing prebuilt binaries.
+ * Bump when the oldest maintained LTS goes EOL: https://nodejs.org/en/about/previous-releases
+ */
+export const OLDEST_NON_EOL_NODE_MAJOR = 22;
 export const SERVER_PORT = 3000;
 export const STOREFRONT_PORT = 3001;
 export const STOREFRONT_REPO = 'vendure-ecommerce/nextjs-starter-vendure';

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -42,8 +42,10 @@ import {
     getDependencies,
     getMonorepoRootPackageJson,
     getPackageManagerInfo,
+    getPnpmWorkspaceYaml,
     getServerPackageScripts,
     getSingleProjectPackageJson,
+    getYarnRcYml,
     installPackages,
     isSafeToCreateProjectIn,
     registerTemplateHelpers,
@@ -80,10 +82,7 @@ program
         'info',
     )
     .option('--verbose', 'Alias for --log-level verbose', false)
-    .option(
-        '--use-npm',
-        'Force npm, overriding auto-detection of the package manager that invoked the CLI',
-    )
+    .option('--use-npm', 'Force npm, overriding auto-detection of the package manager that invoked the CLI')
     .option('--ci', 'Runs without prompts for use in CI scenarios', false)
     .option('--with-storefront', 'Include Next.js storefront (only used with --ci)', false)
     .parse(process.argv);
@@ -235,9 +234,16 @@ export async function createVendureApp(
         );
 
         // pnpm does not read the package.json `workspaces` field; it requires a
-        // pnpm-workspace.yaml instead.
-        if (!pmInfo.usesPackageJsonWorkspaces) {
-            fs.writeFileSync(path.join(root, 'pnpm-workspace.yaml'), `packages:\n  - 'apps/*'\n`);
+        // pnpm-workspace.yaml instead. The file also carries pnpm's settings,
+        // including the build-script allowlist for native dependencies.
+        if (pmInfo.name === 'pnpm') {
+            fs.writeFileSync(
+                path.join(root, 'pnpm-workspace.yaml'),
+                getPnpmWorkspaceYaml(dbType, ['apps/*']),
+            );
+        }
+        if (pmInfo.name === 'yarn') {
+            fs.writeFileSync(path.join(root, '.yarnrc.yml'), getYarnRcYml());
         }
 
         // Generate root README from template
@@ -272,6 +278,14 @@ export async function createVendureApp(
             path.join(root, 'package.json'),
             JSON.stringify(getSingleProjectPackageJson(appName, pmInfo, dbType), null, 2) + os.EOL,
         );
+        // Since pnpm v11, all pnpm settings (including the build-script allowlist for
+        // native dependencies) live in pnpm-workspace.yaml, even for single projects.
+        if (pmInfo.name === 'pnpm') {
+            fs.writeFileSync(path.join(root, 'pnpm-workspace.yaml'), getPnpmWorkspaceYaml(dbType));
+        }
+        if (pmInfo.name === 'yarn') {
+            fs.writeFileSync(path.join(root, '.yarnrc.yml'), getYarnRcYml());
+        }
         fs.ensureDirSync(path.join(root, 'src'));
     }
 
@@ -405,7 +419,16 @@ export async function createVendureApp(
 
     if (mode === 'quick' && dbType === 'postgres') {
         cleanUpDockerResources(name);
-        await startPostgresDatabase(serverRoot);
+        const dbStarted = await startPostgresDatabase(serverRoot, appName);
+        if (!dbStarted) {
+            outro(
+                pc.red(
+                    'The PostgreSQL database could not be started. Check the Docker logs, ' +
+                        'then run the create command again.',
+                ),
+            );
+            process.exit(1);
+        }
     }
 
     const populateSpinner = spinner();
@@ -637,10 +660,14 @@ async function installDependenciesWithSpinner(installOptions: InstallDependencie
         installSpinner.stop(successMessage);
         return true;
     } catch (e) {
+        const detail = e instanceof Error ? e.message : String(e);
         if (warnOnFailure) {
             installSpinner.stop(pc.yellow(`Warning: ${failureMessage}`));
+            log(detail);
             return false;
         } else {
+            installSpinner.stop(pc.red(failureMessage));
+            log(detail);
             outro(pc.red(failureMessage));
             process.exit(1);
         }

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -428,7 +428,9 @@ export async function createVendureApp(
     // Manual mode is excluded: there the user supplies their own database connection,
     // so no Docker container is started on their behalf.
     if ((mode === 'quick' || mode === 'ci') && dbType === 'postgres') {
-        cleanUpDockerResources(name);
+        // appName (the resolved directory basename) is what the docker-compose labels are
+        // keyed off — the raw CLI argument may be a nested path like `apps/my-shop`.
+        cleanUpDockerResources(appName);
         const dbStarted = await startPostgresDatabase(serverRoot, appName);
         if (!dbStarted) {
             outro(

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -85,6 +85,12 @@ program
     .option('--use-npm', 'Force npm, overriding auto-detection of the package manager that invoked the CLI')
     .option('--ci', 'Runs without prompts for use in CI scenarios', false)
     .option('--with-storefront', 'Include Next.js storefront (only used with --ci)', false)
+    .option(
+        '--db <database>',
+        "Database to use with --ci: 'sqlite' or 'postgres' (postgres is started via Docker)",
+        /^(sqlite|postgres)$/i,
+        'sqlite',
+    )
     .parse(process.argv);
 
 const options = program.opts();
@@ -94,6 +100,7 @@ void createVendureApp(
     options.verbose ? 'verbose' : options.logLevel || 'info',
     options.ci,
     options.withStorefront,
+    options.db,
 ).catch(err => {
     log(err);
     process.exit(1);
@@ -105,6 +112,7 @@ export async function createVendureApp(
     logLevel: CliLogLevel,
     isCi: boolean = false,
     withStorefront: boolean = false,
+    ciDbType: 'sqlite' | 'postgres' = 'sqlite',
 ) {
     setLogLevel(logLevel);
     if (!runPreChecks(name)) {
@@ -181,7 +189,7 @@ export async function createVendureApp(
         includeStorefront,
     } =
         mode === 'ci'
-            ? await getCiConfiguration(root, packageManager, port, withStorefront)
+            ? await getCiConfiguration(root, packageManager, port, withStorefront, ciDbType)
             : mode === 'manual'
               ? await getManualConfiguration(root, packageManager, port)
               : await getQuickStartConfiguration(root, packageManager, port);
@@ -417,7 +425,9 @@ export async function createVendureApp(
     }
     scaffoldSpinner.stop(`Generated app scaffold`);
 
-    if (mode === 'quick' && dbType === 'postgres') {
+    // Manual mode is excluded: there the user supplies their own database connection,
+    // so no Docker container is started on their behalf.
+    if ((mode === 'quick' || mode === 'ci') && dbType === 'postgres') {
         cleanUpDockerResources(name);
         const dbStarted = await startPostgresDatabase(serverRoot, appName);
         if (!dbStarted) {

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -100,7 +100,9 @@ void createVendureApp(
     options.verbose ? 'verbose' : options.logLevel || 'info',
     options.ci,
     options.withStorefront,
-    options.db,
+    // The --db regex validates case-insensitively, but the comparisons downstream
+    // are against the lowercase literals.
+    options.db?.toLowerCase(),
 ).catch(err => {
     log(err);
     process.exit(1);

--- a/packages/create/src/gather-user-responses.ts
+++ b/packages/create/src/gather-user-responses.ts
@@ -287,14 +287,7 @@ async function generateSources(
 ): Promise<FileSources> {
     const assetPath = (fileName: string) => path.join(__dirname, '../assets', fileName);
 
-    /**
-     * Helper to escape single quotes only. Used when generating the config file since e.g. passwords
-     * might use special chars (`< > ' "` etc) which Handlebars would be default convert to HTML entities.
-     * Instead, we disable escaping and use this custom helper to escape only the single quote character.
-     */
-    Handlebars.registerHelper('escapeSingle', (aString: unknown) => {
-        return typeof aString === 'string' ? aString.replace(/'/g, "\\'") : aString;
-    });
+    registerEscapeSingleHelper();
 
     const templateContext = {
         ...answers,
@@ -341,4 +334,16 @@ function defaultDBPort(dbType: DbType): number {
         default:
             return 3306;
     }
+}
+
+/**
+ * Registers the Handlebars helper used for values rendered inside single-quoted string
+ * literals (e.g. passwords in the generated config). Handlebars' default escaping would
+ * convert special chars (`< > ' "` etc.) to HTML entities, so templates render these
+ * values raw and this helper escapes backslashes and single quotes instead.
+ */
+export function registerEscapeSingleHelper(): void {
+    Handlebars.registerHelper('escapeSingle', (aString: unknown) => {
+        return typeof aString === 'string' ? aString.replace(/\\/g, '\\\\').replace(/'/g, "\\'") : aString;
+    });
 }

--- a/packages/create/src/gather-user-responses.ts
+++ b/packages/create/src/gather-user-responses.ts
@@ -256,7 +256,7 @@ export async function getCiConfiguration(
         dbType,
         dbHost: usePostgres ? 'localhost' : '',
         dbPort: usePostgres ? '6543' : '',
-        dbName: 'vendure',
+        dbName: usePostgres ? 'vendure' : '',
         dbUserName: usePostgres ? 'vendure' : '',
         dbPassword: usePostgres ? randomBytes(16).toString('base64url') : '',
         dbSchema: usePostgres ? 'public' : '',

--- a/packages/create/src/gather-user-responses.ts
+++ b/packages/create/src/gather-user-responses.ts
@@ -5,7 +5,7 @@ import fs from 'fs-extra';
 import Handlebars from 'handlebars';
 import path from 'path';
 
-import { checkCancel, isDockerAvailable } from './helpers';
+import { checkCancel, isDockerAvailable, toComposeProjectName } from './helpers';
 import { DbType, FileSources, PackageManager, UserResponses } from './types';
 
 interface PromptAnswers {
@@ -295,6 +295,7 @@ async function generateSources(
         ...answers,
         dbType: answers.dbType === 'sqlite' ? 'better-sqlite3' : answers.dbType,
         name: path.basename(root),
+        composeProjectName: toComposeProjectName(path.basename(root)),
         isSQLite: answers.dbType === 'sqlite',
         requiresConnection: answers.dbType !== 'sqlite',
         cookieSecret: randomBytes(16).toString('base64url'),

--- a/packages/create/src/gather-user-responses.ts
+++ b/packages/create/src/gather-user-responses.ts
@@ -247,14 +247,19 @@ export async function getCiConfiguration(
     packageManager: PackageManager,
     port: number,
     includeStorefront: boolean = false,
+    dbType: 'sqlite' | 'postgres' = 'sqlite',
 ): Promise<UserResponses> {
+    // The postgres answers mirror the Quick Start flow, which starts the database
+    // in a Docker container mapped to host port 6543 (see docker-compose.hbs).
+    const usePostgres = dbType === 'postgres';
     const ciAnswers = {
-        dbType: 'sqlite' as const,
-        dbHost: '',
-        dbPort: '',
+        dbType,
+        dbHost: usePostgres ? 'localhost' : '',
+        dbPort: usePostgres ? '6543' : '',
         dbName: 'vendure',
-        dbUserName: '',
-        dbPassword: '',
+        dbUserName: usePostgres ? 'vendure' : '',
+        dbPassword: usePostgres ? randomBytes(16).toString('base64url') : '',
+        dbSchema: usePostgres ? 'public' : '',
         populateProducts: true,
         superadminIdentifier: SUPER_ADMIN_USER_IDENTIFIER,
         superadminPassword: SUPER_ADMIN_USER_PASSWORD,

--- a/packages/create/src/helpers.spec.ts
+++ b/packages/create/src/helpers.spec.ts
@@ -1,9 +1,12 @@
+import spawn from 'cross-spawn';
 import fs from 'fs-extra';
 import Handlebars from 'handlebars';
+import { EventEmitter } from 'node:events';
 import { Socket, createServer, type Server } from 'node:net';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
+import { registerEscapeSingleHelper } from './gather-user-responses';
 import {
     checkNodeVersion,
     detectPackageManager,
@@ -17,6 +20,7 @@ import {
     getSingleProjectPackageJson,
     getYarnDependenciesMeta,
     getYarnRcYml,
+    installPackages,
     isServerPortInUse,
     registerTemplateHelpers,
     toComposeProjectName,
@@ -29,6 +33,13 @@ import { PackageManager } from './types';
 vi.mock('./logger', () => ({
     log: vi.fn(),
 }));
+
+// Mocked so installPackages can be exercised without spawning real package managers.
+vi.mock('cross-spawn', () => {
+    const spawnMock = vi.fn();
+    (spawnMock as any).sync = vi.fn();
+    return { default: spawnMock };
+});
 
 /**
  * Binds an ephemeral port on 127.0.0.1 and returns both the server and its
@@ -505,16 +516,22 @@ describe('toComposeProjectName', () => {
     it('passes through already-valid names', () => {
         expect(toComposeProjectName('my-shop')).toBe('my-shop');
         expect(toComposeProjectName('shop_2')).toBe('shop_2');
+        expect(toComposeProjectName('123')).toBe('123');
     });
 
-    it('lowercases and strips characters Compose does not allow', () => {
-        expect(toComposeProjectName('My Shop!')).toBe('myshop');
-        expect(toComposeProjectName('shop.name')).toBe('shopname');
+    it('sanitizes disallowed characters and appends a stable suffix', () => {
+        expect(toComposeProjectName('My Shop!')).toMatch(/^my-shop-[0-9a-f]{8}$/);
+        expect(toComposeProjectName('shop.name')).toMatch(/^shop-name-[0-9a-f]{8}$/);
+        expect(toComposeProjectName('--shop')).toMatch(/^shop-[0-9a-f]{8}$/);
+        expect(toComposeProjectName('...')).toMatch(/^vendure-[0-9a-f]{8}$/);
+        // Deterministic: re-running create over the same directory must yield the same project.
+        expect(toComposeProjectName('My Shop!')).toBe(toComposeProjectName('My Shop!'));
     });
 
-    it('strips leading separators and falls back for empty results', () => {
-        expect(toComposeProjectName('--shop')).toBe('shop');
-        expect(toComposeProjectName('...')).toBe('vendure');
+    it('keeps distinct names distinct after sanitization', () => {
+        const names = ['shop.v1', 'shop v1', 'shop-v1', 'shopv1', 'SHOP-V1'];
+        const projects = names.map(toComposeProjectName);
+        expect(new Set(projects).size).toBe(names.length);
     });
 });
 
@@ -554,20 +571,28 @@ describe('registerTemplateHelpers + Dockerfile template', () => {
 // #4932 — the compose file must pin its own project name so containers/volumes never
 // collide across projects (the monorepo layout puts the file in apps/server for everyone).
 describe('docker-compose template', () => {
-    it('renders the sanitized compose project name', () => {
+    function renderComposeTemplate(projectName: string): string {
         // Registered by generateSources() in production; needed for the labels/env sections.
-        Handlebars.registerHelper('escapeSingle', (aString: unknown) =>
-            typeof aString === 'string' ? aString.replace(/'/g, "\\'") : aString,
-        );
+        registerEscapeSingleHelper();
         const template = fs.readFileSync(path.join(__dirname, '../templates/docker-compose.hbs'), 'utf-8');
-        const out = Handlebars.compile(template)({
-            composeProjectName: toComposeProjectName('My Shop'),
+        return Handlebars.compile(template)({
+            composeProjectName: toComposeProjectName(projectName),
             dbName: 'vendure',
             dbUserName: 'vendure',
             dbPassword: 'secret',
-            name: 'My Shop',
+            name: projectName,
         });
-        expect(out).toContain('name: myshop');
+    }
+
+    it('renders the sanitized compose project name', () => {
+        expect(renderComposeTemplate('My Shop')).toMatch(/^name: 'my-shop-[0-9a-f]{8}'$/m);
+    });
+
+    // Numeric or boolean-looking directory names must stay YAML strings — Compose
+    // rejects a non-string project name.
+    it('quotes the project name so numeric-looking names stay strings', () => {
+        expect(renderComposeTemplate('123')).toContain("name: '123'");
+        expect(renderComposeTemplate('true')).toContain("name: 'true'");
     });
 });
 
@@ -586,5 +611,79 @@ describe('checkNodeVersion', () => {
     it('does not warn on a maintained Node version', () => {
         checkNodeVersion('>=20.0.0', 'v22.15.0');
         expect(log).not.toHaveBeenCalled();
+    });
+});
+
+// #4932 — failed installs used to run with stdio: 'ignore' and reject with a generic
+// message, hiding the actual package-manager error (npm reports on stderr; yarn and
+// pnpm largely on stdout). These pin the captured-output failure messages.
+describe('installPackages', () => {
+    function fakeChild() {
+        const child = new EventEmitter() as any;
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        return child;
+    }
+
+    afterEach(() => {
+        vi.mocked(spawn).mockReset();
+    });
+
+    it('resolves when the install exits 0', async () => {
+        vi.mocked(spawn).mockImplementation((() => {
+            const child = fakeChild();
+            setImmediate(() => child.emit('close', 0));
+            return child;
+        }) as any);
+
+        await expect(
+            installPackages({ dependencies: ['dotenv'], logLevel: 'info', packageManager: 'npm' }),
+        ).resolves.toBeUndefined();
+    });
+
+    it('rejects with the command and captured output tail from both streams', async () => {
+        vi.mocked(spawn).mockImplementation((() => {
+            const child = fakeChild();
+            setImmediate(() => {
+                child.stdout.emit('data', Buffer.from('ERR_PNPM_IGNORED_BUILDS Ignored build scripts\n'));
+                child.stderr.emit('data', Buffer.from('some stderr detail\n'));
+                child.emit('close', 1);
+            });
+            return child;
+        }) as any);
+
+        await expect(
+            installPackages({ dependencies: ['dotenv'], logLevel: 'info', packageManager: 'pnpm' }),
+        ).rejects.toThrow(
+            expect.objectContaining({
+                message: expect.stringMatching(
+                    /`pnpm add --save-exact dotenv` failed with exit code 1[\s\S]*ERR_PNPM_IGNORED_BUILDS[\s\S]*some stderr detail/,
+                ),
+            }),
+        );
+    });
+
+    it('suggests verbose logging when the install produced no output', async () => {
+        vi.mocked(spawn).mockImplementation((() => {
+            const child = fakeChild();
+            setImmediate(() => child.emit('close', 1));
+            return child;
+        }) as any);
+
+        await expect(
+            installPackages({ dependencies: ['dotenv'], logLevel: 'info', packageManager: 'npm' }),
+        ).rejects.toThrow(/--log-level verbose/);
+    });
+
+    it('rejects with a PATH hint when the package manager cannot be spawned', async () => {
+        vi.mocked(spawn).mockImplementation((() => {
+            const child = fakeChild();
+            setImmediate(() => child.emit('error', new Error('spawn yarn ENOENT')));
+            return child;
+        }) as any);
+
+        await expect(
+            installPackages({ dependencies: ['dotenv'], logLevel: 'info', packageManager: 'yarn' }),
+        ).rejects.toThrow(/Is yarn installed and on your PATH\?/);
     });
 });

--- a/packages/create/src/helpers.spec.ts
+++ b/packages/create/src/helpers.spec.ts
@@ -9,12 +9,16 @@ import {
     findAvailablePort,
     getInstallCommand,
     getMonorepoRootPackageJson,
+    getNativeBuildDependencies,
     getPackageManagerInfo,
-    getPnpmOnlyBuiltDependencies,
+    getPnpmWorkspaceYaml,
     getServerPackageScripts,
     getSingleProjectPackageJson,
+    getYarnDependenciesMeta,
+    getYarnRcYml,
     isServerPortInUse,
     registerTemplateHelpers,
+    toComposeProjectName,
 } from './helpers';
 import { log } from './logger';
 import { PackageManager } from './types';
@@ -99,12 +103,10 @@ describe('isServerPortInUse', () => {
         // Simulate a firewall that drops SYN packets: connect() neither resolves
         // nor emits ECONNREFUSED. Without a setTimeout guard the promise would
         // hang for the OS-level connect timeout (~75s macOS, ~127s Linux).
-        const connectSpy = vi
-            .spyOn(Socket.prototype, 'connect')
-            .mockImplementation(function (this: Socket) {
-                // Intentionally never emit anything — let the socket's own timeout fire.
-                return this;
-            });
+        const connectSpy = vi.spyOn(Socket.prototype, 'connect').mockImplementation(function (this: Socket) {
+            // Intentionally never emit anything — let the socket's own timeout fire.
+            return this;
+        });
 
         await expect(isServerPortInUse(12345)).rejects.toThrow(/Timed out/);
         expect(connectSpy).toHaveBeenCalledOnce();
@@ -117,16 +119,14 @@ describe('isServerPortInUse', () => {
         // failures (e.g. EACCES on privileged ports, EHOSTUNREACH on DNS
         // misconfiguration) without needing elevated privileges or DNS
         // tricks at test time.
-        const connectSpy = vi
-            .spyOn(Socket.prototype, 'connect')
-            .mockImplementation(function (this: Socket) {
-                queueMicrotask(() => {
-                    const err = new Error('Host unreachable') as NodeJS.ErrnoException;
-                    err.code = 'EHOSTUNREACH';
-                    this.emit('error', err);
-                });
-                return this;
+        const connectSpy = vi.spyOn(Socket.prototype, 'connect').mockImplementation(function (this: Socket) {
+            queueMicrotask(() => {
+                const err = new Error('Host unreachable') as NodeJS.ErrnoException;
+                err.code = 'EHOSTUNREACH';
+                this.emit('error', err);
             });
+            return this;
+        });
 
         await expect(isServerPortInUse(12345)).rejects.toMatchObject({ code: 'EHOSTUNREACH' });
         expect(connectSpy).toHaveBeenCalledOnce();
@@ -326,9 +326,15 @@ describe('getPackageManagerInfo', () => {
 
     it('builds workspace run commands in each manager’s syntax', () => {
         expect(getPackageManagerInfo('npm').workspaceScript('server', 'dev')).toBe('npm run dev -w server');
-        expect(getPackageManagerInfo('yarn').workspaceScript('server', 'dev')).toBe('yarn workspace server dev');
-        expect(getPackageManagerInfo('pnpm').workspaceScript('server', 'dev')).toBe('pnpm --filter server dev');
-        expect(getPackageManagerInfo('bun').workspaceScript('server', 'dev')).toBe('bun run --filter server dev');
+        expect(getPackageManagerInfo('yarn').workspaceScript('server', 'dev')).toBe(
+            'yarn workspace server dev',
+        );
+        expect(getPackageManagerInfo('pnpm').workspaceScript('server', 'dev')).toBe(
+            'pnpm --filter server dev',
+        );
+        expect(getPackageManagerInfo('bun').workspaceScript('server', 'dev')).toBe(
+            'bun run --filter server dev',
+        );
     });
 
     it('flags pnpm as needing pnpm-workspace.yaml rather than the package.json workspaces field', () => {
@@ -375,17 +381,30 @@ describe('getMonorepoRootPackageJson', () => {
         ).toBeUndefined();
     });
 
-    // #4891 — pnpm v10 blocks dependency build scripts unless allowed at the workspace root.
-    it('adds pnpm.onlyBuiltDependencies only for pnpm, driver-aware', () => {
-        expect(getMonorepoRootPackageJson('x', getPackageManagerInfo('pnpm'), 'sqlite').pnpm).toEqual({
-            onlyBuiltDependencies: ['bcrypt', 'better-sqlite3', 'esbuild', 'sharp'],
+    // #4932 — pnpm v11 no longer reads the package.json `pnpm` field; the build-script
+    // allowlist lives in pnpm-workspace.yaml instead, so the field must never be written.
+    it('does not write a package.json pnpm field for any manager', () => {
+        for (const pm of ['npm', 'yarn', 'pnpm', 'bun'] as const) {
+            expect(getMonorepoRootPackageJson('x', getPackageManagerInfo(pm), 'sqlite').pnpm).toBeUndefined();
+        }
+    });
+
+    // #4932 — yarn ≥4.14 does not run dependency build scripts unless allowlisted.
+    it('adds dependenciesMeta with built: true only for yarn, driver-aware', () => {
+        expect(
+            getMonorepoRootPackageJson('x', getPackageManagerInfo('yarn'), 'sqlite').dependenciesMeta,
+        ).toEqual({
+            bcrypt: { built: true },
+            'better-sqlite3': { built: true },
+            esbuild: { built: true },
+            sharp: { built: true },
         });
-        expect(getMonorepoRootPackageJson('x', getPackageManagerInfo('pnpm'), 'postgres').pnpm).toEqual({
-            onlyBuiltDependencies: ['bcrypt', 'esbuild', 'sharp'],
-        });
-        // Non-pnpm managers run build scripts by default, so the field must be absent.
-        expect(getMonorepoRootPackageJson('x', getPackageManagerInfo('npm'), 'sqlite').pnpm).toBeUndefined();
-        expect(getMonorepoRootPackageJson('x', getPackageManagerInfo('bun'), 'sqlite').pnpm).toBeUndefined();
+        expect(
+            getMonorepoRootPackageJson('x', getPackageManagerInfo('npm'), 'sqlite').dependenciesMeta,
+        ).toBeUndefined();
+        expect(
+            getMonorepoRootPackageJson('x', getPackageManagerInfo('pnpm'), 'sqlite').dependenciesMeta,
+        ).toBeUndefined();
     });
 });
 
@@ -397,31 +416,35 @@ describe('getSingleProjectPackageJson', () => {
         expect((pkg.scripts as Record<string, string>).dev).toBe('vendure dev all');
     });
 
-    // #4891 — the single-project root package.json is where pnpm reads onlyBuiltDependencies.
-    it('adds pnpm.onlyBuiltDependencies only for pnpm, driver-aware', () => {
-        expect(getSingleProjectPackageJson('x', getPackageManagerInfo('pnpm'), 'sqlite').pnpm).toEqual({
-            onlyBuiltDependencies: ['bcrypt', 'better-sqlite3', 'esbuild', 'sharp'],
+    // #4932 — pnpm settings live in pnpm-workspace.yaml; yarn build scripts need allowlisting.
+    it('writes manager-specific build-script config fields', () => {
+        expect(
+            getSingleProjectPackageJson('x', getPackageManagerInfo('pnpm'), 'sqlite').pnpm,
+        ).toBeUndefined();
+        expect(
+            getSingleProjectPackageJson('x', getPackageManagerInfo('yarn'), 'postgres').dependenciesMeta,
+        ).toEqual({
+            bcrypt: { built: true },
+            esbuild: { built: true },
+            sharp: { built: true },
         });
-        expect(getSingleProjectPackageJson('x', getPackageManagerInfo('pnpm'), 'postgres').pnpm).toEqual({
-            onlyBuiltDependencies: ['bcrypt', 'esbuild', 'sharp'],
-        });
-        // Non-pnpm managers run build scripts by default, so the field must be absent.
-        expect(getSingleProjectPackageJson('x', getPackageManagerInfo('npm'), 'sqlite').pnpm).toBeUndefined();
-        expect(getSingleProjectPackageJson('x', getPackageManagerInfo('bun'), 'sqlite').pnpm).toBeUndefined();
+        expect(
+            getSingleProjectPackageJson('x', getPackageManagerInfo('npm'), 'sqlite').dependenciesMeta,
+        ).toBeUndefined();
     });
 });
 
-// #4891 — pnpm v10 does not run dependency build scripts unless they are listed in
-// pnpm.onlyBuiltDependencies, so better-sqlite3's native binding never compiles.
-describe('getPnpmOnlyBuiltDependencies', () => {
+// #4891 — pnpm and yarn do not run dependency build scripts unless allowlisted, so
+// e.g. better-sqlite3's native binding never compiles.
+describe('getNativeBuildDependencies', () => {
     it('always includes the native deps a Vendure scaffold installs', () => {
         for (const dbType of ['postgres', 'mysql', 'mariadb'] as const) {
-            expect(getPnpmOnlyBuiltDependencies(dbType)).toEqual(['bcrypt', 'esbuild', 'sharp']);
+            expect(getNativeBuildDependencies(dbType)).toEqual(['bcrypt', 'esbuild', 'sharp']);
         }
     });
 
     it('adds better-sqlite3 for the SQLite driver', () => {
-        expect(getPnpmOnlyBuiltDependencies('sqlite')).toEqual([
+        expect(getNativeBuildDependencies('sqlite')).toEqual([
             'bcrypt',
             'better-sqlite3',
             'esbuild',
@@ -430,13 +453,68 @@ describe('getPnpmOnlyBuiltDependencies', () => {
     });
 });
 
+// #4932 — pnpm v10 reads `onlyBuiltDependencies`, pnpm v11 replaced it with `allowBuilds`
+// and ignores both the old key and the package.json `pnpm` field. Both keys are written
+// so the scaffold works under either version.
+describe('getPnpmWorkspaceYaml', () => {
+    it('declares both the v10 and v11 build-script allowlists', () => {
+        const yaml = getPnpmWorkspaceYaml('sqlite');
+        expect(yaml).toContain('onlyBuiltDependencies:');
+        expect(yaml).toContain('    - better-sqlite3');
+        expect(yaml).toContain('allowBuilds:');
+        expect(yaml).toContain('    better-sqlite3: true');
+        expect(yaml).not.toContain('packages:');
+    });
+
+    it('includes the workspace packages globs when provided (monorepo)', () => {
+        const yaml = getPnpmWorkspaceYaml('postgres', ['apps/*']);
+        expect(yaml).toContain("packages:\n    - 'apps/*'");
+        expect(yaml).toContain('    - bcrypt');
+        expect(yaml).not.toContain('better-sqlite3');
+    });
+});
+
+describe('getYarnDependenciesMeta', () => {
+    it('marks each native build dependency as built', () => {
+        expect(getYarnDependenciesMeta('sqlite')).toEqual({
+            bcrypt: { built: true },
+            'better-sqlite3': { built: true },
+            esbuild: { built: true },
+            sharp: { built: true },
+        });
+    });
+});
+
+describe('getYarnRcYml', () => {
+    it('disables Plug’n’Play in favour of a physical node_modules tree', () => {
+        expect(getYarnRcYml()).toContain('nodeLinker: node-modules');
+    });
+});
+
+// #4932 — in monorepo mode the compose file lives in apps/server, so without an explicit
+// project name every created project collides on the Compose project "server": the second
+// `docker compose up` then hangs forever on an unanswerable "Recreate volume?" prompt.
+describe('toComposeProjectName', () => {
+    it('passes through already-valid names', () => {
+        expect(toComposeProjectName('my-shop')).toBe('my-shop');
+        expect(toComposeProjectName('shop_2')).toBe('shop_2');
+    });
+
+    it('lowercases and strips characters Compose does not allow', () => {
+        expect(toComposeProjectName('My Shop!')).toBe('myshop');
+        expect(toComposeProjectName('shop.name')).toBe('shopname');
+    });
+
+    it('strips leading separators and falls back for empty results', () => {
+        expect(toComposeProjectName('--shop')).toBe('shop');
+        expect(toComposeProjectName('...')).toBe('vendure');
+    });
+});
+
 // The Dockerfile template is rendered with helpers registered by registerTemplateHelpers.
 // A misspelled helper name renders an empty string silently, so assert real output.
 describe('registerTemplateHelpers + Dockerfile template', () => {
-    const dockerfileTemplate = fs.readFileSync(
-        path.join(__dirname, '../templates/Dockerfile.hbs'),
-        'utf-8',
-    );
+    const dockerfileTemplate = fs.readFileSync(path.join(__dirname, '../templates/Dockerfile.hbs'), 'utf-8');
 
     function renderDockerfile(pm: PackageManager): string {
         registerTemplateHelpers(getPackageManagerInfo(pm));
@@ -463,5 +541,25 @@ describe('registerTemplateHelpers + Dockerfile template', () => {
         expect(out).toContain('COPY package.json pnpm-lock.yaml ./');
         expect(out).toContain('RUN pnpm install --frozen-lockfile');
         expect(out).toContain('RUN pnpm run build');
+    });
+});
+
+// #4932 — the compose file must pin its own project name so containers/volumes never
+// collide across projects (the monorepo layout puts the file in apps/server for everyone).
+describe('docker-compose template', () => {
+    it('renders the sanitized compose project name', () => {
+        // Registered by generateSources() in production; needed for the labels/env sections.
+        Handlebars.registerHelper('escapeSingle', (aString: unknown) =>
+            typeof aString === 'string' ? aString.replace(/'/g, "\\'") : aString,
+        );
+        const template = fs.readFileSync(path.join(__dirname, '../templates/docker-compose.hbs'), 'utf-8');
+        const out = Handlebars.compile(template)({
+            composeProjectName: toComposeProjectName('My Shop'),
+            dbName: 'vendure',
+            dbUserName: 'vendure',
+            dbPassword: 'secret',
+            name: 'My Shop',
+        });
+        expect(out).toContain('name: myshop');
     });
 });

--- a/packages/create/src/helpers.spec.ts
+++ b/packages/create/src/helpers.spec.ts
@@ -5,6 +5,7 @@ import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import {
+    checkNodeVersion,
     detectPackageManager,
     findAvailablePort,
     getInstallCommand,
@@ -561,5 +562,23 @@ describe('docker-compose template', () => {
             name: 'My Shop',
         });
         expect(out).toContain('name: myshop');
+    });
+});
+
+// #4932 — native deps (e.g. better-sqlite3) stop publishing prebuilt binaries for EOL
+// Node versions, so users on them hit cryptic install failures without this heads-up.
+describe('checkNodeVersion', () => {
+    afterEach(() => {
+        vi.mocked(log).mockClear();
+    });
+
+    it('warns when running on an EOL Node version', () => {
+        checkNodeVersion('>=20.0.0', 'v20.20.2');
+        expect(log).toHaveBeenCalledWith(expect.stringContaining('end-of-life'));
+    });
+
+    it('does not warn on a maintained Node version', () => {
+        checkNodeVersion('>=20.0.0', 'v22.15.0');
+        expect(log).not.toHaveBeenCalled();
     });
 });

--- a/packages/create/src/helpers.spec.ts
+++ b/packages/create/src/helpers.spec.ts
@@ -467,6 +467,12 @@ describe('getPnpmWorkspaceYaml', () => {
         expect(yaml).not.toContain('packages:');
     });
 
+    // pnpm v11 defaults strictDepBuilds to true, which hard-fails the install for any
+    // script-bearing dep not covered by allowBuilds (e.g. @apollo/protobufjs, msw).
+    it('disables strictDepBuilds so uncovered build scripts warn instead of failing', () => {
+        expect(getPnpmWorkspaceYaml('sqlite')).toContain('strictDepBuilds: false');
+    });
+
     it('includes the workspace packages globs when provided (monorepo)', () => {
         const yaml = getPnpmWorkspaceYaml('postgres', ['apps/*']);
         expect(yaml).toContain("packages:\n    - 'apps/*'");

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -466,6 +466,11 @@ export function getPnpmWorkspaceYaml(dbType: DbType, packagesGlobs?: string[]): 
         lines.push(`    ${dep}: true`);
     }
     lines.push('');
+    lines.push('# pnpm v11 fails the install when a dependency has build scripts not covered by');
+    lines.push('# allowBuilds. Off, such scripts are skipped with a warning (as in pnpm v10);');
+    lines.push('# the packages concerned work without their build scripts.');
+    lines.push('strictDepBuilds: false');
+    lines.push('');
     return lines.join('\n');
 }
 

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -17,6 +17,7 @@ import * as tar from 'tar';
 import {
     CONCURRENTLY_VERSION,
     DEFAULT_PROJECT_VERSION,
+    OLDEST_NON_EOL_NODE_MAJOR,
     PG_READY_MAX_ATTEMPTS,
     PG_READY_POLL_INTERVAL_MS,
     SOCKET_TIMEOUT_MS,
@@ -106,16 +107,26 @@ export function scaffoldAlreadyExists(root: string, name: string): boolean {
     return scaffoldFiles.every(scaffoldFile => files.includes(scaffoldFile));
 }
 
-export function checkNodeVersion(requiredVersion: string) {
-    if (!semver.satisfies(process.version, requiredVersion)) {
+export function checkNodeVersion(requiredVersion: string, currentVersion: string = process.version) {
+    if (!semver.satisfies(currentVersion, requiredVersion)) {
         log(
             pc.red(
-                `You are running Node ${process.version}.` +
+                `You are running Node ${currentVersion}.` +
                     `Vendure requires Node ${requiredVersion} or higher.` +
                     'Please update your version of Node.',
             ),
         );
         process.exit(1);
+    }
+    if (semver.major(currentVersion) < OLDEST_NON_EOL_NODE_MAJOR) {
+        log(
+            pc.yellow(
+                `You are running Node ${currentVersion}, which has reached end-of-life. ` +
+                    'Native dependencies may no longer provide prebuilt binaries for it, ' +
+                    'which can cause installation failures. Consider upgrading to the ' +
+                    'current LTS release: https://nodejs.org/en/download',
+            ),
+        );
     }
 }
 

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -514,16 +514,19 @@ export function installPackages(options: {
             logLevel,
         });
 
-        // Below verbose, capture stderr so a failing install can report the actual
-        // package-manager error rather than a generic message.
+        // Below verbose, capture output so a failing install can report the actual
+        // package-manager error rather than a generic message. Both streams are needed:
+        // npm reports errors on stderr, while yarn and pnpm largely report on stdout.
         const child = spawn(command, args, {
-            stdio: logLevel === 'verbose' ? 'inherit' : ['ignore', 'ignore', 'pipe'],
+            stdio: logLevel === 'verbose' ? 'inherit' : ['ignore', 'pipe', 'pipe'],
             cwd,
         });
-        let stderrTail = '';
-        child.stderr?.on('data', (chunk: Buffer) => {
-            stderrTail = (stderrTail + chunk.toString()).slice(-4000);
-        });
+        let outputTail = '';
+        const collectTail = (chunk: Buffer) => {
+            outputTail = (outputTail + chunk.toString()).slice(-4000);
+        };
+        child.stdout?.on('data', collectTail);
+        child.stderr?.on('data', collectTail);
         child.on('error', err => {
             reject(
                 new Error(
@@ -534,8 +537,8 @@ export function installPackages(options: {
         child.on('close', code => {
             if (code !== 0) {
                 let message = `\`${command} ${args.join(' ')}\` failed with exit code ${String(code)}.`;
-                if (stderrTail.trim()) {
-                    message += `\n\n${stderrTail.trim()}`;
+                if (outputTail.trim()) {
+                    message += `\n\n${outputTail.trim()}`;
                 } else if (logLevel !== 'verbose') {
                     message += ' Try running with `--log-level verbose` to diagnose.';
                 }

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -17,6 +17,8 @@ import * as tar from 'tar';
 import {
     CONCURRENTLY_VERSION,
     DEFAULT_PROJECT_VERSION,
+    PG_READY_MAX_ATTEMPTS,
+    PG_READY_POLL_INTERVAL_MS,
     SOCKET_TIMEOUT_MS,
     STOREFRONT_BRANCH,
     STOREFRONT_REPO,
@@ -372,10 +374,8 @@ export function getMonorepoRootPackageJson(
     if (pmInfo.usesPackageJsonWorkspaces) {
         pkg.workspaces = ['apps/*'];
     }
-    // pnpm reads `onlyBuiltDependencies` from the workspace root, where it governs every
-    // package in the workspace (the deps themselves live in apps/server).
-    if (pmInfo.name === 'pnpm') {
-        pkg.pnpm = { onlyBuiltDependencies: getPnpmOnlyBuiltDependencies(dbType) };
+    if (pmInfo.name === 'yarn') {
+        pkg.dependenciesMeta = getYarnDependenciesMeta(dbType);
     }
     return pkg;
 }
@@ -394,28 +394,77 @@ export function getSingleProjectPackageJson(
         private: true,
         scripts: getServerPackageScripts(),
     };
-    if (pmInfo.name === 'pnpm') {
-        pkg.pnpm = { onlyBuiltDependencies: getPnpmOnlyBuiltDependencies(dbType) };
+    if (pmInfo.name === 'yarn') {
+        pkg.dependenciesMeta = getYarnDependenciesMeta(dbType);
     }
     return pkg;
 }
 
 /**
- * Native dependencies whose install/build scripts pnpm v10 blocks by default. Listed
- * under `pnpm.onlyBuiltDependencies` so their build scripts run — otherwise e.g.
- * better-sqlite3's native binding is never compiled and the server crashes on startup.
+ * Native dependencies whose install/build scripts must run for the scaffolded project to
+ * work — otherwise e.g. better-sqlite3's native binding is never compiled and the server
+ * crashes on startup. pnpm (v10+) and yarn (v4.14+) block dependency build scripts unless
+ * allowlisted, so this list feeds their respective allowlist mechanisms.
  * `bcrypt` (core), `sharp` (asset-server-plugin) and `esbuild` (vite) are always present;
  * SQLite adds `better-sqlite3`.
  *
  * This list is derived from the scaffold's transitive native deps; re-check it against
  * `getDependencies()` whenever Vendure's direct native-dep surface changes.
  */
-export function getPnpmOnlyBuiltDependencies(dbType: DbType): string[] {
+export function getNativeBuildDependencies(dbType: DbType): string[] {
     const deps = ['bcrypt', 'esbuild', 'sharp'];
     if (dbType === 'sqlite') {
         deps.push('better-sqlite3');
     }
     return deps.sort((a, b) => a.localeCompare(b));
+}
+
+/**
+ * Yarn ≥4.14 does not run dependency build scripts unless they are allowlisted via
+ * `dependenciesMeta` in the top-level package.json (`built: true` per package).
+ */
+export function getYarnDependenciesMeta(dbType: DbType): Record<string, { built: true }> {
+    return Object.fromEntries(getNativeBuildDependencies(dbType).map(dep => [dep, { built: true }]));
+}
+
+/**
+ * Generates the pnpm-workspace.yaml contents. Since pnpm v11, this file is the only place
+ * pnpm reads its settings from (the package.json `pnpm` field is ignored), and it is also
+ * where build-script permissions live: v10 uses `onlyBuiltDependencies`, v11 replaced it
+ * with `allowBuilds`. Both keys are written so the scaffold works under either version.
+ */
+export function getPnpmWorkspaceYaml(dbType: DbType, packagesGlobs?: string[]): string {
+    const nativeDeps = getNativeBuildDependencies(dbType);
+    const lines: string[] = [];
+    if (packagesGlobs?.length) {
+        lines.push('packages:');
+        for (const glob of packagesGlobs) {
+            lines.push(`    - '${glob}'`);
+        }
+        lines.push('');
+    }
+    lines.push('# pnpm v10 build-script allowlist');
+    lines.push('onlyBuiltDependencies:');
+    for (const dep of nativeDeps) {
+        lines.push(`    - ${dep}`);
+    }
+    lines.push('');
+    lines.push('# pnpm v11 build-script allowlist');
+    lines.push('allowBuilds:');
+    for (const dep of nativeDeps) {
+        lines.push(`    ${dep}: true`);
+    }
+    lines.push('');
+    return lines.join('\n');
+}
+
+/**
+ * Generates the .yarnrc.yml for yarn-created projects. The scaffold (ts-node registration,
+ * the `vendure` CLI, the dashboard build) resolves packages from a physical node_modules
+ * tree, so Plug'n'Play is disabled.
+ */
+export function getYarnRcYml(): string {
+    return 'nodeLinker: node-modules\n';
 }
 
 /**
@@ -454,20 +503,32 @@ export function installPackages(options: {
             logLevel,
         });
 
+        // Below verbose, capture stderr so a failing install can report the actual
+        // package-manager error rather than a generic message.
         const child = spawn(command, args, {
-            stdio: logLevel === 'verbose' ? 'inherit' : 'ignore',
+            stdio: logLevel === 'verbose' ? 'inherit' : ['ignore', 'ignore', 'pipe'],
             cwd,
+        });
+        let stderrTail = '';
+        child.stderr?.on('data', (chunk: Buffer) => {
+            stderrTail = (stderrTail + chunk.toString()).slice(-4000);
+        });
+        child.on('error', err => {
+            reject(
+                new Error(
+                    `Could not run \`${command} ${args.join(' ')}\`: ${err.message}. Is ${command} installed and on your PATH?`,
+                ),
+            );
         });
         child.on('close', code => {
             if (code !== 0) {
-                let message = 'An error occurred when installing dependencies.';
-                if (logLevel === 'silent') {
+                let message = `\`${command} ${args.join(' ')}\` failed with exit code ${String(code)}.`;
+                if (stderrTail.trim()) {
+                    message += `\n\n${stderrTail.trim()}`;
+                } else if (logLevel !== 'verbose') {
                     message += ' Try running with `--log-level verbose` to diagnose.';
                 }
-                reject({
-                    message,
-                    command: `${command} ${args.join(' ')}`,
-                });
+                reject(new Error(message));
                 return;
             }
             resolve();
@@ -669,13 +730,29 @@ export async function isDockerAvailable(): Promise<{ result: 'not-found' | 'not-
     return { result: 'not-running' };
 }
 
-export async function startPostgresDatabase(root: string): Promise<boolean> {
+/**
+ * Sanitizes a project name into a valid Docker Compose project name
+ * (lowercase letters, digits, `-` and `_`, starting with an alphanumeric).
+ * Used as the top-level `name` in the generated docker-compose.yml so that each
+ * created project gets its own Compose project. Without it, Compose derives the
+ * project name from the compose file's directory — which in monorepo mode is
+ * always `apps/server`, so every project would collide on the project "server".
+ */
+export function toComposeProjectName(name: string): string {
+    const sanitized = name
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]/g, '')
+        .replace(/^[_-]+/, '');
+    return sanitized || 'vendure';
+}
+
+export async function startPostgresDatabase(root: string, projectName: string): Promise<boolean> {
     // Now we need to run the postgres database via Docker
     let containerName: string | undefined;
     const postgresContainerSpinner = spinner();
     postgresContainerSpinner.start('Starting PostgreSQL database');
     try {
-        const result = await promisify(execFile)(`docker`, [
+        const composePromise = promisify(execFile)(`docker`, [
             `compose`,
             `-f`,
             path.join(root, 'docker-compose.yml'),
@@ -683,10 +760,15 @@ export async function startPostgresDatabase(root: string): Promise<boolean> {
             `-d`,
             `postgres_db`,
         ]);
+        // `docker compose up` can ask interactive questions (e.g. "Volume exists but
+        // doesn't match configuration. Recreate?"). Close stdin so it gets EOF instead
+        // of blocking forever on a prompt the user cannot see.
+        composePromise.child.stdin?.end();
+        const result = await composePromise;
         containerName = result.stderr.match(/Container\s+(.+-postgres_db[^ ]*)/)?.[1];
         if (!containerName) {
-            // guess the container name based on the directory name
-            containerName = path.basename(root).replace(/[^a-z0-9]/gi, '') + '-postgres_db-1';
+            // Fall back to Compose's naming convention: <project>-<service>-<index>
+            containerName = `${toComposeProjectName(projectName)}-postgres_db-1`;
             postgresContainerSpinner.message(
                 'Could not find container name. Guessing it is: ' + containerName,
             );
@@ -709,9 +791,19 @@ export async function startPostgresDatabase(root: string): Promise<boolean> {
     let attempts = 1;
     let isReady = false;
     do {
-        // We now need to ensure that the database is ready to accept connections
+        // We now need to ensure that the database is ready to accept connections.
+        // The `-h localhost` forces a TCP check: during a first boot, initdb runs a
+        // temporary server that only listens on the unix socket, and a socket-based
+        // pg_isready would report "ready" before the real server is up.
         try {
-            const result = execFileSync(`docker`, [`exec`, `-i`, containerName, `pg_isready`]);
+            const result = execFileSync(`docker`, [
+                `exec`,
+                `-i`,
+                containerName,
+                `pg_isready`,
+                `-h`,
+                `localhost`,
+            ]);
             isReady = result?.toString().includes('accepting connections');
             if (!isReady) {
                 log(pc.yellow(`PostgreSQL database not yet ready. Attempt ${attempts}...`), {
@@ -722,9 +814,23 @@ export async function startPostgresDatabase(root: string): Promise<boolean> {
             // ignore
             log('is_ready error:' + (e.message as string), { level: 'verbose', newline: 'before' });
         }
-        await new Promise(resolve => setTimeout(resolve, 50));
+        if (isReady) {
+            break;
+        }
+        await new Promise(resolve => setTimeout(resolve, PG_READY_POLL_INTERVAL_MS));
         attempts++;
-    } while (!isReady && attempts < 100);
+    } while (attempts <= PG_READY_MAX_ATTEMPTS);
+    if (!isReady) {
+        postgresContainerSpinner.stop(
+            pc.red(
+                `PostgreSQL database did not become ready within ${Math.round(
+                    (PG_READY_MAX_ATTEMPTS * PG_READY_POLL_INTERVAL_MS) / 1000,
+                )} seconds`,
+            ),
+        );
+        log(`Check the container logs with: docker logs ${containerName}`);
+        return false;
+    }
     postgresContainerSpinner.stop('PostgreSQL database is ready');
     return true;
 }
@@ -828,16 +934,23 @@ export function checkCancel<T>(value: T | symbol): value is T {
 }
 
 export function cleanUpDockerResources(name: string) {
+    const labelFilter = `label=io.vendure.create.name=${name}`;
+    const listIds = (args: string[]): string[] =>
+        execFileSync('docker', args)
+            .toString()
+            .split('\n')
+            .map(line => line.trim())
+            .filter(Boolean);
     try {
-        execSync(`docker stop $(docker ps -a -q --filter "label=io.vendure.create.name=${name}")`, {
-            stdio: 'ignore',
-        });
-        execSync(`docker rm $(docker ps -a -q --filter "label=io.vendure.create.name=${name}")`, {
-            stdio: 'ignore',
-        });
-        execSync(`docker volume rm $(docker volume ls --filter "label=io.vendure.create.name=${name}" -q)`, {
-            stdio: 'ignore',
-        });
+        const containerIds = listIds(['ps', '-a', '-q', '--filter', labelFilter]);
+        if (containerIds.length) {
+            execFileSync('docker', ['stop', ...containerIds], { stdio: 'ignore' });
+            execFileSync('docker', ['rm', ...containerIds], { stdio: 'ignore' });
+        }
+        const volumeIds = listIds(['volume', 'ls', '-q', '--filter', labelFilter]);
+        if (volumeIds.length) {
+            execFileSync('docker', ['volume', 'rm', ...volumeIds], { stdio: 'ignore' });
+        }
     } catch (e) {
         log(pc.yellow(`Could not clean up Docker resources`), { level: 'verbose' });
     }
@@ -932,9 +1045,7 @@ export async function findAvailablePort(startPort: number, range: number = 20): 
         try {
             inUse = await isServerPortInUse(port);
         } catch (e) {
-            throw new Error(
-                `Could not probe port ${port}: ${e instanceof Error ? e.message : String(e)}`,
-            );
+            throw new Error(`Could not probe port ${port}: ${e instanceof Error ? e.message : String(e)}`);
         }
         if (!inUse) return port;
         port++;

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -3,6 +3,7 @@ import spawn from 'cross-spawn';
 import fs from 'fs-extra';
 import Handlebars from 'handlebars';
 import { execFile, execFileSync, execSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
 import { createWriteStream } from 'node:fs';
 import { Socket } from 'node:net';
 import { platform } from 'node:os';
@@ -467,8 +468,8 @@ export function getPnpmWorkspaceYaml(dbType: DbType, packagesGlobs?: string[]): 
     }
     lines.push('');
     lines.push('# pnpm v11 fails the install when a dependency has build scripts not covered by');
-    lines.push('# allowBuilds. Off, such scripts are skipped with a warning (as in pnpm v10);');
-    lines.push('# the packages concerned work without their build scripts.');
+    lines.push('# allowBuilds. With this off, uncovered scripts are skipped with a warning instead');
+    lines.push('# (as in pnpm v10); the packages concerned work without their build scripts.');
     lines.push('strictDepBuilds: false');
     lines.push('');
     return lines.join('\n');
@@ -756,13 +757,22 @@ export async function isDockerAvailable(): Promise<{ result: 'not-found' | 'not-
  * created project gets its own Compose project. Without it, Compose derives the
  * project name from the compose file's directory — which in monorepo mode is
  * always `apps/server`, so every project would collide on the project "server".
+ *
+ * When sanitization alters the name, a stable suffix derived from the original is
+ * appended: otherwise distinct project names could sanitize to the same value
+ * (e.g. `shop.v1` and `shopv1`) and end up sharing containers and volumes.
  */
 export function toComposeProjectName(name: string): string {
     const sanitized = name
         .toLowerCase()
-        .replace(/[^a-z0-9_-]/g, '')
+        .replace(/[^a-z0-9_-]+/g, '-')
         .replace(/^[_-]+/, '');
-    return sanitized || 'vendure';
+    if (sanitized === name) {
+        return name;
+    }
+    const suffix = createHash('sha256').update(name).digest('hex').slice(0, 8);
+    const base = sanitized.replace(/[_-]+$/, '') || 'vendure';
+    return `${base}-${suffix}`;
 }
 
 export async function startPostgresDatabase(root: string, projectName: string): Promise<boolean> {

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -1005,11 +1005,12 @@ export async function downloadAndExtractStorefront(targetDir: string): Promise<v
     const tempTarPath = path.join(targetDir, '..', 'storefront-temp.tar.gz');
 
     try {
-        // Fetch the tarball from GitHub
+        // Fetch the tarball from GitHub. A token (e.g. in CI) raises the rate limit.
         const response = await fetch(tarballUrl, {
             headers: {
                 Accept: 'application/vnd.github+json',
                 'User-Agent': 'vendure-create',
+                ...(process.env.GITHUB_TOKEN ? { Authorization: `Bearer ${process.env.GITHUB_TOKEN}` } : {}),
             },
         });
 

--- a/packages/create/templates/docker-compose.hbs
+++ b/packages/create/templates/docker-compose.hbs
@@ -4,6 +4,11 @@
 # In case you don't have any services running on the default ports, you can expose them by changing the
 # ports section in the services block. Please don't forget to update the ports in the .env file as well.
 
+# The explicit project name keeps this project's containers and volumes distinct from
+# those of other projects, even when this file lives in an identically-named directory
+# (e.g. apps/server in a monorepo).
+name: {{ composeProjectName }}
+
 services:
     postgres_db:
         image: postgres:16-alpine

--- a/packages/create/templates/docker-compose.hbs
+++ b/packages/create/templates/docker-compose.hbs
@@ -6,8 +6,9 @@
 
 # The explicit project name keeps this project's containers and volumes distinct from
 # those of other projects, even when this file lives in an identically-named directory
-# (e.g. apps/server in a monorepo).
-name: {{ composeProjectName }}
+# (e.g. apps/server in a monorepo). Quoted so that numeric-looking names (e.g. "123")
+# stay YAML strings — Compose rejects a non-string name.
+name: '{{ composeProjectName }}'
 
 services:
     postgres_db:

--- a/packages/dashboard/vite/tests/config-path.spec.ts
+++ b/packages/dashboard/vite/tests/config-path.spec.ts
@@ -1,0 +1,24 @@
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+import { getNormalizedVendureConfigPath } from '../vite-plugin-vendure-dashboard.js';
+
+// #4931 — file URLs percent-encode special characters (a space becomes %20). Converting
+// them to filesystem paths via URL.pathname keeps the encoding, producing paths like
+// /Users/x/Local%20Documents/... which then fail to stat and even get mkdir'd literally.
+describe('getNormalizedVendureConfigPath', () => {
+    it('decodes percent-encoded characters in file URLs', () => {
+        // path.resolve makes the expectation platform-correct (drive letter on Windows).
+        const configPath = path.resolve('/Users/x/Local Documents/dev/my-shop/vendure-config.ts');
+        const url = pathToFileURL(configPath);
+        expect(url.href).toContain('%20');
+        expect(getNormalizedVendureConfigPath(url)).toBe(configPath);
+        expect(getNormalizedVendureConfigPath(url.href)).toBe(configPath);
+    });
+
+    it('passes plain string paths through unchanged', () => {
+        const configPath = path.resolve('/Users/x/dev/my-shop/vendure-config.ts');
+        expect(getNormalizedVendureConfigPath(configPath)).toBe(configPath);
+    });
+});

--- a/packages/dashboard/vite/vite-plugin-tailwind-source.ts
+++ b/packages/dashboard/vite/vite-plugin-tailwind-source.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { Plugin } from 'vite';
 
 import { CompileResult } from './utils/compiler.js';
 import { filterActivePluginInfo } from './utils/get-active-plugin-info.js';
 import { getDashboardPaths } from './utils/get-dashboard-paths.js';
 import { ConfigLoaderApi, getConfigLoaderApi } from './vite-plugin-config-loader.js';
-import { fixWindowsPath } from './vite-plugin-vendure-dashboard.js';
 
 /**
  * Resolve the absolute path to the `@vendure-io/ui` source directory.
@@ -16,7 +16,8 @@ import { fixWindowsPath } from './vite-plugin-vendure-dashboard.js';
 function resolveVendureUiSourcePath(): string | undefined {
     try {
         const resolved = import.meta.resolve('@vendure-io/ui/components/ui/button');
-        const filePath = resolved.startsWith('file:') ? fixWindowsPath(new URL(resolved).pathname) : resolved;
+        // fileURLToPath decodes percent-encoding (e.g. spaces) and handles Windows drive letters.
+        const filePath = resolved.startsWith('file:') ? fileURLToPath(resolved) : resolved;
         return path.resolve(filePath, '../../../');
     } catch (error) {
         // eslint-disable-next-line no-console

--- a/packages/dashboard/vite/vite-plugin-vendure-dashboard.ts
+++ b/packages/dashboard/vite/vite-plugin-vendure-dashboard.ts
@@ -3,6 +3,7 @@ import tailwindcss from '@tailwindcss/vite';
 import { tanstackRouter } from '@tanstack/router-plugin/vite';
 import react from '@vitejs/plugin-react';
 import { randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
 import path from 'path';
 import { PluginOption } from 'vite';
 
@@ -390,9 +391,11 @@ export function vendureDashboardPlugin(options: VitePluginVendureDashboardOption
  * Returns the path to the root of the `@vendure/dashboard` package.
  */
 function getDashboardPackageRoot(): string {
+    // fileURLToPath (rather than URL.pathname) decodes percent-encoding, so paths
+    // containing e.g. spaces resolve correctly, and handles Windows drive letters.
     const fileUrl = import.meta.resolve('@vendure/dashboard');
-    const packagePath = fileUrl.startsWith('file:') ? new URL(fileUrl).pathname : fileUrl;
-    return fixWindowsPath(path.join(packagePath, '../../../'));
+    const packagePath = fileUrl.startsWith('file:') ? fileURLToPath(fileUrl) : fileUrl;
+    return path.join(packagePath, '../../../');
 }
 
 /**
@@ -401,7 +404,8 @@ function getDashboardPackageRoot(): string {
 export function getNormalizedVendureConfigPath(vendureConfigPath: string | URL): string {
     const stringPath = typeof vendureConfigPath === 'string' ? vendureConfigPath : vendureConfigPath.href;
     if (stringPath.startsWith('file:')) {
-        return fixWindowsPath(new URL(stringPath).pathname);
+        // fileURLToPath decodes percent-encoding (e.g. spaces) and handles Windows drive letters.
+        return fileURLToPath(stringPath);
     }
     return fixWindowsPath(stringPath);
 }


### PR DESCRIPTION
## Description

Fixes the `@vendure/create` failures reported in #4932 (Quick Start broken across npm/pnpm/yarn/bun) and the percent-encoded path bug in #4931, and closes the CI blind spots that let all of it ship green.

### Quick Start hang at "Starting PostgreSQL database..." (monorepo mode)

In monorepo mode the compose file lives in `apps/server` for every project, so Compose derived the same project name (`server`) for all of them. From the second monorepo project onwards, `docker compose up` asked *"Volume exists but doesn't match configuration. Recreate?"* — a prompt nobody can see or answer, because the child's stdin was an open pipe. Deterministic infinite hang, reproduced locally.

- The generated `docker-compose.yml` now pins a unique, sanitized top-level `name`
- stdin is closed on the compose child so it can never block on a prompt

### "PostgreSQL database is ready" lie → ECONNRESET

The `pg_isready` wait allowed ~5 seconds (less than a first-boot `initdb`), then unconditionally reported ready and returned `true`, so populate failed mid-initdb. Now: 60s budget, TCP-based check (`-h localhost`, avoiding initdb's socket-only temporary server), and an honest failure that aborts the run with guidance.

### pnpm ≥ 11 hard install failure

pnpm 11 no longer reads `package.json#pnpm`, replaced `onlyBuiltDependencies` with `allowBuilds`, and defaults `strictDepBuilds` to true (any script-bearing dep without an explicit verdict fails the install). The scaffold now writes a `pnpm-workspace.yaml` with both the v10 and v11 allowlists plus `strictDepBuilds: false`, verified against pnpm 10 and 11. Everything downstream in the report (`vendure: command not found`, missing `graphql`) was fallout from the aborted install.

### yarn ≥ 4.14 disables build scripts by default

Yarn projects now get a `dependenciesMeta` allowlist (`built: true` for the native deps) and a `.yarnrc.yml` with `nodeLinker: node-modules` (the scaffold resolves packages from a physical node_modules tree). Verified against yarn 4.14/4.17.

Note: yarn ≥ 4.12 also quarantines versions younger than `npmMinimalAgeGate` (default 1 day, YN0016) — users installing right after a Vendure release will see this. It is yarn's intended supply-chain protection; the improved error output now surfaces the message plainly.

### Swallowed install errors

`installPackages` ran with `stdio: 'ignore'` below verbose, hiding the real package-manager error (npm reports on stderr; yarn/pnpm largely on stdout). Both streams are now captured and the tail is shown on failure.

### Percent-encoded paths (#4931)

Three places in the dashboard's Vite plugins converted `file://` URLs to paths via `URL.pathname`, which keeps percent-encoding — a project under a path with a space became `/Users/x/Local%20Documents/...`, breaking `run dev` and literally creating `Local%20Documents` directories (the TanStack router generator mkdirs its routes directory). All three now use `fileURLToPath()`, which also handles Windows drive letters, replacing the `fixWindowsPath` workaround at those sites.

### Other

- `--db postgres` option for `--ci` mode, so the Docker/postgres flow can run non-interactively
- Warn (not block) when running on an EOL Node version
- `downloadAndExtractStorefront` sends `GITHUB_TOKEN` when present (CI rate limits)
- Portable Docker resource cleanup (no shell command substitution; previously always errored when there was nothing to clean, and never worked on Windows)

## CI changes

The Windows/Node 20 job had failed on every run since June 16 — not flake: `better-sqlite3@12.11.1` dropped Node 20 prebuilds (EOL April 2026) and Node 20's bundled node-gyp cannot drive the Visual Studio 2026 on current runners.

- Matrix tests non-EOL Node versions: 22/24/26 (was 20/22/24)
- New `test_quickstart_postgres` job: three creates on one runner — two monorepo back-to-back (the compose-collision regression), from a path containing a space, with a dev-server smoke test (the #4931 regression)
- `test_package_managers` now covers yarn, and pnpm/yarn are deliberately unpinned so policy changes in new majors fail here instead of in user installs
- `timeout-minutes` on all jobs; step-level timeouts on the create steps
- Retry hardening in the smoke/dashboard test scripts (the two flake families that kept this workflow red)

## Verification

Full workflow run with all 14 jobs green: https://github.com/vendurehq/vendure/actions/runs/29086867800 — the first fully green run of this workflow since June 12.

Related: the storefront starter's missing `graphql` dependency (pnpm-only breakage) is tracked in vendurehq/nextjs-starter-vendure issue 38.

## Breaking changes

None.

Fixes #4932
Fixes #4931

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4946"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786273906&installation_id=128408429&pr_number=4946&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4946&signature=54d6adf511d5d802270d8bc33ac98ccf75eafbc2a5a7b6895108b3573759f2d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->