### PR TITLE
docs: Fix typo in CMS integration plugin guide

### DIFF
--- a/docs/docs/guides/how-to/cms-integration-plugin/index.mdx
+++ b/docs/docs/guides/how-to/cms-integration-plugin/index.mdx
@@ -10,7 +10,7 @@ This is done in a way that establishes Vendure as the source of truth for the ec
 
 This guide demonstrates how to build a production-ready CMS integration plugin. The principles covered here are designed to be CMS-agnostic, however we do have [working examples](/how-to/cms-integration-plugin/#platform-specific-setup) for various platforms.
 
-Platfroms covered in the [guide](/how-to/cms-integration-plugin/#platform-specific-setup):
+Platforms covered in the [guide](/how-to/cms-integration-plugin/#platform-specific-setup):
 
 - [Payload](https://payloadcms.com/)
 - [Sanity](https://www.sanity.io/)


### PR DESCRIPTION
Fixes a reported typo in the *Building a CMS Integration Plugin* guide: "Plat**fro**ms covered" → "Plat**for**ms covered".

Resolves OSS-443 (reported via docs feedback).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786614332&installation_id=128408429&pr_number=4963&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4963&signature=3cf4fef73c86035856072d39e25c8b5a0bdc7c14a49899fd219ee13483e664dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->