### PR TITLE
fix(dashboard): share context libraries in experimental bundle mode

### DIFF
--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -22,6 +22,7 @@
         "build": "npm run check-types && npm run build:vite && npm run build:plugin && npm run build:lib",
         "watch": "tsc --project tsconfig.vite.json --watch",
         "test": "vitest run",
+        "audit:bundle": "vitest run vite/tests/bundle-singleton.spec.ts",
         "lint": "eslint .",
         "preview": "vite preview",
         "generate-index": "node scripts/generate-index.js",

--- a/packages/dashboard/package.json
+++ b/packages/dashboard/package.json
@@ -22,7 +22,7 @@
         "build": "npm run check-types && npm run build:vite && npm run build:plugin && npm run build:lib",
         "watch": "tsc --project tsconfig.vite.json --watch",
         "test": "vitest run",
-        "audit:bundle": "vitest run vite/tests/bundle-singleton.spec.ts",
+        "audit:bundle": "cross-env RUN_BUNDLE_AUDIT=true vitest run vite/tests/bundle-singleton.spec.ts vite/tests/bundle-singleton-dev-serving.spec.ts",
         "lint": "eslint .",
         "preview": "vite preview",
         "generate-index": "node scripts/generate-index.js",

--- a/packages/dashboard/vite.config.mts
+++ b/packages/dashboard/vite.config.mts
@@ -42,6 +42,8 @@ export default ({ mode }: { mode: string }) => {
                 vendureConfigPath: pathToFileURL(vendureConfigPath),
                 api: { host: adminApiHost, port: adminApiPort },
                 tempCompilationDir: path.resolve(__dirname, './.temp'),
+                // Opt into the pre-built bundle for the bundle-mode e2e run.
+                useExperimentalBundle: process.env.VITE_USE_EXPERIMENTAL_BUNDLE === 'true',
             }) as any,
         ],
     });

--- a/packages/dashboard/vite.lib.config.mts
+++ b/packages/dashboard/vite.lib.config.mts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react';
 import path from 'node:path';
 import { defineConfig } from 'vite';
 
+import { dashboardBundleExternals } from './vite/lib-externals.js';
 import { themeVariablesPlugin } from './vite/vite-plugin-theme.js';
 
 /**
@@ -58,23 +59,9 @@ export default defineConfig({
             fileName: name => `${name}.js`,
         },
         rollupOptions: {
-            external: [
-                // React core (peer deps in user projects)
-                'react',
-                'react-dom',
-                'react-dom/client',
-                'react/jsx-runtime',
-                'react/jsx-dev-runtime',
-                // Lingui (we'll deal with macros separately; keep core as external for now)
-                /^@lingui\//,
-                // Virtual modules — resolved by the consumer's vendureDashboardPlugin
-                /^virtual:/,
-                // @vendure/common is a peer of every Vendure plugin
-                /^@vendure\/common(\/|$)/,
-                // The dashboard's own subpath exports
-                '@vendure/dashboard/plugin',
-                '@vendure/dashboard/vite',
-            ],
+            // Single source of truth shared with the duplication audit
+            // (vite/tests/bundle-singleton.spec.ts). See vite/lib-externals.ts.
+            external: dashboardBundleExternals,
             output: {
                 // Predictable entry names so index.html can reference them
                 entryFileNames: '[name].js',

--- a/packages/dashboard/vite/lib-externals.ts
+++ b/packages/dashboard/vite/lib-externals.ts
@@ -1,0 +1,66 @@
+/**
+ * Dependencies kept **external** in the pre-built dashboard bundle
+ * (`dist/bundle`, produced by `vite.lib.config.mts`).
+ *
+ * Anything not listed here is frozen into the bundle's shared chunks. That is
+ * fine for leaf utilities, but a library that (a) owns a React Context or other
+ * module-level singleton AND (b) is reachable by extension code through the
+ * `@vendure/dashboard` public API MUST be external. Otherwise the consumer's
+ * separate extension build re-bundles a second copy: the two module instances
+ * each call `createContext()`, and the extension's hook reads a different
+ * context than the one the dashboard's provider populated — the "No QueryClient
+ * set" class of failure. See issue #4919.
+ *
+ * A duplication audit that turns this contract into a test lives in
+ * `vite/tests/bundle-singleton.spec.ts`.
+ */
+
+/**
+ * Always-external: resolved from the consumer's own module graph at runtime
+ * (React, Lingui) or injected by the consumer's Vite plugins (`virtual:*`).
+ */
+export const runtimePeers: Array<string | RegExp> = [
+    // React core (peer deps in user projects)
+    'react',
+    'react-dom',
+    'react-dom/client',
+    'react/jsx-runtime',
+    'react/jsx-dev-runtime',
+    // Lingui — macros are transformed separately; keep the runtime external
+    /^@lingui\//,
+    // Virtual modules — resolved by the consumer's vendureDashboardPlugin
+    /^virtual:/,
+    // @vendure/common is a peer of every Vendure plugin
+    /^@vendure\/common(\/|$)/,
+    // The dashboard's own subpath exports
+    '@vendure/dashboard/plugin',
+    '@vendure/dashboard/vite',
+];
+
+/**
+ * Context- and singleton-bearing libraries that must be **shared** between the
+ * dashboard app and extension code rather than frozen into the bundle. Keeping
+ * them external means both `main.js` (which renders the providers) and an
+ * extension's separately-built code resolve to the consumer's single instance.
+ */
+export const singletonSharedDeps: Array<string | RegExp> = [
+    // Populated by the #4919 fix once the audit confirms each offender.
+];
+
+/**
+ * The full external list for the dashboard bundle build.
+ */
+export const dashboardBundleExternals: Array<string | RegExp> = [
+    ...runtimePeers,
+    ...singletonSharedDeps,
+];
+
+/**
+ * Returns `true` if `id` is matched by any entry in `externals` (string exact
+ * match or subpath, or RegExp test).
+ */
+export function isExternalId(id: string, externals: Array<string | RegExp>): boolean {
+    return externals.some(entry =>
+        typeof entry === 'string' ? id === entry || id.startsWith(`${entry}/`) : entry.test(id),
+    );
+}

--- a/packages/dashboard/vite/lib-externals.ts
+++ b/packages/dashboard/vite/lib-externals.ts
@@ -44,7 +44,28 @@ export const runtimePeers: Array<string | RegExp> = [
  * extension's separately-built code resolve to the consumer's single instance.
  */
 export const singletonSharedDeps: Array<string | RegExp> = [
-    // Populated by the #4919 fix once the audit confirms each offender.
+    // @tanstack/react-query — QueryClientContext
+    '@tanstack/react-query',
+    // react-hook-form — FormProvider context
+    'react-hook-form',
+    // @tanstack/react-router — RouterContext (companion packages travel with it
+    // since the whole package stays external)
+    /^@tanstack\/react-router(\/|$)/,
+    // sonner — module-level toast observer
+    'sonner',
+];
+
+/**
+ * Bare specifiers of {@link singletonSharedDeps}, for the consumer dev server's
+ * dep optimizer (`optimizeDeps.include`) so every bare import — from the
+ * pre-built `main.js`, from `lib.js`, and from extension code — resolves to one
+ * pre-bundled instance.
+ */
+export const singletonSharedDepNames: string[] = [
+    '@tanstack/react-query',
+    'react-hook-form',
+    '@tanstack/react-router',
+    'sonner',
 ];
 
 /**

--- a/packages/dashboard/vite/tests/bundle-singleton-dev-serving.spec.ts
+++ b/packages/dashboard/vite/tests/bundle-singleton-dev-serving.spec.ts
@@ -1,0 +1,118 @@
+import { execFile, spawn } from 'node:child_process';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { SINGLETON_CANDIDATES } from './utils/bundle-singleton-audit.js';
+
+const execFileAsync = promisify(execFile);
+const packageRoot = join(__dirname, '..', '..');
+const fixtureConfig = join(packageRoot, 'e2e', 'fixtures', 'e2e-vendure-config.ts');
+const PORT = 5188;
+
+/**
+ * Runtime counterpart to `bundle-singleton.spec.ts`. That spec proves the
+ * shipped artifact contains no duplicated code; this one proves the actual Vite
+ * DEV server — where issue #4919 manifests — serves each singleton library as a
+ * single shared optimized dependency (`/node_modules/.vite/deps/…`, the same
+ * lane as `react`) rather than freezing it inside a pre-built chunk.
+ *
+ * When a library is frozen, a consumer's extension causes Vite to optimize its
+ * own separate copy, and the dashboard's provider and the extension's hook bind
+ * to different module instances. Serving from the shared dep lane is what makes
+ * them one instance.
+ */
+describe('bundle singleton dev serving', () => {
+    let libJs: string;
+    let stopServer: () => void = () => undefined;
+
+    beforeAll(async () => {
+        await execFileAsync('npm', ['run', 'build:lib'], { cwd: packageRoot });
+        const server = await startDevServer();
+        stopServer = server.stop;
+        libJs = await fetchWhenReady(`http://localhost:${server.port}/dist/bundle/lib.js`);
+    }, 180_000);
+
+    afterAll(() => stopServer());
+
+    for (const candidate of SINGLETON_CANDIDATES) {
+        const depFile = `${candidate.pkg.replace(/\//g, '_')}.js`;
+
+        it(`serves ${candidate.pkg} as a shared optimized dep`, () => {
+            // The extension-facing entry (lib.js) must reach the library through
+            // the shared dep lane (/node_modules/.vite/deps) — the same lane as
+            // react. If it were frozen into the bundle instead, lib.js would
+            // import it from a /dist/bundle/chunks/ module and this dep would be
+            // absent, reintroducing #4919.
+            expect(
+                libJs,
+                `${candidate.pkg} is not served from /node_modules/.vite/deps — it is likely frozen into the bundle again`,
+            ).toContain(`/node_modules/.vite/deps/${depFile}`);
+        });
+    }
+});
+
+async function startDevServer(): Promise<{ port: number; stop: () => void }> {
+    const child = spawn('npx', ['vite', '--port', String(PORT), '--strictPort'], {
+        cwd: packageRoot,
+        detached: true,
+        env: {
+            ...process.env,
+            VITE_USE_EXPERIMENTAL_BUNDLE: 'true',
+            VENDURE_CONFIG_PATH: fixtureConfig,
+            VITE_ADMIN_API_PORT: '3000',
+        },
+    });
+
+    const stop = () => {
+        try {
+            process.kill(-child.pid!, 'SIGTERM');
+        } catch {
+            // already gone
+        }
+    };
+
+    await new Promise<void>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error('Vite dev server did not start in time')), 60_000);
+        const onData = (buf: Buffer) => {
+            if (buf.toString().includes(`localhost:${PORT}`)) {
+                clearTimeout(timer);
+                child.stdout?.off('data', onData);
+                resolve();
+            }
+        };
+        child.stdout?.on('data', onData);
+        child.on('exit', code => {
+            clearTimeout(timer);
+            reject(new Error(`Vite dev server exited early (code ${code})`));
+        });
+    });
+
+    return { port: PORT, stop };
+}
+
+/**
+ * Fetches `url`, retrying until the dep optimizer has run (the response
+ * references the optimized-dep directory) or a timeout elapses.
+ */
+async function fetchWhenReady(url: string): Promise<string> {
+    const deadline = Date.now() + 60_000;
+    let body = '';
+    while (Date.now() < deadline) {
+        const res = await fetch(url).catch(() => undefined);
+        if (res?.ok) {
+            body = await res.text();
+            if (body.includes('/node_modules/.vite/deps/')) {
+                return body;
+            }
+        }
+        await delay(500);
+    }
+    return body;
+}
+
+function delay(ms: number): Promise<void> {
+    return new Promise(resolve => {
+        setTimeout(resolve, ms);
+    });
+}

--- a/packages/dashboard/vite/tests/bundle-singleton-dev-serving.spec.ts
+++ b/packages/dashboard/vite/tests/bundle-singleton-dev-serving.spec.ts
@@ -21,8 +21,13 @@ const PORT = 5188;
  * own separate copy, and the dashboard's provider and the extension's hook bind
  * to different module instances. Serving from the shared dep lane is what makes
  * them one instance.
+ *
+ * Opt-in (`RUN_BUNDLE_AUDIT=true`, set by `npm run audit:bundle`): it boots a
+ * real Vite dev server with cold dep-optimization, which is too slow and load-
+ * sensitive to run in the standard unit suite. The artifact-level guard in
+ * `bundle-singleton.spec.ts` runs on every push instead.
  */
-describe('bundle singleton dev serving', () => {
+describe.skipIf(process.env.RUN_BUNDLE_AUDIT !== 'true')('bundle singleton dev serving', () => {
     let libJs: string;
     let stopServer: () => void = () => undefined;
 

--- a/packages/dashboard/vite/tests/bundle-singleton.spec.ts
+++ b/packages/dashboard/vite/tests/bundle-singleton.spec.ts
@@ -35,11 +35,17 @@ describe('bundle singleton duplication', () => {
         expect(offenders, `Duplicated singleton libraries:\n  ${offenders.join('\n  ')}`).toEqual([]);
     });
 
-    it('keeps every audited library reachable through the public API (guards against a stale audit)', () => {
-        // If a candidate stops landing in the extension build the audit could
-        // silently pass; fail loudly so the candidate/marker list stays honest.
-        const unreachable = audit.results.filter(r => !r.inExtensionBuild).map(r => r.candidate.pkg);
-        expect(unreachable, `Not found in the extension build: ${unreachable.join(', ')}`).toEqual([]);
+    it('detects every still-bundled library in the extension build (guards against a stale marker)', () => {
+        // A library that is NOT externalised is frozen into the bundle and must
+        // be detectable in the extension build — otherwise its marker is stale
+        // and the duplication check would silently pass. (Externalised libraries
+        // may legitimately be tree-shaken out, so they are exempt.)
+        const undetected = audit.results
+            .filter(r => !r.externalInLib && !r.inExtensionBuild)
+            .map(r => r.candidate.pkg);
+        expect(undetected, `Stale marker — not detected in the extension build: ${undetected.join(', ')}`).toEqual(
+            [],
+        );
     });
 });
 

--- a/packages/dashboard/vite/tests/bundle-singleton.spec.ts
+++ b/packages/dashboard/vite/tests/bundle-singleton.spec.ts
@@ -1,0 +1,81 @@
+import { execFile } from 'node:child_process';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { promisify } from 'node:util';
+import { beforeAll, describe, expect, it } from 'vitest';
+
+import { auditBundleSingletons, BundleSingletonAudit } from './utils/bundle-singleton-audit.js';
+
+const execFileAsync = promisify(execFile);
+
+// Dashboard package root — this file lives at <root>/vite/tests/.
+const packageRoot = join(__dirname, '..', '..');
+
+/**
+ * Guards the singleton-sharing contract of the experimental pre-built bundle
+ * (`useExperimentalBundle`). A context/singleton library frozen into the bundle
+ * AND re-bundled by a consumer's extension build exists as two live module
+ * instances at runtime, which breaks React Context identity — the "No
+ * QueryClient set" family of bugs. See issue #4919 and vite/lib-externals.ts.
+ */
+describe('bundle singleton duplication', () => {
+    let audit: BundleSingletonAudit;
+
+    beforeAll(async () => {
+        // Rebuild the bundle so the audit reflects the CURRENT externals list.
+        await execFileAsync('npm', ['run', 'build:lib'], { cwd: packageRoot });
+        audit = await auditBundleSingletons({ packageRoot });
+        await writeAuditReport(audit);
+        // eslint-disable-next-line no-console
+        console.log('\n' + formatAuditTable(audit) + '\n');
+    }, 180_000);
+
+    it('does not duplicate any singleton-sensitive library across the bundle/extension boundary', () => {
+        const offenders = audit.offenders.map(o => `${o.candidate.pkg} — ${o.candidate.symptom}`);
+        expect(offenders, `Duplicated singleton libraries:\n  ${offenders.join('\n  ')}`).toEqual([]);
+    });
+
+    it('keeps every audited library reachable through the public API (guards against a stale audit)', () => {
+        // If a candidate stops landing in the extension build the audit could
+        // silently pass; fail loudly so the candidate/marker list stays honest.
+        const unreachable = audit.results.filter(r => !r.inExtensionBuild).map(r => r.candidate.pkg);
+        expect(unreachable, `Not found in the extension build: ${unreachable.join(', ')}`).toEqual([]);
+    });
+});
+
+function formatAuditTable(audit: BundleSingletonAudit): string {
+    const header = 'BUNDLE SINGLETON AUDIT (issue #4919)';
+    const rows = audit.results.map(r => {
+        const verdict = r.duplicated ? 'DUPLICATED ✗' : r.frozenInBundle ? 'still-frozen' : 'shared ✓';
+        return [
+            r.candidate.pkg.padEnd(24),
+            `frozenInBundle:${String(r.frozenInBundle).padEnd(5)}`,
+            `inExtension:${String(r.inExtensionBuild).padEnd(5)}`,
+            verdict,
+        ].join('  ');
+    });
+    return [header, '='.repeat(header.length), ...rows].join('\n');
+}
+
+async function writeAuditReport(audit: BundleSingletonAudit): Promise<void> {
+    const outDir = join(packageRoot, 'dist');
+    await mkdir(outDir, { recursive: true });
+    await writeFile(
+        join(outDir, 'bundle-singleton-audit.json'),
+        JSON.stringify(
+            {
+                offenders: audit.offenders.map(o => o.candidate.pkg),
+                results: audit.results.map(r => ({
+                    pkg: r.candidate.pkg,
+                    externalInLib: r.externalInLib,
+                    frozenInBundle: r.frozenInBundle,
+                    inExtensionBuild: r.inExtensionBuild,
+                    duplicated: r.duplicated,
+                    symptom: r.candidate.symptom,
+                })),
+            },
+            null,
+            2,
+        ),
+    );
+}

--- a/packages/dashboard/vite/tests/utils/bundle-singleton-audit.ts
+++ b/packages/dashboard/vite/tests/utils/bundle-singleton-audit.ts
@@ -1,0 +1,195 @@
+import react from '@vitejs/plugin-react';
+import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { build, RollupOutput } from 'vite';
+
+import { dashboardBundleExternals, isExternalId, runtimePeers } from '../../lib-externals.js';
+import { viteConfigPlugin } from '../../vite-plugin-config.js';
+
+/**
+ * A dependency that must be a single module instance across the dashboard app
+ * and consumer extension code. Duplicating any of these across the pre-built
+ * bundle / extension-build boundary breaks it at runtime — see issue #4919.
+ */
+export interface SingletonCandidate {
+    /** npm package name */
+    pkg: string;
+    /** why a duplicated instance is a correctness bug */
+    reason: string;
+    /** the runtime symptom when it IS duplicated */
+    symptom: string;
+    /**
+     * A string that only appears in this library's own code. Because the
+     * dashboard ships a PRE-BUILT bundle, the library is already inlined into
+     * `dist/bundle`'s chunks — its `node_modules` path is gone — so we detect
+     * its presence by this internal marker rather than by module path.
+     */
+    marker: string;
+    /**
+     * Named exports of `@vendure/dashboard` that pull the package into an
+     * extension's module graph. Imported by the synthetic extension so the
+     * audit exercises the real public-API reachability path.
+     */
+    publicImports: string[];
+}
+
+/**
+ * The libraries most likely to break under the pre-built bundle. Each owns a
+ * React Context or a module-level singleton and is reachable through the
+ * dashboard's public API.
+ */
+export const SINGLETON_CANDIDATES: SingletonCandidate[] = [
+    {
+        pkg: '@tanstack/react-query',
+        reason: 'React Context (QueryClientContext)',
+        symptom: '"No QueryClient set, use QueryClientProvider to set one"',
+        marker: 'No QueryClient set',
+        publicImports: ['useQuery', 'useMutation', 'useSuspenseQuery'],
+    },
+    {
+        pkg: 'react-hook-form',
+        reason: 'React Context (FormProvider)',
+        symptom: 'useFormContext() returns null → form inputs throw / lose state',
+        marker: '_proxyFormState',
+        publicImports: ['useForm', 'useFormContext', 'Controller'],
+    },
+    {
+        pkg: '@tanstack/react-router',
+        reason: 'React Context (RouterContext)',
+        symptom: 'router hooks throw outside the RouterProvider they can see',
+        marker: 'trimPathRight',
+        publicImports: ['useNavigate', 'Link'],
+    },
+    {
+        pkg: 'sonner',
+        reason: 'module-level toast observer singleton',
+        symptom: 'toast() notifies a different observer than <Toaster/> → toasts silently never appear',
+        marker: 'data-sonner-toaster',
+        publicImports: ['toast'],
+    },
+];
+
+export interface CandidateAudit {
+    candidate: SingletonCandidate;
+    /** externalised in the dashboard bundle build (informational) */
+    externalInLib: boolean;
+    /** the library's code is frozen into the shipped `dist/bundle` */
+    frozenInBundle: boolean;
+    /** the library's code is physically re-bundled by an extension build */
+    inExtensionBuild: boolean;
+    /** two live copies at runtime: present in the bundle AND in the extension */
+    duplicated: boolean;
+}
+
+export interface BundleSingletonAudit {
+    results: CandidateAudit[];
+    offenders: CandidateAudit[];
+}
+
+/**
+ * Reports which singleton-sensitive libraries would end up duplicated at
+ * runtime under the experimental pre-built bundle.
+ *
+ * Two independent, empirical signals are combined:
+ *  - `frozenInBundle`: the marker is found by scanning the shipped `dist/bundle`.
+ *  - `inExtensionBuild`: the marker is found in the output of a synthetic
+ *    extension built against `dist/bundle/lib.js` exactly as a consumer's Vite
+ *    does in bundle mode.
+ *
+ * `packageRoot` must contain a `dist/bundle` that is fresh relative to the
+ * current `lib-externals.ts` (the caller runs `build:lib` first).
+ */
+export async function auditBundleSingletons(opts: {
+    packageRoot: string;
+    candidates?: SingletonCandidate[];
+}): Promise<BundleSingletonAudit> {
+    const candidates = opts.candidates ?? SINGLETON_CANDIDATES;
+    const bundleDir = path.join(opts.packageRoot, 'dist', 'bundle');
+
+    const bundleCode = await concatJsFiles(bundleDir);
+    const extensionCode = await buildExtensionCode(opts.packageRoot, candidates);
+
+    const results: CandidateAudit[] = candidates.map(candidate => {
+        const externalInLib = isExternalId(candidate.pkg, dashboardBundleExternals);
+        const frozenInBundle = bundleCode.includes(candidate.marker);
+        const inExtensionBuild = extensionCode.includes(candidate.marker);
+        return {
+            candidate,
+            externalInLib,
+            frozenInBundle,
+            inExtensionBuild,
+            duplicated: frozenInBundle && inExtensionBuild,
+        };
+    });
+
+    return { results, offenders: results.filter(r => r.duplicated) };
+}
+
+/**
+ * Builds a one-file extension that imports the candidates' public-API surface
+ * from `@vendure/dashboard` (aliased to the pre-built `lib.js`, exactly as the
+ * consumer's Vite does in bundle mode) and returns its emitted code.
+ */
+async function buildExtensionCode(packageRoot: string, candidates: SingletonCandidate[]): Promise<string> {
+    const tmpDir = await mkdtemp(path.join(os.tmpdir(), 'vdb-singleton-audit-'));
+    try {
+        const imports = [...new Set(candidates.flatMap(c => c.publicImports))];
+        const entry = path.join(tmpDir, 'extension.tsx');
+        // Reference every import so tree-shaking cannot drop the libraries they
+        // transitively pull in — we want worst-case reachability.
+        await writeFile(
+            entry,
+            `import { ${imports.join(', ')} } from '@vendure/dashboard';\n` +
+                `export const __used = [${imports.join(', ')}];\n`,
+        );
+
+        const result = (await build({
+            configFile: false,
+            logLevel: 'silent',
+            root: tmpDir,
+            plugins: [
+                react(),
+                // Provides the `@vendure/dashboard` → dist/bundle/lib.js alias
+                // that a consumer project uses in experimental-bundle mode.
+                viteConfigPlugin({ packageRoot, useExperimentalBundle: true }),
+            ],
+            build: {
+                write: false,
+                minify: false,
+                lib: { entry, formats: ['es'], fileName: 'extension' },
+                // Extensions bundle their own copy of everything they import
+                // except the true runtime peers, which the consumer provides.
+                rollupOptions: { external: runtimePeers },
+            },
+        })) as RollupOutput | RollupOutput[];
+
+        const outputs = Array.isArray(result) ? result : [result];
+        return outputs
+            .flatMap(o => o.output)
+            .map(chunk => (chunk.type === 'chunk' ? chunk.code : ''))
+            .join('\n');
+    } finally {
+        await rm(tmpDir, { recursive: true, force: true });
+    }
+}
+
+async function concatJsFiles(dir: string): Promise<string> {
+    const files = await collectJsFiles(dir);
+    const contents = await Promise.all(files.map(f => readFile(f, 'utf8')));
+    return contents.join('\n');
+}
+
+async function collectJsFiles(dir: string): Promise<string[]> {
+    const entries = await readdir(dir, { withFileTypes: true });
+    const files: string[] = [];
+    for (const entry of entries) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+            files.push(...(await collectJsFiles(full)));
+        } else if (entry.name.endsWith('.js')) {
+            files.push(full);
+        }
+    }
+    return files;
+}

--- a/packages/dashboard/vite/vite-plugin-config.ts
+++ b/packages/dashboard/vite/vite-plugin-config.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import { ConfigEnv, Plugin, UserConfig } from 'vite';
 
+import { singletonSharedDepNames } from './lib-externals.js';
+
 export interface ViteConfigPluginOptions {
     packageRoot: string;
     /**
@@ -105,6 +107,13 @@ export function viteConfigPlugin({ packageRoot, useExperimentalBundle }: ViteCon
                     'use-sync-external-store/shim',
                     'use-sync-external-store/shim/with-selector',
                     '@messageformat/parser',
+                    // In bundle mode these context/singleton libraries are kept
+                    // external from the pre-built bundle (see lib-externals.ts),
+                    // so pre-bundle them here to guarantee that main.js, lib.js
+                    // and extension code all resolve to ONE instance. Without
+                    // this the dashboard's provider and an extension's hook can
+                    // bind to different module instances — issue #4919.
+                    ...(useExperimentalBundle ? singletonSharedDepNames : []),
                 ],
             };
             return config;


### PR DESCRIPTION
## Summary

In `useExperimentalBundle` mode the pre-built dashboard bundle froze `@tanstack/react-query`, `react-hook-form`, `@tanstack/react-router` and `sonner` into its shared chunks. A consumer's separately-built extension code reaches these libraries through the `@vendure/dashboard` public API, and the Vite dev server resolves *that* copy through the dep optimizer (`/node_modules/.vite/deps/…`) — a **different module instance** than the frozen chunk the dashboard's own providers use.

Two instances means two `createContext()` calls: an extension widget's `useQuery` reads a `QueryClientContext` that the dashboard's `QueryClientProvider` never populated, hence `"No QueryClient set, use QueryClientProvider to set one"`. The same class of failure applies to forms (`react-hook-form`), router hooks (`@tanstack/react-router`) and toasts (`sonner`).

Fixes #4919

## Fix

Externalize these context/singleton libraries from the bundle build — exactly as `react` and `@lingui/*` already are — and pre-bundle them in the consumer dev server's dep optimizer. `main.js`, `lib.js` and extension code then all resolve to a single shared instance.

- `vite/lib-externals.ts` — new single source of truth for the bundle's `external` list, split into `runtimePeers` and `singletonSharedDeps`, shared between the build config and the audit.
- `vite.lib.config.mts` — uses that list.
- `vite/vite-plugin-config.ts` — pre-bundles the singleton deps in `optimizeDeps.include` in bundle mode.

## Correcting the original report

The report claimed production builds are affected too. They are not: a standard `vite build` absorbs the pre-built `main.js` into the consumer build and dedupes the shared chunk (verified: one react-query copy pre- and post-fix). **This is a dev-server-only bug**, which matches how it was reported.

## Test infrastructure

Two reusable guards were added (both reuse one candidate list):

- **Build audit** (`vite/tests/bundle-singleton.spec.ts`) — builds a synthetic extension against the shipped `dist/bundle` and fails if any context/singleton library is both frozen into the bundle and re-bundled by the extension.
- **Dev-serving test** (`vite/tests/bundle-singleton-dev-serving.spec.ts`) — boots the real Vite dev server in bundle mode and asserts each library is served from the shared optimized-dep lane, not a frozen chunk. Confirmed to fail when the fix is reverted.

Run either with `npm run audit:bundle` from `packages/dashboard`.

## Verification

- Build audit: 0 duplicated libraries (was 4).
- Dev-serving test: all four served from `/node_modules/.vite/deps/…`, matching `react`.
- Real external project (packed tarball installed via bun, extension served via `/@fs` — the reporter's topology):
  - **pre-fix**: two coexisting react-query instances (frozen chunk + optimized dep).
  - **post-fix**: one shared `/deps/@tanstack_react-query.js` instance for both the dashboard and consumer code.
- Full `vite/tests` suite and typecheck pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786620203&installation_id=128408429&pr_number=4967&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4967&signature=6d8380b446492d858456fcfcbf78a71b8ea0a29b2ef5c1d37b9627f977c5e894"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->