### PR TITLE
chore(core): Fix flaky e2e search-index and scheduler tests

### DIFF
--- a/packages/core/e2e/default-scheduler-plugin.e2e-spec.ts
+++ b/packages/core/e2e/default-scheduler-plugin.e2e-spec.ts
@@ -8,6 +8,7 @@ import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-conf
 
 import { getTasksDocument, runTaskDocument, updateTaskDocument } from './graphql/shared-definitions';
 import { awaitRunningJobs } from './utils/await-running-jobs';
+import { pollUntil } from './utils/poll-until';
 
 // Mirrors DEFAULT_MAX_LOCK_HOLD_MS in default-scheduler-plugin/constants.ts.
 const MAX_HOLD_MS = 5_000;
@@ -113,7 +114,7 @@ describe('Default scheduler plugin', () => {
         const { runScheduledTask } = await adminClient.query(runTaskDocument, { id: 'test-job' });
         expect(runScheduledTask.success).toBe(true);
 
-        await new Promise(resolve => setTimeout(resolve, 100));
+        await pollUntil(() => taskSpy.mock.calls.length >= 1);
         expect(taskSpy).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/core/e2e/utils/await-running-jobs.ts
+++ b/packages/core/e2e/utils/await-running-jobs.ts
@@ -4,39 +4,69 @@ import { GetRunningJobsQuery, GetRunningJobsQueryVariables } from '../graphql/ge
 import { getRunningJobsDocument } from '../graphql/shared-definitions';
 
 /**
- * For mutation which trigger background jobs, this can be used to "pause" the execution of
- * the test until those jobs have completed;
+ * For mutations which trigger background jobs, this "pauses" the test until those jobs have
+ * completed.
+ *
+ * The jobs are not enqueued synchronously with the triggering mutation: the subscribers run
+ * after the transaction commits (via the EventBus), and some paths debounce by up to 50ms. So
+ * checking the queue once and stopping at the first empty result is unsafe — the job may simply
+ * not have been enqueued yet, and the assertion then runs against a stale index.
+ *
+ * Instead we wait until the queue has been continuously empty for a confirmation window; any
+ * in-flight job resets that window. The initial call counts as activity, so an empty queue must
+ * still stay empty for the full window before we trust it — this catches jobs that appear after
+ * we start polling. The window is sized above the search plugin's 50ms collection debounce and
+ * widened under CI load, where enqueue latency is highest.
  */
 export async function awaitRunningJobs(
     adminClient: SimpleGraphQLClient,
     timeout: number = 5000,
-    delay = 100,
+    confirmMs: number = defaultConfirmMs(),
+    pollMs = 50,
 ) {
-    let runningJobs = 0;
-    const startTime = +new Date();
-    let timedOut = false;
-    // Allow a brief period for the jobs to start in the case that
-    // e.g. event debouncing is used before triggering the job.
-    await new Promise(resolve => setTimeout(resolve, delay));
-    do {
-        const { jobs } = await adminClient.query<GetRunningJobsQuery, GetRunningJobsQueryVariables>(
-            getRunningJobsDocument,
-            {
-                options: {
-                    filter: {
-                        isSettled: {
-                            eq: false,
-                        },
-                    },
-                },
-            },
-        );
-        runningJobs = jobs.totalItems;
-        timedOut = timeout < +new Date() - startTime;
-    } while (runningJobs > 0 && !timedOut);
+    const startTime = Date.now();
+    // The last time we saw unsettled jobs. Seeded with the start time so that a queue which is
+    // already empty must remain empty for the whole confirmation window before we return.
+    let lastActivity = startTime;
 
-    if (runningJobs > 0) {
-        /* eslint-disable no-console */
-        console.log(`awaitRunningJobs time out with ${runningJobs} jobs still running`);
+    for (;;) {
+        const runningJobs = await queryRunningJobs(adminClient);
+        const now = Date.now();
+        if (runningJobs > 0) {
+            lastActivity = now;
+        } else if (now - lastActivity >= confirmMs) {
+            return;
+        }
+        if (now - startTime >= timeout) {
+            throw new Error(
+                `awaitRunningJobs timed out after ${timeout}ms with ${runningJobs} job(s) still running`,
+            );
+        }
+        await sleep(pollMs);
     }
+}
+
+/**
+ * The confirmation window must comfortably exceed the largest enqueue delay in the system (the
+ * search plugin buffers collection updates with a 50ms debounce) plus the event-emission latency,
+ * which grows under CI load. Overridable via `E2E_AWAIT_JOBS_CONFIRM_MS` for tuning and for
+ * exercising the race in tests (a value of 0 reproduces the historic flaky behaviour).
+ */
+function defaultConfirmMs(): number {
+    if (process.env.E2E_AWAIT_JOBS_CONFIRM_MS !== undefined) {
+        return +process.env.E2E_AWAIT_JOBS_CONFIRM_MS;
+    }
+    return process.env.CI ? 500 : 200;
+}
+
+async function queryRunningJobs(adminClient: SimpleGraphQLClient): Promise<number> {
+    const { jobs } = await adminClient.query<GetRunningJobsQuery, GetRunningJobsQueryVariables>(
+        getRunningJobsDocument,
+        { options: { filter: { isSettled: { eq: false } } } },
+    );
+    return jobs.totalItems;
+}
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
 }

--- a/packages/core/e2e/utils/poll-until.ts
+++ b/packages/core/e2e/utils/poll-until.ts
@@ -1,0 +1,23 @@
+/**
+ * Polls the given predicate until it returns true, or throws once the timeout elapses.
+ *
+ * Use this instead of a fixed `setTimeout` when waiting for asynchronous work whose completion
+ * time is not deterministic (e.g. a scheduled task firing). A fixed sleep either flakes when the
+ * work is slower than expected (CI load) or wastes time when it is faster; polling waits exactly
+ * as long as needed and fails loudly if the work never happens.
+ */
+export async function pollUntil(
+    predicate: () => boolean | Promise<boolean>,
+    { timeout = 5000, interval = 25 }: { timeout?: number; interval?: number } = {},
+): Promise<void> {
+    const startTime = Date.now();
+    for (;;) {
+        if (await predicate()) {
+            return;
+        }
+        if (Date.now() - startTime >= timeout) {
+            throw new Error(`pollUntil timed out after ${timeout}ms waiting for the predicate to pass`);
+        }
+        await new Promise(resolve => setTimeout(resolve, interval));
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the dominant class of flaky e2e failures on master CI, where a single DB/Node matrix cell would go red while the other 11 passed. Root cause: e2e tests assert against state produced by **asynchronous background jobs**, and the wait helpers guessed when that async work had *started* instead of confirming when it had *finished*.

## Root cause

The search-index and collection subscribers enqueue their reindex jobs **after** the triggering mutation's transaction commits (via the EventBus), and some paths debounce by up to 50ms. The old `awaitRunningJobs` slept a fixed 100ms "to let jobs start", then drained the queue. When enqueue latency exceeded that 100ms — CI load, or a slower DB engine — the first poll saw an empty queue, returned immediately, and the assertion ran against a **stale index**. On timeout it only `console.log`'d and continued, so a half-built index still reached the assertion. The scheduler test had the same shape: a hardcoded `setTimeout(100)` before asserting a spy was called.

## Changes

- **`awaitRunningJobs`** rewritten from a *leading-delay guess* to a *trailing-confirmation* wait: poll the unsettled-job count and only return once it has stayed empty for a confirmation window; any in-flight job resets the window, and the initial call counts as activity so a job enqueued after we start polling is still caught. Throws on timeout instead of continuing silently. Window defaults to 200ms locally / 500ms in CI, overridable via `E2E_AWAIT_JOBS_CONFIRM_MS`.
- **`pollUntil`** new shared e2e helper — poll a predicate until true or throw. Replaces fixed-sleep-then-assert patterns.
- **`default-scheduler-plugin.e2e-spec.ts`** — `setTimeout(100)` replaced with `pollUntil(() => taskSpy.mock.calls.length >= 1)`.

The signature stays backward compatible; existing callers need no changes.

## Verification

Reproduced the exact CI failures locally against mysql by forcing the window to 0 (`E2E_AWAIT_JOBS_CONFIRM_MS=0`), which yields the same stale-index assertion errors seen in CI. With the fix:

- `default-search-plugin` 5/5 runs green (103/103), `default-scheduler-plugin` 5/5 (6/6), `collection` 3/3 (77/77) — vs the old code failing 9–13 tests on **every** run at window=0.
- Regression-checked the other `awaitRunningJobs` callers (`error-handler-strategy`, `shop-catalog`) — green.
- CI-time cost is negligible (search suite 38s → ~41s).
- The `E2E_AWAIT_JOBS_CONFIRM_MS=0` knob keeps the race reproducible for future regression.

Relates to #4949

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4950"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786300345&installation_id=128408429&pr_number=4950&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4950&signature=e7aeb6d41af4e6e2556a37e07721e417450b0ae77202907e777ee135b6c909db"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->