### PR TITLE
chore: Correct 2FA session-window assumption in stage approve script

### DIFF
--- a/scripts/npm-stage-approve-all.sh
+++ b/scripts/npm-stage-approve-all.sh
@@ -4,8 +4,14 @@
 #
 # After a GitHub release triggers publish_to_npm.yml, every published
 # package lands in npm's staging area. This script finds them and
-# approves them all behind a single 2FA prompt (the 5-min OTP-skip
-# window covers the rest).
+# approves them in sequence.
+#
+# Every approval needs its own 2FA challenge. Unlike `npm trust`, npm does
+# not grant `stage approve` a session window — staging exists to prove a
+# human is present for each artifact, so a window would defeat it. Register
+# a passkey as a security key on your npm account: the challenge opens in
+# the browser, making each approval a fingerprint tap rather than a typed
+# OTP code.
 #
 # Usage:
 #   ./scripts/npm-stage-approve-all.sh 3.7.0
@@ -156,8 +162,6 @@ for entry in "${pending[@]}"; do
     continue
   fi
   approved=$((approved + 1))
-  # Stay inside the 5-minute 2FA skip window without hammering the API.
-  sleep 2
 done
 
 echo


### PR DESCRIPTION
The header comment on `npm-stage-approve-all.sh` claimed that approving the first
staged package covers the rest via npm's ~5-minute OTP-skip window. That isn't
true, and the `sleep 2` in the approve loop existed to stay inside that
non-existent window.

### Why the window doesn't apply

`npm stage approve` and `npm trust` both route through the same `otplease` helper
in the npm CLI, so the difference isn't client-side — it's the registry
responding differently per endpoint. npm deliberately withholds the session
window from `stage approve`, because staged publishing exists to prove a human is
present for *each* artifact; a window covering everything staged in the next five
minutes would defeat the entire control. `npm trust` does get the window, so that
script's equivalent comment is accurate and is left alone.

The practical effect: every one of the ~15 packages issues its own 2FA challenge,
and no amount of waiting changes that.

### What this changes

- Corrects the header comment to describe the real behaviour, and records the
  reason so the next reader doesn't go hunting for the same dead end.
- Documents that registering a passkey as a security key on the npm account makes
  each approval a fingerprint tap instead of a typed OTP code. The approve
  challenge returns `authUrl`/`doneUrl`, so it opens in the browser, where a
  WebAuthn key is offered. This takes a full release approval from roughly
  fifteen minutes of typing codes down to about a minute of tapping — and
  WebAuthn is origin-bound and phishing-resistant, which TOTP is not.
- Drops the `sleep 2` from the approve loop. It was 30 seconds of dead time
  justified by the incorrect assumption; each approval already blocks on human
  interaction, which paces the calls naturally.

No behavioural change to what gets approved.

### Follow-up

The real fix is upstream: there is no bulk-approve UX, which is a genuine gap for
monorepos publishing many packages per release. A batched
`npm stage approve <id1> <id2> ...` under a single WebAuthn challenge signing over
a manifest of exactly those ids would preserve proof-of-presence while collapsing
fifteen ceremonies into one. Worth raising with npm separately.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786619822&installation_id=128408429&pr_number=4966&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4966&signature=b908d1d1af5296ed2ed01a32e28dcd842a82fe5fdd0df8fe9318087c1dfff3a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->