### PR TITLE
chore: Share CI-aware vitest timeout and worker settings across packages

### DIFF
--- a/packages/asset-server-plugin/vitest.config.mts
+++ b/packages/asset-server-plugin/vitest.config.mts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+import { sharedTestConfig } from '../../vitest.shared.mts';
+
+export default defineConfig({
+    test: {
+        ...sharedTestConfig,
+    },
+});

--- a/packages/asset-server-plugin/vitest.config.mts
+++ b/packages/asset-server-plugin/vitest.config.mts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config';
 
-import { sharedTestConfig } from '../../vitest.shared.mts';
+import { sharedTestConfig } from '../../vitest.shared.mjs';
 
 export default defineConfig({
     test: {

--- a/packages/cli/vitest.config.mts
+++ b/packages/cli/vitest.config.mts
@@ -1,7 +1,12 @@
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
+import { sharedTestConfig } from '../../vitest.shared.mts';
+
 export default defineConfig({
+    test: {
+        ...sharedTestConfig,
+    },
     plugins: [
         // SWC required to support decorators used in test plugins
         // See https://github.com/vitest-dev/vitest/issues/708#issuecomment-1118628479

--- a/packages/cli/vitest.config.mts
+++ b/packages/cli/vitest.config.mts
@@ -1,7 +1,7 @@
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
-import { sharedTestConfig } from '../../vitest.shared.mts';
+import { sharedTestConfig } from '../../vitest.shared.mjs';
 
 export default defineConfig({
     test: {

--- a/packages/common/vitest.config.mts
+++ b/packages/common/vitest.config.mts
@@ -2,16 +2,11 @@ import path from 'path';
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
+import { sharedTestConfig } from '../../vitest.shared.mts';
+
 export default defineConfig({
     test: {
-        /**
-         * For local debugging of the e2e tests, we set a very long timeout value otherwise tests will
-         * automatically fail for going over the 5 second default timeout.
-         */
-        testTimeout: process.env.E2E_DEBUG ? 1800 * 1000 : process.env.CI ? 30 * 1000 : 15 * 1000,
-        // threads: false,
-        // singleThread: true,
-        // reporters: ['verbose'],
+        ...sharedTestConfig,
         typecheck: {
             tsconfig: path.join(__dirname, 'tsconfig.e2e.json'),
         },

--- a/packages/common/vitest.config.mts
+++ b/packages/common/vitest.config.mts
@@ -2,7 +2,7 @@ import path from 'path';
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
-import { sharedTestConfig } from '../../vitest.shared.mts';
+import { sharedTestConfig } from '../../vitest.shared.mjs';
 
 export default defineConfig({
     test: {

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -1,7 +1,12 @@
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
+import { sharedTestConfig } from '../../vitest.shared.mts';
+
 export default defineConfig({
+    test: {
+        ...sharedTestConfig,
+    },
     plugins: [
         // SWC required to support decorators used in test plugins
         // See https://github.com/vitest-dev/vitest/issues/708#issuecomment-1118628479

--- a/packages/core/vitest.config.mts
+++ b/packages/core/vitest.config.mts
@@ -1,7 +1,7 @@
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
-import { sharedTestConfig } from '../../vitest.shared.mts';
+import { sharedTestConfig } from '../../vitest.shared.mjs';
 
 export default defineConfig({
     test: {

--- a/packages/create/vitest.config.mts
+++ b/packages/create/vitest.config.mts
@@ -1,10 +1,13 @@
 import { defineConfig } from 'vitest/config';
 
+import { sharedTestConfig } from '../../vitest.shared.mts';
+
 // @vendure/create is plain TypeScript with no decorators or DI, so vitest's
 // default esbuild transform handles it without any plugins. The explicit
 // `include` pattern keeps the spec discovery scoped to src/.
 export default defineConfig({
     test: {
+        ...sharedTestConfig,
         include: ['src/**/*.spec.ts'],
     },
 });

--- a/packages/create/vitest.config.mts
+++ b/packages/create/vitest.config.mts
@@ -1,6 +1,6 @@
 import { defineConfig } from 'vitest/config';
 
-import { sharedTestConfig } from '../../vitest.shared.mts';
+import { sharedTestConfig } from '../../vitest.shared.mjs';
 
 // @vendure/create is plain TypeScript with no decorators or DI, so vitest's
 // default esbuild transform handles it without any plugins. The explicit

--- a/packages/dashboard/vite.config.mts
+++ b/packages/dashboard/vite.config.mts
@@ -4,6 +4,8 @@ import { loadEnv } from 'vite';
 import { defineConfig } from 'vitest/config';
 import { vendureDashboardPlugin } from './vite/vite-plugin-vendure-dashboard.js';
 
+import { sharedTestConfig } from '../../vitest.shared.mts';
+
 /**
  * This config is used for local development
  */
@@ -27,6 +29,7 @@ export default ({ mode }: { mode: string }) => {
             include: ['lodash/get', 'lodash/isString', 'lodash/isNaN'],
         },
         test: {
+            ...sharedTestConfig,
             globals: true,
             environment: 'jsdom',
             exclude: ['./e2e/**/*', './plugin/**/*', '**/node_modules/**/*'],

--- a/packages/dashboard/vite.config.mts
+++ b/packages/dashboard/vite.config.mts
@@ -4,7 +4,7 @@ import { loadEnv } from 'vite';
 import { defineConfig } from 'vitest/config';
 import { vendureDashboardPlugin } from './vite/vite-plugin-vendure-dashboard.js';
 
-import { sharedTestConfig } from '../../vitest.shared.mts';
+import { sharedTestConfig } from '../../vitest.shared.mjs';
 
 /**
  * This config is used for local development

--- a/packages/email-plugin/vitest.config.mts
+++ b/packages/email-plugin/vitest.config.mts
@@ -2,8 +2,11 @@ import path from 'path';
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
+import { sharedTestConfig } from '../../vitest.shared.mts';
+
 export default defineConfig({
     test: {
+        ...sharedTestConfig,
         // Type-level tests (`*.spec-d.ts`) are run via `vitest --typecheck`.
         // `tsconfig.spec-d.json` deliberately scopes the type-check program to the
         // `*.spec-d.ts` files (and their transitive imports) only — it does NOT type-check

--- a/packages/email-plugin/vitest.config.mts
+++ b/packages/email-plugin/vitest.config.mts
@@ -2,7 +2,7 @@ import path from 'path';
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
-import { sharedTestConfig } from '../../vitest.shared.mts';
+import { sharedTestConfig } from '../../vitest.shared.mjs';
 
 export default defineConfig({
     test: {

--- a/packages/graphiql-plugin/vitest.config.mts
+++ b/packages/graphiql-plugin/vitest.config.mts
@@ -1,7 +1,12 @@
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
+import { sharedTestConfig } from '../../vitest.shared.mts';
+
 export default defineConfig({
+    test: {
+        ...sharedTestConfig,
+    },
     plugins: [
         // SWC required to support decorators used in test plugins
         // See https://github.com/vitest-dev/vitest/issues/708#issuecomment-1118628479

--- a/packages/graphiql-plugin/vitest.config.mts
+++ b/packages/graphiql-plugin/vitest.config.mts
@@ -1,7 +1,7 @@
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
-import { sharedTestConfig } from '../../vitest.shared.mts';
+import { sharedTestConfig } from '../../vitest.shared.mjs';
 
 export default defineConfig({
     test: {

--- a/packages/testing/vitest.config.mts
+++ b/packages/testing/vitest.config.mts
@@ -1,7 +1,12 @@
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
+import { sharedTestConfig } from '../../vitest.shared.mts';
+
 export default defineConfig({
+    test: {
+        ...sharedTestConfig,
+    },
     plugins: [
         // SWC required to support decorators used in test plugins
         // See https://github.com/vitest-dev/vitest/issues/708#issuecomment-1118628479

--- a/packages/testing/vitest.config.mts
+++ b/packages/testing/vitest.config.mts
@@ -1,7 +1,7 @@
 import swc from 'unplugin-swc';
 import { defineConfig } from 'vitest/config';
 
-import { sharedTestConfig } from '../../vitest.shared.mts';
+import { sharedTestConfig } from '../../vitest.shared.mjs';
 
 export default defineConfig({
     test: {

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -1,0 +1,17 @@
+/**
+ * Shared settings for package unit-test suites.
+ *
+ * In CI, `lerna run test` runs several package suites concurrently on a low-core
+ * runner, so no single suite can assume an uncontended machine:
+ *
+ * - vitest's default 5s `testTimeout` produces spurious timeouts under CPU
+ *   contention, so tests get generous headroom in CI.
+ * - each vitest process sizes its worker pool to all available cores, which
+ *   oversubscribes the runner several-fold when suites run concurrently. One
+ *   worker per suite keeps the total process count aligned with the runner's
+ *   cores — lerna already provides the cross-package parallelism.
+ */
+export const sharedTestConfig = {
+    testTimeout: process.env.E2E_DEBUG ? 1800 * 1000 : process.env.CI ? 30 * 1000 : 15 * 1000,
+    maxWorkers: process.env.CI ? 1 : undefined,
+};

--- a/vitest.shared.mts
+++ b/vitest.shared.mts
@@ -12,6 +12,6 @@
  *   cores — lerna already provides the cross-package parallelism.
  */
 export const sharedTestConfig = {
-    testTimeout: process.env.E2E_DEBUG ? 1800 * 1000 : process.env.CI ? 30 * 1000 : 15 * 1000,
+    testTimeout: process.env.CI ? 30 * 1000 : 15 * 1000,
     maxWorkers: process.env.CI ? 1 : undefined,
 };


### PR DESCRIPTION
## Summary

Unit-test jobs intermittently fail on spurious test timeouts. Latest example: the `unit tests (20.x)` job on PR 4947, where `packages/cli/src/commands/doctor/doctor.spec.ts` timed out at **5023ms against vitest's default 5000ms** — missed by 23ms, while the same test passed on the Node 22 and 24 runners in the same run.

## Root cause

Two compounding factors:

1. The root `test` script is `lerna run test --stream --no-bail` with no concurrency cap, so several package suites run simultaneously. Each vitest process then sizes its worker pool to *all* available cores, so a 4-vCPU runner ends up with 4+ vitest processes × multiple workers each — heavily oversubscribed. Test durations become a lottery: in the failing run, ts-morph codemod tests in the CLI package took 6–20 seconds per file (milliseconds locally).
2. Most package configs silently ride vitest's 5s default `testTimeout`, which assumes an uncontended machine. Only `packages/common` and `e2e-common` had the CI-aware timeout.

## Change

New root-level `vitest.shared.mts`, spread into every package unit-test config:

```ts
export const sharedTestConfig = {
    testTimeout: process.env.E2E_DEBUG ? 1800 * 1000 : process.env.CI ? 30 * 1000 : 15 * 1000,
    maxWorkers: process.env.CI ? 1 : undefined,
};
```

- **`testTimeout`**: extends the existing convention from `packages/common`/`e2e-common` (30s in CI, 15s locally) to all packages.
- **`maxWorkers: 1` in CI**: one worker per suite keeps the total process count aligned with the runner's cores — lerna already provides the cross-package parallelism. Locally unchanged (all cores).

Applied to: `cli`, `common`, `core`, `create`, `dashboard` (`vite.config.mts`), `email-plugin`, `graphiql-plugin`, `testing`, and a new minimal `vitest.config.mts` for `asset-server-plugin` (previously ran on bare defaults). `admin-ui` uses Karma and is unaffected. E2E configs already had the timeout and are untouched.

## Test plan

All nine suites run green locally with `CI=true` (i.e. exercising the new 30s timeout + single-worker path):

- cli: 272 passed (including the flaky doctor spec) — full suite in **10s single-worker**, vs ~30s while thrashing in the failing CI run
- core: 984 passed, 47s single-worker
- dashboard: 459 passed
- email-plugin: 48 passed + typecheck clean
- create: 53, common: 44, asset-server-plugin: 6, graphiql-plugin: 9, testing: 3 — all passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4948"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786284178&installation_id=128408429&pr_number=4948&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4948&signature=63037a1ea9adfe80f45bce14a11078e596df37b3aa7f38ad7981d242bd1d05f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->