### PR TITLE
fix: resolve SonarCloud reliability issues in maintained packages

### DIFF
--- a/packages/admin-ui/src/lib/core/src/shared/components/dropdown/dropdown-menu.component.ts
+++ b/packages/admin-ui/src/lib/core/src/shared/components/dropdown/dropdown-menu.component.ts
@@ -71,7 +71,7 @@ export class DropdownMenuComponent implements AfterViewInit, OnInit, OnDestroy {
         for (const entry of entries) {
             const contentWrapper = entry.target.querySelector('.dropdown-content-wrapper');
             if (contentWrapper) {
-                const { bottom, top } = contentWrapper?.getBoundingClientRect();
+                const { bottom, top } = contentWrapper.getBoundingClientRect();
                 if (bottom > window.innerHeight - margin) {
                     // dropdown is going off the bottom of the screen
                     this.maxHeight = window.innerHeight - top - margin;

--- a/packages/cli/src/commands/doctor/checks/dependency-check.ts
+++ b/packages/cli/src/commands/doctor/checks/dependency-check.ts
@@ -191,7 +191,7 @@ function findDuplicatePackages(
         }
 
         if (versions.size > 0) {
-            result.set(pkg, [...versions].sort());
+            result.set(pkg, [...versions].sort((a, b) => a.localeCompare(b)));
         }
     }
 

--- a/packages/core/src/config/catalog/default-stock-location-strategy.ts
+++ b/packages/core/src/config/catalog/default-stock-location-strategy.ts
@@ -14,7 +14,7 @@ import { AvailableStock, LocationWithQuantity, StockLocationStrategy } from './s
 export abstract class BaseStockLocationStrategy implements StockLocationStrategy {
     protected connection: TransactionalConnection;
 
-    init(injector: Injector) {
+    init(injector: Injector): void | Promise<void> {
         this.connection = injector.get(TransactionalConnection);
     }
 

--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -177,7 +177,7 @@ export class CollectionService implements OnModuleInit {
                         job.setProgress(Math.ceil((completed / collectionIds.length) * 100));
                         if (affectedVariantIds.length) {
                             // To avoid performance issues on huge collections we first split the affected variant ids into chunks
-                            this.chunkArray(affectedVariantIds, 50000).map(chunk =>
+                            this.chunkArray(affectedVariantIds, 50000).forEach(chunk =>
                                 this.eventBus.publish(
                                     new CollectionModificationEvent(ctx, collection, chunk),
                                 ),

--- a/packages/dashboard/plugin/service/metrics.service.ts
+++ b/packages/dashboard/plugin/service/metrics.service.ts
@@ -48,7 +48,7 @@ export class MetricsService {
                 JSON.stringify({
                     startDate: calculatedStartDate,
                     endDate: calculatedEndDate,
-                    types: [...types].sort(),
+                    types: [...types].sort((a, b) => a.localeCompare(b)),
                     channel: ctx.channel.token,
                 }),
             )

--- a/packages/dashboard/src/lib/components/layout/nav-main.tsx
+++ b/packages/dashboard/src/lib/components/layout/nav-main.tsx
@@ -184,7 +184,9 @@ export function NavMain({ items }: Readonly<{ items: Array<NavMenuSection | NavM
                 .map(section => {
                     if ('items' in section) {
                         // Filter items based on permissions
-                        const allowedItems = (section.items ?? []).filter(isItemAllowed).sort(sortByOrder);
+                        const allowedItems = (section.items ?? [])
+                            .filter(item => isItemAllowed(item))
+                            .sort(sortByOrder);
                         return { ...section, items: allowedItems };
                     }
                     return section;

--- a/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.ts
+++ b/packages/dashboard/src/lib/framework/document-introspection/add-custom-fields.ts
@@ -50,11 +50,11 @@ function createOptionsKey(options?: {
     }
 
     if (options.includeCustomFields) {
-        parts.push(`include:${[...options.includeCustomFields].sort().join(',')}`);
+        parts.push(`include:${[...options.includeCustomFields].sort((a, b) => a.localeCompare(b)).join(',')}`);
     }
 
     if (options.includeNestedFragments) {
-        parts.push(`nested:${[...options.includeNestedFragments].sort().join(',')}`);
+        parts.push(`nested:${[...options.includeNestedFragments].sort((a, b) => a.localeCompare(b)).join(',')}`);
     }
 
     return parts.join('|') || 'default';

--- a/packages/dashboard/src/lib/framework/document-introspection/include-only-selected-list-fields.ts
+++ b/packages/dashboard/src/lib/framework/document-introspection/include-only-selected-list-fields.ts
@@ -73,7 +73,10 @@ function createCacheKey(
 }
 
 function sortJoin<T>(arr: T[], separator: string): string {
-    return arr.slice(0).sort().join(separator);
+    return arr
+        .slice(0)
+        .sort((a, b) => String(a).localeCompare(String(b)))
+        .join(separator);
 }
 
 /**

--- a/packages/dashboard/src/lib/framework/extension-api/custom-providers.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/custom-providers.ts
@@ -85,7 +85,7 @@ export function registerDashboardCustomProviders(providers: DashboardCustomProvi
     }
 
     if (duplicateIds.size) {
-        const duplicates = Array.from(duplicateIds).sort();
+        const duplicates = Array.from(duplicateIds).sort((a, b) => a.localeCompare(b));
         throw new Error(
             `Duplicate dashboard custom provider ids detected: ` +
                 `${duplicates.map(id => `"${id}"`).join(', ')}. ` +


### PR DESCRIPTION
## Summary

Fixes a cluster of SonarCloud reliability issues (CRITICAL/MAJOR bugs) that dropped the New Code Reliability rating on `master`. All changes are in actively-maintained packages (`core`, `dashboard`, `cli`, plus one trivial `admin-ui` fix) and are safe, mechanical corrections.

## Changes

| Fix | Location(s) | Rule |
|---|---|---|
| `Array.sort()` given an explicit `localeCompare` comparator (implicit sort coerces to strings — a footgun) | `cli/.../dependency-check.ts`, `dashboard/.../custom-providers.ts`, `dashboard/plugin/.../metrics.service.ts`, `dashboard/.../add-custom-fields.ts` (×2), `dashboard/.../include-only-selected-list-fields.ts` | S2871 |
| Widened `BaseStockLocationStrategy.init` return type to `void \| Promise<void>` so the async override in `MultiChannelStockLocationStrategy` conforms (framework already awaits `init`) | `core/.../default-stock-location-strategy.ts` | S6544 |
| `.map()` used purely for side-effects → `.forEach()` | `core/.../collection.service.ts` | S2201 |
| `.filter(isItemAllowed)` → `.filter(item => isItemAllowed(item))` to pin predicate arity | `dashboard/.../nav-main.tsx` | S7737 |
| Removed redundant `?.` after a preceding null-check (would throw on destructure of `undefined`) | `admin-ui/.../dropdown-menu.component.ts` | S6582 |

## Notes

These are the low-risk, genuinely-correct wins. They do **not** flip the Quality Gate green on their own — Reliability "A" requires zero bugs on new code, and the bulk of the remaining count is long-standing `admin-ui` accessibility template warnings. The Security Rating / Hotspot conditions are driven mostly by `.github/workflows/*.yml` findings (unpinned installs, `Math.random`, weak hashes in non-sensitive contexts) that are better triaged as Safe/Won't-Fix in the SonarCloud UI than changed in code.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4968"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786624098&installation_id=128408429&pr_number=4968&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4968&signature=56b2fd8b62e98d5d7ab28f37edf1b6338a0212cb0d84ec98d08fdcd2f277f22f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->