### PR TITLE
fix(core): Guard mergeDeep against undefined array elements

### DIFF
--- a/packages/core/src/service/helpers/entity-hydrator/merge-deep.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/merge-deep.spec.ts
@@ -69,6 +69,40 @@ describe('mergeDeep()', () => {
         expect(merged[1].productVariant.facetValues?.[0].facet.code).toBe('weight');
     });
 
+    // https://github.com/vendurehq/vendure/issues/4955 (OSS-642)
+    // A target relation array can contain undefined holes (e.g. surcharges / payments /
+    // shippingLines after OrderPlacedEvent). The id-based reordering must not dereference
+    // those holes — otherwise mergeDeep throws `Cannot read properties of undefined`,
+    // crashing EntityHydrator.hydrate() and (via EmailPlugin loadData) silently dropping
+    // the order-confirmation email.
+    it('should not crash when the target array has an undefined leading element', () => {
+        const a = [undefined, { id: 2, name: 'B' }];
+        const b = [
+            { id: 1, name: 'A' },
+            { id: 2, name: 'B' },
+        ];
+
+        let merged: any;
+        expect(() => (merged = mergeDeep(a as any, b as any))).not.toThrow();
+        expect(merged[0].id).toBe(1);
+        expect(merged[1].id).toBe(2);
+    });
+
+    it('should not crash when the target array has an undefined element in the middle', () => {
+        const a = [{ id: 1, name: 'A' }, undefined, { id: 3, name: 'C' }];
+        const b = [
+            { id: 1, name: 'A' },
+            { id: 2, name: 'B' },
+            { id: 3, name: 'C' },
+        ];
+
+        let merged: any;
+        expect(() => (merged = mergeDeep(a as any, b as any))).not.toThrow();
+        expect(merged[0].id).toBe(1);
+        expect(merged[1].id).toBe(2);
+        expect(merged[2].id).toBe(3);
+    });
+
     it('should handle circular objects', () => {
         const first = {
             name: 'John',

--- a/packages/core/src/service/helpers/entity-hydrator/merge-deep.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/merge-deep.ts
@@ -33,7 +33,15 @@ export function mergeDeep<T extends { [key: string]: any }>(
     }
 
     if (Array.isArray(a) && Array.isArray(b) && a.length === b.length && a.length > 1) {
-        if (a[0].hasOwnProperty('id')) {
+        // Only attempt id-based reordering when both arrays are fully populated with
+        // entities. A relation array can legitimately contain `undefined` holes (e.g.
+        // surcharges/payments/shippingLines on an Order after OrderPlacedEvent); the
+        // reordering below dereferences every element (`.hasOwnProperty`, `.id`), so a
+        // hole would throw and crash EntityHydrator.hydrate() — silently dropping the
+        // order-confirmation email when hydrate() is called from an EmailPlugin loadData
+        // handler. When there are holes we skip reordering and fall through to the
+        // index-based merge below, which handles `undefined` entries safely. See #4955.
+        if (a.every(item => item != null) && b.every(item => item != null) && a[0].hasOwnProperty('id')) {
             // If the array contains entities, we can use the id to match them up
             // so that we ensure that we don't merge properties from different entities
             // with the same index.


### PR DESCRIPTION
## Summary

Fixes the `TypeError: Cannot read properties of undefined` crash in `mergeDeep` (used by `EntityHydrator.hydrate()`) when a target relation array contains `undefined` holes. When `hydrate()` is called from an `EmailPlugin` `loadData` handler (e.g. on `OrderPlacedEvent`), this crash makes **order-confirmation emails silently fail**.

## Root cause

`merge-deep.ts` reorders array elements by `id` to keep the target and hydrated arrays aligned. The branch dereferences every element — `a[0].hasOwnProperty('id')`, then `a.map(e => e.id)` and a sort on `_a.id` — but an `Order`'s relation arrays (`surcharges`, `payments`, `shippingLines`, …) can legitimately contain `undefined` entries. A hole makes those accesses throw:

- `a[0]` undefined → `Cannot read properties of undefined (reading 'hasOwnProperty')`
- a hole anywhere else → `Cannot read properties of undefined (reading 'id')` (in `a.map(e => e.id)`)

The `WeakSet` circular-reference guard added earlier does not cover this.

## Fix

Only attempt the id-based reordering when **both** arrays are fully populated (`a.every(x => x != null) && b.every(x => x != null)`). When there are holes we skip the reorder and fall through to the existing index-based merge, which already handles `undefined` entries safely (`mergeDeep(undefined, b)` returns `b`).

This guards a hole *anywhere* in the array, not just the leading element — the minimal `a[0] && …` guard would still crash on `a.map(e => e.id)` when the hole is in the middle (covered by a test below).

## Tests

`merge-deep.spec.ts` — two regression tests (leading `undefined`, and `undefined` in the middle). Both reproduce the exact `TypeError`s before the fix and pass after; the existing reorder/shared-instance/circular tests still pass (6/6 green).

Fixes #4955

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4961"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786611263&installation_id=128408429&pr_number=4961&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4961&signature=95c86ba4830cb2ebadc8221e14f945cd91ba43967ea5f42077f885538323417c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->