### PR TITLE
fix(core): prevent ReDoS in SQLite regex filters using RE2

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -81,7 +81,7 @@
         "@ng-select/ng-select": "^14.2.6",
         "@ngx-translate/core": "^16.0.4",
         "@ngx-translate/http-loader": "^16.0.1",
-        "@vendure/common": "3.6.3",
+        "@vendure/common": "3.7.0",
         "@webcomponents/custom-elements": "^1.6.0",
         "apollo-angular": "^10.0.3",
         "apollo-upload-client": "^18.0.1",
@@ -157,9 +157,9 @@
       "devDependencies": {
         "@types/express": "^5.0.1",
         "@types/fs-extra": "^11.0.4",
-        "@vendure/admin-ui": "3.6.3",
-        "@vendure/common": "3.6.3",
-        "@vendure/core": "3.6.3",
+        "@vendure/admin-ui": "3.7.0",
+        "@vendure/common": "3.7.0",
+        "@vendure/core": "3.7.0",
         "express": "^5.1.0",
         "rimraf": "^5.0.5",
         "typescript": "5.8.2",
@@ -195,7 +195,7 @@
       },
       "dependencies": {
         "@clack/prompts": "^0.7.0",
-        "@vendure/common": "3.6.3",
+        "@vendure/common": "3.7.0",
         "change-case": "^4.1.2",
         "chokidar": "^3.6.0",
         "commander": "^11.0.0",
@@ -211,8 +211,8 @@
         "vite": "^7.3.1",
       },
       "devDependencies": {
-        "@vendure/core": "3.6.3",
-        "@vendure/testing": "3.6.3",
+        "@vendure/core": "3.7.0",
+        "@vendure/testing": "3.7.0",
         "cross-env": "^7.0.3",
       },
     },
@@ -289,6 +289,9 @@
         "sql.js": "1.13.0",
         "typescript": "5.8.2",
       },
+      "optionalDependencies": {
+        "re2": ">=1.21.0 <1.24.0",
+      },
       "peerDependencies": {
         "ioredis": "^5.3.2",
       },
@@ -304,7 +307,7 @@
       },
       "dependencies": {
         "@clack/prompts": "^0.11.0",
-        "@vendure/common": "3.6.4",
+        "@vendure/common": "3.7.0",
         "commander": "^14.0.1",
         "cross-spawn": "^7.0.6",
         "fs-extra": "^11.2.0",
@@ -319,7 +322,7 @@
         "@types/fs-extra": "^11.0.4",
         "@types/handlebars": "^4.1.0",
         "@types/semver": "^7.5.8",
-        "@vendure/core": "3.6.4",
+        "@vendure/core": "3.7.0",
         "rimraf": "^5.0.5",
         "ts-node": "^10.9.2",
         "typescript": "5.8.2",
@@ -406,8 +409,8 @@
         "@storybook/addon-vitest": "^10.3.1",
         "@storybook/react-vite": "^10.3.1",
         "@types/node": "^22.19.0",
-        "@vendure/common": "3.6.3",
-        "@vendure/core": "3.6.3",
+        "@vendure/common": "3.7.0",
+        "@vendure/core": "3.7.0",
         "@vitest/browser": "^3.2.4",
         "@vitest/coverage-v8": "^3.2.4",
         "eslint": "^9.39.0",
@@ -430,17 +433,17 @@
       "version": "3.7.0",
       "dependencies": {
         "@nestjs/axios": "^4.0.0",
-        "@vendure/admin-ui-plugin": "3.6.3",
-        "@vendure/asset-server-plugin": "3.6.3",
-        "@vendure/common": "3.6.3",
-        "@vendure/core": "3.6.3",
-        "@vendure/email-plugin": "3.6.3",
+        "@vendure/admin-ui-plugin": "3.7.0",
+        "@vendure/asset-server-plugin": "3.7.0",
+        "@vendure/common": "3.7.0",
+        "@vendure/core": "3.7.0",
+        "@vendure/email-plugin": "3.7.0",
       },
       "devDependencies": {
         "@typescript/native-preview": "7.0.0-dev.20260515.1",
-        "@vendure/cli": "3.6.3",
-        "@vendure/testing": "3.6.3",
-        "@vendure/ui-devkit": "3.6.3",
+        "@vendure/cli": "3.7.0",
+        "@vendure/testing": "3.7.0",
+        "@vendure/ui-devkit": "3.7.0",
         "commander": "^12.0.0",
         "concurrently": "^9.2.0",
         "csv-stringify": "^6.4.6",
@@ -468,8 +471,8 @@
         "@types/express": "^5.0.1",
         "@types/fs-extra": "^11.0.4",
         "@types/mjml": "^5.0.0",
-        "@vendure/common": "3.6.4",
-        "@vendure/core": "3.6.4",
+        "@vendure/common": "3.7.0",
+        "@vendure/core": "3.7.0",
         "rimraf": "^5.0.5",
         "typescript": "5.8.2",
       },
@@ -485,8 +488,8 @@
         "@types/express": "^5.0.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
-        "@vendure/common": "3.6.3",
-        "@vendure/core": "3.6.3",
+        "@vendure/common": "3.7.0",
+        "@vendure/core": "3.7.0",
         "@vitejs/plugin-react": "^5.0.4",
         "graphiql": "^4.0.2",
         "react": "^19.0.0",
@@ -503,8 +506,8 @@
         "graphql-query-complexity": "^0.12.0",
       },
       "devDependencies": {
-        "@vendure/common": "3.6.3",
-        "@vendure/core": "3.6.3",
+        "@vendure/common": "3.7.0",
+        "@vendure/core": "3.7.0",
       },
       "peerDependencies": {
         "@apollo/server": "^4.12.2",
@@ -514,8 +517,8 @@
       "name": "@vendure/job-queue-plugin",
       "version": "3.7.0",
       "devDependencies": {
-        "@vendure/common": "3.6.3",
-        "@vendure/core": "3.6.3",
+        "@vendure/common": "3.7.0",
+        "@vendure/core": "3.7.0",
         "bullmq": "^5.67.1",
         "ioredis": "5.9.3",
         "rimraf": "^5.0.5",
@@ -552,8 +555,8 @@
         "javascript-stringify": "^2.1.0",
       },
       "devDependencies": {
-        "@vendure/common": "3.6.3",
-        "@vendure/core": "3.6.3",
+        "@vendure/common": "3.7.0",
+        "@vendure/core": "3.7.0",
         "typescript": "5.8.2",
       },
     },
@@ -562,7 +565,7 @@
       "version": "3.7.0",
       "dependencies": {
         "@graphql-typed-document-node/core": "^3.2.0",
-        "@vendure/common": "3.6.3",
+        "@vendure/common": "3.7.0",
         "faker": "^4.1.0",
         "graphql": "^16.11.0",
         "graphql-tag": "^2.12.6",
@@ -574,7 +577,7 @@
         "@types/mime-types": "^3.0.1",
         "@types/mysql": "^2.15.26",
         "@types/pg": "^8.11.2",
-        "@vendure/core": "3.6.3",
+        "@vendure/core": "3.7.0",
         "mysql2": "^3.15.0",
         "pg": "^8.11.3",
         "rimraf": "^5.0.5",
@@ -589,8 +592,8 @@
         "@angular/cli": "^19.2.5",
         "@angular/compiler": "^19.2.4",
         "@angular/compiler-cli": "^19.2.4",
-        "@vendure/admin-ui": "3.6.3",
-        "@vendure/common": "3.6.3",
+        "@vendure/admin-ui": "3.7.0",
+        "@vendure/common": "3.7.0",
         "chalk": "^4.1.0",
         "chokidar": "^3.6.0",
         "fs-extra": "^11.2.0",
@@ -601,7 +604,7 @@
         "@rollup/plugin-node-resolve": "^15.2.3",
         "@rollup/plugin-terser": "^0.4.4",
         "@types/fs-extra": "^11.0.4",
-        "@vendure/core": "3.6.3",
+        "@vendure/core": "3.7.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "rimraf": "^5.0.5",
@@ -615,6 +618,7 @@
   "trustedDependencies": [
     "husky",
     "better-sqlite3",
+    "re2",
   ],
   "overrides": {
     "graphql": "^16.11.0",
@@ -3826,6 +3830,8 @@
 
     "inquirer": ["inquirer@12.9.6", "", { "dependencies": { "@inquirer/ansi": "^1.0.0", "@inquirer/core": "^10.2.2", "@inquirer/prompts": "^7.8.6", "@inquirer/type": "^3.0.8", "mute-stream": "^2.0.0", "run-async": "^4.0.5", "rxjs": "^7.8.2" }, "peerDependencies": { "@types/node": ">=18" } }, "sha512-603xXOgyfxhuis4nfnWaZrMaotNT0Km9XwwBNWUKbIDqeCY89jGr2F9YPEMiNhU6XjIP4VoWISMBFfcc5NgrTw=="],
 
+    "install-artifact-from-github": ["install-artifact-from-github@1.6.0", "", { "bin": { "install-from-cache": "bin/install-from-cache.js", "save-to-github-cache": "bin/save-to-github-cache.js" } }, "sha512-wKsuzN8fy8QK7iEUqyWTQmvZ1QFGPn1xyl3/1iIIDthDjS7Hn9HoPwHlNakZirWbCsbad0lZMkr6Xfbpe1pUzw=="],
+
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
 
     "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
@@ -4424,6 +4430,8 @@
 
     "named-placeholders": ["named-placeholders@1.1.6", "", { "dependencies": { "lru.min": "^1.1.0" } }, "sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w=="],
 
+    "nan": ["nan@2.28.0", "", {}, "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ=="],
+
     "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
 
     "napi-build-utils": ["napi-build-utils@2.0.0", "", {}, "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA=="],
@@ -4460,7 +4468,7 @@
 
     "node-forge": ["node-forge@1.3.3", "", {}, "sha512-rLvcdSyRCyouf6jcOIPe/BgwG/d7hKjzMKOas33/pHEr6gbq18IK9zV7DiPvzsz0oBJPme6qr6H6kGZuI9/DZg=="],
 
-    "node-gyp": ["node-gyp@11.5.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "make-fetch-happen": "^14.0.3", "nopt": "^8.0.0", "proc-log": "^5.0.0", "semver": "^7.3.5", "tar": "^7.4.3", "tinyglobby": "^0.2.12", "which": "^5.0.0" }, "bin": "bin/node-gyp.js" }, "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ=="],
+    "node-gyp": ["node-gyp@12.4.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "nopt": "^9.0.0", "proc-log": "^6.0.0", "semver": "^7.3.5", "tar": "^7.5.4", "tinyglobby": "^0.2.12", "undici": "^6.25.0", "which": "^6.0.0" }, "bin": { "node-gyp": "bin/node-gyp.js" } }, "sha512-OMcPNvqTCFUnNaBlmdgq+lfNqY7gTiSmNRDjY3uAXRyudeKZEZxu3CLtjMQrx4zZxCX2b/mpNqTtwuCJgXhHkw=="],
 
     "node-gyp-build": ["node-gyp-build@4.8.4", "", { "bin": { "node-gyp-build": "bin.js", "node-gyp-build-optional": "optional.js", "node-gyp-build-test": "build-test.js" } }, "sha512-LA4ZjwlnUblHVgq0oBF3Jl/6h/Nvs5fzBLwdEF4nuxnFdsfajde4WfxtJr3CaiH+F6ewcIB/q4jQ4UzPyid+CQ=="],
 
@@ -4889,6 +4897,8 @@
     "raw-body": ["raw-body@2.5.3", "", { "dependencies": { "bytes": "~3.1.2", "http-errors": "~2.0.1", "iconv-lite": "~0.4.24", "unpipe": "~1.0.0" } }, "sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA=="],
 
     "rc": ["rc@1.2.8", "", { "dependencies": { "deep-extend": "^0.6.0", "ini": "~1.3.0", "minimist": "^1.2.0", "strip-json-comments": "~2.0.1" }, "bin": "cli.js" }, "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw=="],
+
+    "re2": ["re2@1.23.3", "", { "dependencies": { "install-artifact-from-github": "^1.4.0", "nan": "^2.25.0", "node-gyp": "^12.2.0" } }, "sha512-5jh686rmj/8dYpBo72XYgwzgG8Y9HNDATYZ1x01gqZ6FvXVUP33VZ0+6GLCeavaNywz3OkXBU8iNX7LjiuisPg=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
@@ -6038,6 +6048,8 @@
 
     "@npmcli/run-script/@npmcli/node-gyp": ["@npmcli/node-gyp@5.0.0", "", {}, "sha512-uuG5HZFXLfyFKqg8QypsmgLQW7smiRjVc45bqD/ofZZcR/uxEjgQU8qDPv0s9TEeMUiAAU/GC5bR6++UdTirIQ=="],
 
+    "@npmcli/run-script/node-gyp": ["node-gyp@11.5.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "make-fetch-happen": "^14.0.3", "nopt": "^8.0.0", "proc-log": "^5.0.0", "semver": "^7.3.5", "tar": "^7.4.3", "tinyglobby": "^0.2.12", "which": "^5.0.0" }, "bin": "bin/node-gyp.js" }, "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ=="],
+
     "@npmcli/run-script/proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
 
     "@npmcli/run-script/which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
@@ -6710,13 +6722,15 @@
 
     "node-fetch/whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
-    "node-gyp/make-fetch-happen": ["make-fetch-happen@14.0.3", "", { "dependencies": { "@npmcli/agent": "^3.0.0", "cacache": "^19.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^4.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^5.0.0", "promise-retry": "^2.0.1", "ssri": "^12.0.0" } }, "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ=="],
+    "node-gyp/nopt": ["nopt@9.0.0", "", { "dependencies": { "abbrev": "^4.0.0" }, "bin": { "nopt": "bin/nopt.js" } }, "sha512-Zhq3a+yFKrYwSBluL4H9XP3m3y5uvQkB/09CwDruCiRmR/UJYnn9W4R48ry0uGC70aeTPKLynBtscP9efFFcPw=="],
 
-    "node-gyp/semver": ["semver@7.7.1", "", { "bin": "bin/semver.js" }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+    "node-gyp/proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
+
+    "node-gyp/tar": ["tar@7.5.19", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw=="],
 
     "node-gyp/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
-    "node-gyp/which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
+    "node-gyp/which": ["which@6.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-f+gEpIKMR9faW/JgAgPK1D7mekkFoqbmiwvNzuhsHetni20QSgzg9Vhn0g2JSJkkfehQnqdUAx7/e15qS1lPxg=="],
 
     "normalize-package-data/semver": ["semver@7.7.1", "", { "bin": "bin/semver.js" }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
 
@@ -7476,6 +7490,14 @@
 
     "@npmcli/promise-spawn/which/isexe": ["isexe@3.1.1", "", {}, "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="],
 
+    "@npmcli/run-script/node-gyp/make-fetch-happen": ["make-fetch-happen@14.0.3", "", { "dependencies": { "@npmcli/agent": "^3.0.0", "cacache": "^19.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^4.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^5.0.0", "promise-retry": "^2.0.1", "ssri": "^12.0.0" } }, "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ=="],
+
+    "@npmcli/run-script/node-gyp/proc-log": ["proc-log@5.0.0", "", {}, "sha512-Azwzvl90HaF0aCz1JrDdXQykFakSSNPaPoiZ9fm5qJIMHioDZEi7OAdRwSm6rSoPtY3Qutnm3L7ogmg3dc+wbQ=="],
+
+    "@npmcli/run-script/node-gyp/semver": ["semver@7.7.1", "", { "bin": "bin/semver.js" }, "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="],
+
+    "@npmcli/run-script/node-gyp/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
     "@npmcli/run-script/which/isexe": ["isexe@3.1.1", "", {}, "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="],
 
     "@nx/devkit/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
@@ -7912,11 +7934,7 @@
 
     "node-fetch/whatwg-url/webidl-conversions": ["webidl-conversions@3.0.1", "", {}, "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="],
 
-    "node-gyp/make-fetch-happen/@npmcli/agent": ["@npmcli/agent@3.0.0", "", { "dependencies": { "agent-base": "^7.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.1", "lru-cache": "^10.0.1", "socks-proxy-agent": "^8.0.3" } }, "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q=="],
-
-    "node-gyp/make-fetch-happen/cacache": ["cacache@19.0.1", "", { "dependencies": { "@npmcli/fs": "^4.0.0", "fs-minipass": "^3.0.0", "glob": "^10.2.2", "lru-cache": "^10.0.1", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^12.0.0", "tar": "^7.4.3", "unique-filename": "^4.0.0" } }, "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ=="],
-
-    "node-gyp/make-fetch-happen/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
+    "node-gyp/nopt/abbrev": ["abbrev@4.0.0", "", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
 
     "node-gyp/which/isexe": ["isexe@3.1.1", "", {}, "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="],
 
@@ -8350,6 +8368,8 @@
 
     "@angular/cli/pacote/@npmcli/promise-spawn/which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
 
+    "@angular/cli/pacote/@npmcli/run-script/node-gyp": ["node-gyp@11.5.0", "", { "dependencies": { "env-paths": "^2.2.0", "exponential-backoff": "^3.1.1", "graceful-fs": "^4.2.6", "make-fetch-happen": "^14.0.3", "nopt": "^8.0.0", "proc-log": "^5.0.0", "semver": "^7.3.5", "tar": "^7.4.3", "tinyglobby": "^0.2.12", "which": "^5.0.0" }, "bin": "bin/node-gyp.js" }, "sha512-ra7Kvlhxn5V9Slyus0ygMa2h+UqExPqUIkfk7Pc8QTLT956JLSy51uWFwHtIYy0vI8cB4BDhc/S03+880My/LQ=="],
+
     "@angular/cli/pacote/@npmcli/run-script/which": ["which@5.0.0", "", { "dependencies": { "isexe": "^3.1.1" }, "bin": { "node-which": "bin/which.js" } }, "sha512-JEdGzHwwkrbWoGOlIHqQ5gtprKGOenpDHpxE9zVR1bWbOtYRyPPHMe9FaP6x61CmNaTThSkb0DAJte5jD+DmzQ=="],
 
     "@angular/cli/pacote/cacache/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
@@ -8481,6 +8501,12 @@
     "@npmcli/metavuln-calculator/pacote/npm-pick-manifest/npm-normalize-package-bin": ["npm-normalize-package-bin@5.0.0", "", {}, "sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag=="],
 
     "@npmcli/package-json/glob/path-scurry/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
+
+    "@npmcli/run-script/node-gyp/make-fetch-happen/@npmcli/agent": ["@npmcli/agent@3.0.0", "", { "dependencies": { "agent-base": "^7.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.1", "lru-cache": "^10.0.1", "socks-proxy-agent": "^8.0.3" } }, "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q=="],
+
+    "@npmcli/run-script/node-gyp/make-fetch-happen/cacache": ["cacache@19.0.1", "", { "dependencies": { "@npmcli/fs": "^4.0.0", "fs-minipass": "^3.0.0", "glob": "^10.2.2", "lru-cache": "^10.0.1", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^12.0.0", "tar": "^7.4.3", "unique-filename": "^4.0.0" } }, "sha512-hdsUxulXCi5STId78vRVYEtDAjq99ICAUktLTeTYsLoTE6Z8dS0c8pWNCxwdrk9YfJeobDZc2Y186hD/5ZQgFQ=="],
+
+    "@npmcli/run-script/node-gyp/make-fetch-happen/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "@opentelemetry/instrumentation-runtime-node/@opentelemetry/instrumentation/import-in-the-middle/cjs-module-lexer": ["cjs-module-lexer@2.2.0", "", {}, "sha512-4bHTS2YuzUvtoLjdy+98ykbNB5jS0+07EvFNXerqZQJ89F7DI6ET7OQo/HJuW6K0aVsKA9hj9/RVb2kQVOrPDQ=="],
 
@@ -8626,14 +8652,6 @@
 
     "multer/type-is/mime-types/mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
-    "node-gyp/make-fetch-happen/@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "node-gyp/make-fetch-happen/cacache/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
-
-    "node-gyp/make-fetch-happen/cacache/p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
-
-    "node-gyp/make-fetch-happen/cacache/unique-filename": ["unique-filename@4.0.0", "", { "dependencies": { "unique-slug": "^5.0.0" } }, "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ=="],
-
     "npm-pick-manifest/npm-package-arg/hosted-git-info/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "npm-registry-fetch/npm-package-arg/hosted-git-info/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
@@ -8714,6 +8732,12 @@
 
     "@angular/cli/pacote/@npmcli/promise-spawn/which/isexe": ["isexe@3.1.1", "", {}, "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="],
 
+    "@angular/cli/pacote/@npmcli/run-script/node-gyp/make-fetch-happen": ["make-fetch-happen@14.0.3", "", { "dependencies": { "@npmcli/agent": "^3.0.0", "cacache": "^19.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^4.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^5.0.0", "promise-retry": "^2.0.1", "ssri": "^12.0.0" } }, "sha512-QMjGbFTP0blj97EeidG5hk/QhKQ3T4ICckQGLgz38QF7Vgbk6e6FTARN8KhKxyBbWn8R0HU+bnw8aSoFPD4qtQ=="],
+
+    "@angular/cli/pacote/@npmcli/run-script/node-gyp/tar": ["tar@7.5.2", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-7NyxrTE4Anh8km8iEy7o0QYPs+0JKBTj5ZaqHg6B39erLg0qYXN3BijtShwbsNSvQ+LN75+KV+C4QR/f6Gwnpg=="],
+
+    "@angular/cli/pacote/@npmcli/run-script/node-gyp/tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
     "@angular/cli/pacote/@npmcli/run-script/which/isexe": ["isexe@3.1.1", "", {}, "sha512-LpB/54B+/2J5hqQ7imZHfdU31OlgQqx7ZicVlkm9kzg9/w8GKLEcFfJl/t7DCEDueOyBAD6zCCwTO6Fzs0NoEQ=="],
 
     "@angular/cli/pacote/cacache/unique-filename/unique-slug": ["unique-slug@5.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg=="],
@@ -8783,6 +8807,14 @@
     "@lerna/create/rimraf/glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
     "@npmcli/metavuln-calculator/pacote/npm-package-arg/hosted-git-info/lru-cache": ["lru-cache@11.2.4", "", {}, "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg=="],
+
+    "@npmcli/run-script/node-gyp/make-fetch-happen/@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@npmcli/run-script/node-gyp/make-fetch-happen/cacache/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "@npmcli/run-script/node-gyp/make-fetch-happen/cacache/p-map": ["p-map@7.0.4", "", {}, "sha512-tkAQEw8ysMzmkhgw8k+1U/iPhWNhykKnSk4Rd5zLoPJCuJaGRPo6YposrZgaxHKzDHdDWWZvE/Sk7hsL2X/CpQ=="],
+
+    "@npmcli/run-script/node-gyp/make-fetch-happen/cacache/unique-filename": ["unique-filename@4.0.0", "", { "dependencies": { "unique-slug": "^5.0.0" } }, "sha512-XSnEewXmQ+veP7xX2dS5Q4yZAvO40cBN2MWkJ7D/6sW4Dg6wYBNwM1Vrnz1FhH5AdeLIlUXRI9e28z1YZi71NQ=="],
 
     "@tanstack/eslint-plugin-query/@typescript-eslint/utils/@typescript-eslint/scope-manager/@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@4.2.1", "", {}, "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ=="],
 
@@ -8862,8 +8894,6 @@
 
     "listr2/cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
-    "node-gyp/make-fetch-happen/cacache/unique-filename/unique-slug": ["unique-slug@5.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg=="],
-
     "posthtml-parser/htmlparser2/domutils/dom-serializer/entities": ["entities@2.2.0", "", {}, "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="],
 
     "read-pkg-up/find-up/locate-path/p-locate/p-limit": ["p-limit@4.0.0", "", { "dependencies": { "yocto-queue": "^1.0.0" } }, "sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ=="],
@@ -8883,6 +8913,10 @@
     "@angular/build/listr2/cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "@angular/cli/listr2/cli-truncate/string-width/strip-ansi/ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "@angular/cli/pacote/@npmcli/run-script/node-gyp/make-fetch-happen/@npmcli/agent": ["@npmcli/agent@3.0.0", "", { "dependencies": { "agent-base": "^7.1.0", "http-proxy-agent": "^7.0.0", "https-proxy-agent": "^7.0.1", "lru-cache": "^10.0.1", "socks-proxy-agent": "^8.0.3" } }, "sha512-S79NdEgDQd/NGCay6TCoVzXSj74skRZIKJcpJjC5lOq34SZzyI6MqtiiWoiVWoVrTcGjNeC4ipbh1VIHlpfF5Q=="],
+
+    "@angular/cli/pacote/@npmcli/run-script/node-gyp/make-fetch-happen/negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
     "@angular/cli/pacote/npm-packlist/ignore-walk/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
 
@@ -8927,6 +8961,8 @@
     "@lerna/create/conventional-changelog-core/read-pkg-up/find-up/locate-path/p-locate": ["p-locate@2.0.0", "", { "dependencies": { "p-limit": "^1.1.0" } }, "sha512-nQja7m7gSKuewoVRen45CtVfODR3crN3goVQ0DDZ9N3yHxgpkuBhZqsaiotSQRrADUrne346peY7kT3TSACykg=="],
 
     "@lerna/create/conventional-changelog-core/read-pkg-up/find-up/locate-path/path-exists": ["path-exists@3.0.0", "", {}, "sha512-bpC7GYwiDYQ4wYLe+FA8lhRjhQCMcQGuSgGGqDkg/QerRWw9CmGRT0iSOVRSZJ29NMLZgIzqaljJ63oaL4NIJQ=="],
+
+    "@npmcli/run-script/node-gyp/make-fetch-happen/cacache/unique-filename/unique-slug": ["unique-slug@5.0.0", "", { "dependencies": { "imurmurhash": "^0.1.4" } }, "sha512-9OdaqO5kwqR+1kVgHAhsp5vPNU0hnxRa26rBFNfNgM7M6pNtgzeBn3s/xbyCQL3dcjzOatcef6UUHpB/6MaETg=="],
 
     "babel-loader/find-cache-dir/pkg-dir/find-up/locate-path/p-locate": ["p-locate@6.0.0", "", { "dependencies": { "p-limit": "^4.0.0" } }, "sha512-wPrq66Llhl7/4AGC6I+cqxT07LhXvWL08LNXz1fENOw0Ap4sRZZ/gZpTTJ5jpurzzzfS2W/Ge9BY3LgLjCShcw=="],
 
@@ -8975,6 +9011,8 @@
     "read-pkg-up/find-up/locate-path/p-locate/p-limit/yocto-queue": ["yocto-queue@1.2.2", "", {}, "sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ=="],
 
     "shadcn/ts-morph/@ts-morph/common/minimatch/brace-expansion/balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "@angular/cli/pacote/@npmcli/run-script/node-gyp/make-fetch-happen/@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 
     "@angular/cli/pacote/sigstore/@sigstore/sign/make-fetch-happen/@npmcli/agent/lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
 

--- a/docs/docs/reference/typescript-api/data-access/list-query-builder.mdx
+++ b/docs/docs/reference/typescript-api/data-access/list-query-builder.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## ListQueryBuilder
 
-<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="207" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="208" packageName="@vendure/core" />
 
 This helper class is used when fetching entities the database from queries which return a [PaginatedList](/reference/typescript-api/common/paginated-list#paginatedlist) type.
 These queries all follow the same format:
@@ -107,7 +107,7 @@ to join that relation.
 </div>
 ## ExtendedListQueryOptions
 
-<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="48" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/list-query-builder/list-query-builder.ts" sourceLine="49" packageName="@vendure/core" />
 
 Options which can be passed to the ListQueryBuilder's `build()` method.
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1544,7 +1544,7 @@
                   "title": "ListQueryBuilder",
                   "slug": "list-query-builder",
                   "file": "docs/reference/typescript-api/data-access/list-query-builder.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-13T10:08:48Z"
                 },
                 {
                   "title": "TransactionalConnection",

--- a/package.json
+++ b/package.json
@@ -82,7 +82,8 @@
   },
   "trustedDependencies": [
     "husky",
-    "better-sqlite3"
+    "better-sqlite3",
+    "re2"
   ],
   "workspaces": [
     "packages/*"

--- a/packages/core/e2e/list-query-builder.e2e-spec.ts
+++ b/packages/core/e2e/list-query-builder.e2e-spec.ts
@@ -402,22 +402,28 @@ describe('ListQueryBuilder', () => {
             );
 
             // https://github.com/vendurehq/vendure/security/advisories/GHSA-jgm3-qmp2-c4p7
-            // An overlapping-alternation pattern that the star-height check does not reject: it is
-            // safe to evaluate (linear time under RE2 on SQLite backends) and must be accepted.
-            it('evaluates an overlapping-alternation pattern without error', async () => {
-                const { testEntities } = await adminClient.query(GET_LIST, {
-                    options: {
-                        filter: {
-                            description: {
-                                regex: '^(.|..)+$Z',
+            // An overlapping-alternation pattern that the star-height check does not reject. On
+            // SQLite backends it is evaluated by RE2 in linear time and must be accepted. Other
+            // database engines handle it their own way (e.g. MySQL's ICU aborts with a match-limit
+            // error), so this SQLite-focused assertion is scoped to the SQLite drivers.
+            const dbType = process.env.DB || 'sqljs';
+            it.skipIf(dbType !== 'sqljs' && dbType !== 'better-sqlite3')(
+                'evaluates an overlapping-alternation pattern without error',
+                async () => {
+                    const { testEntities } = await adminClient.query(GET_LIST, {
+                        options: {
+                            filter: {
+                                description: {
+                                    regex: '^(.|..)+$Z',
+                                },
                             },
                         },
-                    },
-                });
+                    });
 
-                // The trailing `Z` after `$` can never match, so no rows are returned.
-                expect(testEntities.items).toEqual([]);
-            });
+                    // The trailing `Z` after `$` can never match, so no rows are returned.
+                    expect(testEntities.items).toEqual([]);
+                },
+            );
         });
     });
 

--- a/packages/core/e2e/list-query-builder.e2e-spec.ts
+++ b/packages/core/e2e/list-query-builder.e2e-spec.ts
@@ -400,6 +400,24 @@ describe('ListQueryBuilder', () => {
                     'exceeds the maximum allowed length',
                 ),
             );
+
+            // https://github.com/vendurehq/vendure/security/advisories/GHSA-jgm3-qmp2-c4p7
+            // An overlapping-alternation pattern that the star-height check does not reject: it is
+            // safe to evaluate (linear time under RE2 on SQLite backends) and must be accepted.
+            it('evaluates an overlapping-alternation pattern without error', async () => {
+                const { testEntities } = await adminClient.query(GET_LIST, {
+                    options: {
+                        filter: {
+                            description: {
+                                regex: '^(.|..)+$Z',
+                            },
+                        },
+                    },
+                });
+
+                // The trailing `Z` after `$` can never match, so no rows are returned.
+                expect(testEntities.items).toEqual([]);
+            });
         });
     });
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -108,5 +108,8 @@
         "ioredis": {
             "optional": true
         }
+    },
+    "optionalDependencies": {
+        "re2": ">=1.21.0 <1.24.0"
     }
 }

--- a/packages/core/src/i18n/messages/en.json
+++ b/packages/core/src/i18n/messages/en.json
@@ -53,6 +53,7 @@
     "promotion-channels-can-only-be-changed-from-default-channel": "Promotions channels may only be changed from the Default Channel",
     "regex-filter-pattern-too-long": "The regex filter pattern exceeds the maximum allowed length of { max } characters",
     "regex-filter-pattern-unsafe": "The regex filter pattern is not allowed as it may cause excessive resource consumption",
+    "regex-filter-pattern-unsupported-syntax": "The regex filter pattern uses syntax that is not supported by the safe regex engine (such as lookaround or backreferences)",
     "stockonhand-cannot-be-negative": "stockOnHand cannot be a negative value",
     "superadmin-must-have-superadmin-role": "Cannot remove the SuperAdmin role from the sole SuperAdmin",
     "target-customer-not-assigned-to-order-channels": "The target Customer is not assigned to the same Channels as the Order. Missing channels IDs: { missingChannelIds }",

--- a/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
+++ b/packages/core/src/service/helpers/list-query-builder/list-query-builder.ts
@@ -31,6 +31,7 @@ import { getColumnMetadata, getEntityAlias } from './connection-utils';
 import { getCalculatedColumns } from './get-calculated-columns';
 import { parseFilterParams, WhereCondition, WhereGroup } from './parse-filter-params';
 import { parseSortParams } from './parse-sort-params';
+import { createSqliteRegexpFunction } from './sqlite-regexp-function';
 
 /**
  * Counter for generating unique aliases in EXISTS subqueries.
@@ -915,18 +916,17 @@ export class ListQueryBuilder implements OnApplicationBootstrap {
      * so that we can run regex filters on string fields.
      */
     private registerSQLiteRegexpFunction() {
-        const regexpFn = (pattern: string, value: string) => {
-            const result = new RegExp(`${pattern}`, 'i').test(value);
-            return result ? 1 : 0;
-        };
         const dbType = this.connection.rawConnection.options.type;
+        // Only the SQLite flavours evaluate regex filters via a JS function; other backends
+        // defer to the database's own engine, so the regexp function (and any re2 warning)
+        // must not be created for them.
         if (dbType === 'better-sqlite3') {
             const driver = this.connection.rawConnection.driver as BetterSqlite3Driver;
-            driver.databaseConnection.function('regexp', regexpFn);
+            driver.databaseConnection.function('regexp', createSqliteRegexpFunction());
         }
         if (dbType === 'sqljs') {
             const driver = this.connection.rawConnection.driver as SqljsDriver;
-            driver.databaseConnection.create_function('regexp', regexpFn);
+            driver.databaseConnection.create_function('regexp', createSqliteRegexpFunction());
         }
     }
 

--- a/packages/core/src/service/helpers/list-query-builder/parse-filter-params.ts
+++ b/packages/core/src/service/helpers/list-query-builder/parse-filter-params.ts
@@ -18,6 +18,7 @@ import { VendureEntity } from '../../../entity/base/base.entity';
 
 import { escapeCalculatedColumnExpression, getColumnMetadata } from './connection-utils';
 import { getCalculatedColumns } from './get-calculated-columns';
+import { assertRegexFilterEngineCompatible } from './sqlite-regexp-function';
 import { assertSafeRegexFilter } from './validate-regex-filter';
 
 export interface WhereGroup {
@@ -321,6 +322,7 @@ function buildWhereCondition(
         }
         case 'regex':
             assertSafeRegexFilter(operand);
+            assertRegexFilterEngineCompatible(operand, dbType);
             return {
                 clause: getRegexpClause(fieldName, argIndex, dbType),
                 parameters: { [`arg${argIndex}`]: operand },

--- a/packages/core/src/service/helpers/list-query-builder/sqlite-regexp-function.spec.ts
+++ b/packages/core/src/service/helpers/list-query-builder/sqlite-regexp-function.spec.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import { UserInputError } from '../../../common/error/errors';
+
+import {
+    assertRegexFilterEngineCompatible,
+    buildRegexpTester,
+    createSqliteRegexpFunction,
+} from './sqlite-regexp-function';
+
+// The RE2-specific behaviour can only be exercised when the optional `re2` dependency is
+// installed. When it is absent these assertions are skipped rather than failing the suite.
+type RegExpEngine = new (pattern: string, flags: string) => { test(value: string): boolean };
+const RE2: RegExpEngine | undefined = (() => {
+    try {
+        // eslint-disable-next-line @typescript-eslint/no-var-requires
+        return require('re2') as RegExpEngine;
+    } catch {
+        return undefined;
+    }
+})();
+
+// A pattern that is catastrophically slow under the backtracking RegExp engine but harmless
+// under RE2. See GHSA-jgm3-qmp2-c4p7. The trailing `Z` after `$` makes every match attempt
+// fail, forcing exhaustive backtracking over all 1-/2-char partitions of the input.
+const REDOS_PATTERN = '^(.|..)+$Z';
+
+describe('buildRegexpTester()', () => {
+    it('matches case-insensitively and returns 1/0', () => {
+        const test = buildRegexpTester(RegExp);
+        expect(test('foo', 'a FOO b')).toBe(1);
+        expect(test('^bar$', 'bar')).toBe(1);
+        expect(test('^bar$', 'bard')).toBe(0);
+    });
+
+    it('reuses a compiled pattern across calls', () => {
+        let compilations = 0;
+        class CountingRegExp {
+            private re: RegExp;
+            constructor(pattern: string, flags: string) {
+                compilations++;
+                this.re = new RegExp(pattern, flags);
+            }
+            test(value: string) {
+                return this.re.test(value);
+            }
+        }
+        const test = buildRegexpTester(CountingRegExp as any);
+        test('foo', 'foo');
+        test('foo', 'barfoo');
+        test('foo', 'nope');
+        expect(compilations).toBe(1);
+    });
+
+    it.skipIf(!RE2)('evaluates a ReDoS pattern in linear time under RE2', () => {
+        if (!RE2) {
+            return;
+        }
+        const test = buildRegexpTester(RE2);
+        const input = 'x'.repeat(60);
+        const start = process.hrtime.bigint();
+        const result = test(REDOS_PATTERN, input);
+        const elapsedMs = Number(process.hrtime.bigint() - start) / 1e6;
+        expect(result).toBe(0);
+        // RE2 completes in well under a millisecond; the backtracking engine takes many seconds.
+        expect(elapsedMs).toBeLessThan(1000);
+    });
+});
+
+describe('createSqliteRegexpFunction()', () => {
+    it('returns a working case-insensitive tester', () => {
+        const regexpFn = createSqliteRegexpFunction();
+        expect(regexpFn('widget', 'Blue Widget')).toBe(1);
+        expect(regexpFn('^exact$', 'exact')).toBe(1);
+        expect(regexpFn('^exact$', 'not exact')).toBe(0);
+    });
+});
+
+describe('assertRegexFilterEngineCompatible()', () => {
+    it('does nothing for non-SQLite backends', () => {
+        // Lookaround is unsupported by RE2 but fine for the Postgres engine, so it must not throw here.
+        expect(() => assertRegexFilterEngineCompatible('(?=.*foo)bar', 'postgres')).not.toThrow();
+        expect(() => assertRegexFilterEngineCompatible('(a)\\1', 'mysql')).not.toThrow();
+    });
+
+    it('allows normal patterns on SQLite backends', () => {
+        expect(() => assertRegexFilterEngineCompatible('^[a-z0-9-]+$', 'better-sqlite3')).not.toThrow();
+        expect(() => assertRegexFilterEngineCompatible('foo.*bar', 'sqljs')).not.toThrow();
+    });
+
+    it.skipIf(!RE2)('rejects RE2-incompatible syntax on SQLite backends', () => {
+        expect(() => assertRegexFilterEngineCompatible('(?=.*foo)bar', 'better-sqlite3')).toThrowError(
+            UserInputError,
+        );
+        expect(() => assertRegexFilterEngineCompatible('(a)\\1', 'sqljs')).toThrowError(UserInputError);
+    });
+});

--- a/packages/core/src/service/helpers/list-query-builder/sqlite-regexp-function.ts
+++ b/packages/core/src/service/helpers/list-query-builder/sqlite-regexp-function.ts
@@ -1,0 +1,107 @@
+import { DataSourceOptions } from 'typeorm';
+
+import { UserInputError } from '../../../common/error/errors';
+import { Logger } from '../../../config/logger/vendure-logger';
+
+const loggerCtx = 'ListQueryBuilder';
+
+/**
+ * A compiled regular expression able to test string values. Both the built-in `RegExp`
+ * and the RE2 engine satisfy this shape.
+ */
+interface CompiledRegExp {
+    test(value: string): boolean;
+}
+
+type RegExpEngine = new (pattern: string, flags: string) => CompiledRegExp;
+
+/**
+ * The SQLite driver flavours whose `regexp` implementation is a JS function evaluated on the
+ * Node.js event loop, and which are therefore exposed to ReDoS via the built-in `RegExp` engine.
+ */
+const SQLITE_REGEXP_DB_TYPES: Array<DataSourceOptions['type']> = ['better-sqlite3', 'sqljs'];
+
+// `undefined` = not yet attempted, `null` = re2 is not installed.
+let re2Engine: RegExpEngine | null | undefined;
+
+/**
+ * Lazily resolves the optional `re2` dependency. RE2 matches in guaranteed linear time and so
+ * cannot be driven into catastrophic backtracking, unlike the built-in backtracking `RegExp`.
+ */
+function loadRe2Engine(): RegExpEngine | null {
+    if (re2Engine === undefined) {
+        try {
+            // eslint-disable-next-line @typescript-eslint/no-var-requires
+            re2Engine = require('re2') as RegExpEngine;
+        } catch {
+            re2Engine = null;
+        }
+    }
+    return re2Engine;
+}
+
+/**
+ * Throws a {@link UserInputError} if a `regex` filter cannot be evaluated safely on the given
+ * database. On SQLite backends the pattern runs through the {@link https://github.com/google/re2 | RE2}
+ * engine, which does not support backtracking-only features such as lookaround and backreferences;
+ * these are rejected up-front with a clear error rather than failing mid-query.
+ *
+ * Has no effect when `re2` is not installed (the built-in engine, which supports those features,
+ * is used as a fallback) or on non-SQLite backends, where the pattern is evaluated by the database.
+ */
+export function assertRegexFilterEngineCompatible(pattern: string, dbType: DataSourceOptions['type']): void {
+    if (!SQLITE_REGEXP_DB_TYPES.includes(dbType)) {
+        return;
+    }
+    const Engine = loadRe2Engine();
+    if (!Engine) {
+        return;
+    }
+    try {
+        // eslint-disable-next-line no-new
+        new Engine(pattern, 'i');
+    } catch {
+        throw new UserInputError('error.regex-filter-pattern-unsupported-syntax');
+    }
+}
+
+/**
+ * Builds the memoised tester used by the SQLite `regexp` user-defined function. Patterns are
+ * compiled once per distinct value and cached, since a given query applies a single constant
+ * pattern across every row.
+ */
+export function buildRegexpTester(Engine: RegExpEngine): (pattern: string, value: string) => number {
+    const cache = new Map<string, CompiledRegExp>();
+    return (pattern: string, value: string): number => {
+        let compiled = cache.get(pattern);
+        if (!compiled) {
+            compiled = new Engine(pattern, 'i');
+            // Bound the cache: patterns are user-supplied, so cap unbounded growth.
+            if (cache.size >= 100) {
+                cache.clear();
+            }
+            cache.set(pattern, compiled);
+        }
+        return compiled.test(value) ? 1 : 0;
+    };
+}
+
+/**
+ * Creates the JS function registered as SQLite's `REGEXP` implementation. When the optional
+ * `re2` dependency is installed, patterns are evaluated by RE2 in guaranteed linear time and so
+ * cannot be exploited for ReDoS. Otherwise it falls back to the built-in `RegExp` engine — which
+ * is vulnerable to catastrophic backtracking on adversarial patterns — and warns once at startup.
+ */
+export function createSqliteRegexpFunction(): (pattern: string, value: string) => number {
+    const Engine = loadRe2Engine();
+    if (!Engine) {
+        Logger.warn(
+            'The optional "re2" package is not installed, so `regex` list filters fall back to the ' +
+                'built-in RegExp engine. On SQLite-based databases this evaluates untrusted patterns on ' +
+                'the Node.js event loop and is vulnerable to ReDoS. Install "re2" to evaluate regex ' +
+                'filters in guaranteed linear time.',
+            loggerCtx,
+        );
+    }
+    return buildRegexpTester(Engine ?? (RegExp as unknown as RegExpEngine));
+}

--- a/packages/core/src/service/helpers/list-query-builder/validate-regex-filter.ts
+++ b/packages/core/src/service/helpers/list-query-builder/validate-regex-filter.ts
@@ -12,15 +12,16 @@ export const MAX_REGEX_FILTER_LENGTH = 100;
  * catastrophic backtracking (ReDoS).
  *
  * The `regex` filter is exposed on the public Shop API and, on SQLite backends, is
- * evaluated by a synchronous JS user-defined function on the Node.js event loop. An
- * unvalidated pattern such as `(a+)+$` can therefore block the entire server. This
- * check is a conservative static analysis applied at the single parse-layer choke
- * point, so it protects all database backends regardless of how they evaluate the regex.
+ * evaluated by a synchronous JS user-defined function on the Node.js event loop, where an
+ * unvalidated pattern such as `(a+)+$` can block the entire server. This check is a cheap
+ * static analysis applied at the single parse-layer choke point, so it gives every database
+ * backend baseline protection regardless of how the regex is evaluated.
  *
- * It is a heuristic, not a proof: it reliably rejects exponential nested-quantifier
- * patterns (star height >= 2) but does not attempt to catch every pathological regex
- * (e.g. alternation-overlap such as `(a|a)+`). Combined with the length cap, it closes
- * the documented attack class while leaving legitimate filters untouched.
+ * It is a heuristic, not a proof: it reliably rejects exponential nested-quantifier patterns
+ * (star height >= 2) but does not attempt to catch every pathological regex (e.g.
+ * alternation-overlap such as `(a|a)+`). The definitive protection on the vulnerable SQLite
+ * path is the RE2 engine (see {@link createSqliteRegexpFunction}), which matches in linear
+ * time; this check remains as a light cross-backend guard and length cap.
  */
 export function assertSafeRegexFilter(pattern: string): void {
     if (pattern.length > MAX_REGEX_FILTER_LENGTH) {

--- a/packages/create/src/helpers.spec.ts
+++ b/packages/create/src/helpers.spec.ts
@@ -409,6 +409,7 @@ describe('getMonorepoRootPackageJson', () => {
             bcrypt: { built: true },
             'better-sqlite3': { built: true },
             esbuild: { built: true },
+            re2: { built: true },
             sharp: { built: true },
         });
         expect(
@@ -416,6 +417,19 @@ describe('getMonorepoRootPackageJson', () => {
         ).toBeUndefined();
         expect(
             getMonorepoRootPackageJson('x', getPackageManagerInfo('pnpm'), 'sqlite').dependenciesMeta,
+        ).toBeUndefined();
+    });
+
+    // bun blocks dependency lifecycle scripts unless listed in `trustedDependencies`.
+    it('adds trustedDependencies only for bun, driver-aware', () => {
+        expect(
+            getMonorepoRootPackageJson('x', getPackageManagerInfo('bun'), 'sqlite').trustedDependencies,
+        ).toEqual(['bcrypt', 'better-sqlite3', 'esbuild', 're2', 'sharp']);
+        expect(
+            getMonorepoRootPackageJson('x', getPackageManagerInfo('bun'), 'postgres').trustedDependencies,
+        ).toEqual(['bcrypt', 'esbuild', 'sharp']);
+        expect(
+            getMonorepoRootPackageJson('x', getPackageManagerInfo('yarn'), 'sqlite').trustedDependencies,
         ).toBeUndefined();
     });
 });
@@ -455,11 +469,12 @@ describe('getNativeBuildDependencies', () => {
         }
     });
 
-    it('adds better-sqlite3 for the SQLite driver', () => {
+    it('adds better-sqlite3 and re2 for the SQLite driver', () => {
         expect(getNativeBuildDependencies('sqlite')).toEqual([
             'bcrypt',
             'better-sqlite3',
             'esbuild',
+            're2',
             'sharp',
         ]);
     });
@@ -473,8 +488,10 @@ describe('getPnpmWorkspaceYaml', () => {
         const yaml = getPnpmWorkspaceYaml('sqlite');
         expect(yaml).toContain('onlyBuiltDependencies:');
         expect(yaml).toContain('    - better-sqlite3');
+        expect(yaml).toContain('    - re2');
         expect(yaml).toContain('allowBuilds:');
         expect(yaml).toContain('    better-sqlite3: true');
+        expect(yaml).toContain('    re2: true');
         expect(yaml).not.toContain('packages:');
     });
 
@@ -498,6 +515,7 @@ describe('getYarnDependenciesMeta', () => {
             bcrypt: { built: true },
             'better-sqlite3': { built: true },
             esbuild: { built: true },
+            re2: { built: true },
             sharp: { built: true },
         });
     });

--- a/packages/create/src/helpers.ts
+++ b/packages/create/src/helpers.ts
@@ -389,6 +389,9 @@ export function getMonorepoRootPackageJson(
     if (pmInfo.name === 'yarn') {
         pkg.dependenciesMeta = getYarnDependenciesMeta(dbType);
     }
+    if (pmInfo.name === 'bun') {
+        pkg.trustedDependencies = getNativeBuildDependencies(dbType);
+    }
     return pkg;
 }
 
@@ -409,16 +412,22 @@ export function getSingleProjectPackageJson(
     if (pmInfo.name === 'yarn') {
         pkg.dependenciesMeta = getYarnDependenciesMeta(dbType);
     }
+    if (pmInfo.name === 'bun') {
+        pkg.trustedDependencies = getNativeBuildDependencies(dbType);
+    }
     return pkg;
 }
 
 /**
  * Native dependencies whose install/build scripts must run for the scaffolded project to
  * work — otherwise e.g. better-sqlite3's native binding is never compiled and the server
- * crashes on startup. pnpm (v10+) and yarn (v4.14+) block dependency build scripts unless
- * allowlisted, so this list feeds their respective allowlist mechanisms.
+ * crashes on startup. pnpm (v10+), yarn (v4.14+) and bun block dependency build scripts
+ * unless allowlisted, so this list feeds their respective allowlist mechanisms
+ * (`onlyBuiltDependencies`, `dependenciesMeta.built`, `trustedDependencies`).
  * `bcrypt` (core), `sharp` (asset-server-plugin) and `esbuild` (vite) are always present;
- * SQLite adds `better-sqlite3`.
+ * SQLite adds `better-sqlite3` and `re2`. `re2` lets core evaluate `regex` list filters in
+ * guaranteed linear time; without its native binding those filters fall back to the built-in
+ * RegExp engine, which is vulnerable to ReDoS on SQLite backends (GHSA-jgm3-qmp2-c4p7).
  *
  * This list is derived from the scaffold's transitive native deps; re-check it against
  * `getDependencies()` whenever Vendure's direct native-dep surface changes.
@@ -426,7 +435,7 @@ export function getSingleProjectPackageJson(
 export function getNativeBuildDependencies(dbType: DbType): string[] {
     const deps = ['bcrypt', 'esbuild', 'sharp'];
     if (dbType === 'sqlite') {
-        deps.push('better-sqlite3');
+        deps.push('better-sqlite3', 're2');
     }
     return deps.sort((a, b) => a.localeCompare(b));
 }


### PR DESCRIPTION
## Summary

Closes an incomplete-mitigation bypass of the `StringOperators.regex` ReDoS hardening from GHSA-jgm3-qmp2-c4p7.

The 3.7.0 mitigation added a static check (length cap + star-height) that rejects nested-quantifier patterns like `(a+)+$`. It does **not** catch overlapping-alternation patterns such as `^(.|..)+$Z`, which are only 10 characters and star height 1, yet still cause catastrophic backtracking. On SQLite backends the `regex` filter is evaluated by a synchronous JS function on the Node.js event loop, so a single unauthenticated Shop API request with that pattern blocks the whole server for seconds (reproduced locally at ~12–16s against a 40-char field value).

Rather than keep extending a static heuristic that will always have another bypass, this changes the vulnerable execution path to an engine that **cannot** backtrack catastrophically.

## The fix

- On the SQLite/sqljs backends, the `regexp` user-defined function now evaluates patterns with the [RE2](https://github.com/google/re2) engine (`re2`), which matches in guaranteed linear time. The reported pattern goes from ~16s to ~0.1ms.
- `re2` is an **optional dependency** loaded only on the SQLite path. Postgres/MySQL deployments never install or load it — those backends already evaluate the pattern in the database engine (in the DB process, not the Node event loop), so they are outside the severe attack surface.
- If `re2` is not present, the function falls back to the built-in `RegExp` engine and logs a one-time warning at startup. The existing static check (length cap + star-height) is retained as a cheap cross-backend baseline.
- RE2 does not support backtracking-only syntax (lookaround, backreferences). On SQLite backends these are rejected up-front at parse time with a clear `UserInputError` rather than failing mid-query. On other backends they are unaffected.

## Distribution (`@vendure/create`)

`re2` is a native module, and — like `better-sqlite3`, which SQLite already requires — its build script is blocked by default on modern package managers (pnpm v10+, yarn v4.14+, bun; npm v12). `create` already writes the per-manager build-script allowlist for `better-sqlite3`; this adds `re2` to the same driver-aware list so a scaffolded SQLite app builds it out of the box.

This also fixes a pre-existing gap: `create` was not writing bun's `trustedDependencies` at all, so bun-scaffolded SQLite apps would not build `better-sqlite3` (or now `re2`) either. That is now wired up alongside the yarn/pnpm allowlists.

## Why target `minor`

- **Behaviour change:** regex filters using lookaround or backreferences are now rejected on SQLite backends (RE2 does not support them), and a new optional dependency is introduced. This is more than a pure bug fix.
- **Not high priority:** the event-loop-blocking DoS only affects SQLite/sqljs, which are generally development/demo backends rather than production. Postgres/MySQL production deployments are not exposed to the severe (event-loop) variant.

## Behavioural notes

- Common, safe filters are unaffected: `foo.*bar`, `.*widget.*`, slugs, alternations, quantifiers, and named groups all still work, on every backend.
- Existing SQLite apps that upgrade without adding `re2` to their package manager's build allowlist get the static check plus a startup warning until they add it — the same one-line step they already have for `better-sqlite3`.

## Testing

- Core unit suite: 995 passing (includes 7 new tests for the RE2 factory: linear-time evaluation of the bypass pattern, case-insensitive matching, memoisation, fallback, and RE2-incompatible-syntax rejection).
- `@vendure/create` suite: 54 passing (allowlist assertions extended for `re2` and bun `trustedDependencies`).
- `list-query-builder` e2e against real SQLite: 113 passing, including a new correctness test that the overlapping-alternation pattern is accepted and returns correctly.

Relates to GHSA-jgm3-qmp2-c4p7.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4956"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786529229&installation_id=128408429&pr_number=4956&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4956&signature=f50b935398d9be17ead0b6959719a1dec74d1f4779d5919a30ab2374eab1495f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->