### PR TITLE
fix(dashboard): add password visibility toggle to all password fields

### DIFF
--- a/packages/dashboard/src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_administrators/administrators_.$id.tsx
@@ -3,6 +3,7 @@ import { FormFieldWrapper } from '@/vdb/components/shared/form-field-wrapper.js'
 import { RoleSelector } from '@/vdb/components/shared/role-selector.js';
 import { Button } from '@/vdb/components/ui/button.js';
 import { Input } from '@/vdb/components/ui/input.js';
+import { PasswordInput } from '@/vdb/components/ui/password-input.js';
 import { NEW_ENTITY_PATH } from '@/vdb/constants.js';
 import {    CustomFieldsPageBlock,
     Page,
@@ -131,7 +132,7 @@ function AdministratorDetailPage() {
                             control={form.control}
                             name="password"
                             label={<Trans>Password</Trans>}
-                            render={({ field }) => <Input placeholder="" type="password" {...field} />}
+                            render={({ field }) => <PasswordInput {...field} />}
                         />
                     </div>
                 </PageBlock>

--- a/packages/dashboard/src/app/routes/_authenticated/_profile/profile.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_profile/profile.tsx
@@ -3,6 +3,7 @@ import { FormFieldWrapper } from '@/vdb/components/shared/form-field-wrapper.js'
 import { Badge } from '@/vdb/components/ui/badge.js';
 import { Button } from '@/vdb/components/ui/button.js';
 import { Input } from '@/vdb/components/ui/input.js';
+import { PasswordInput } from '@/vdb/components/ui/password-input.js';
 import { extendDetailFormQuery } from '@/vdb/framework/document-extension/extend-detail-form-query.js';
 import { addCustomFields } from '@/vdb/framework/document-introspection/add-custom-fields.js';
 import {    CustomFieldsPageBlock,
@@ -118,7 +119,7 @@ function ProfilePage() {
                             control={form.control}
                             name="password"
                             label={<Trans>Password</Trans>}
-                            render={({ field }) => <Input type="password" {...field} />}
+                            render={({ field }) => <PasswordInput {...field} />}
                         />
                     </DetailFormGrid>
                 </PageBlock>

--- a/packages/dashboard/src/lib/components/data-input/password-form-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/password-form-input.tsx
@@ -1,6 +1,6 @@
 import { DashboardFormComponentProps } from '@/vdb/framework/form-engine/form-engine-types.js';
 import { isReadonlyField } from '@/vdb/framework/form-engine/utils.js';
-import { Input } from '../ui/input.js';
+import { PasswordInput } from '../ui/password-input.js';
 
 /**
  * @description
@@ -12,8 +12,7 @@ import { Input } from '../ui/input.js';
 export function PasswordFormInput(props: Readonly<DashboardFormComponentProps>) {
     const readOnly = props.disabled || isReadonlyField(props.fieldDef);
     return (
-        <Input
-            type="password"
+        <PasswordInput
             ref={props.ref}
             value={props.value}
             onChange={e => props.onChange(e.target.value)}


### PR DESCRIPTION
## Description

While creating an administrator account I noticed the password field had no eye icon to toggle visibility.  you couldn't see what you were typing. I fixed that, then thought let me check if there are any other password fields across the dashboard with the same issue. Found 3 places total and fixed them all.

The `PasswordInput` component with the eye toggle already existed and was being used on the login page, just wasn't applied consistently everywhere else.

## What changed

Replaced `<Input type="password">` with `<PasswordInput>` in three places:

- Administrator create/edit page -> password field
- Profile page -> password change field
- `PasswordFormInput` component -> used for custom fields of type `password`

It's a minor change but I think having the ability to see your password while setting it is really important, especially for admin accounts.

Some Screenshots before the fix.
<img width="1847" height="450" alt="dashboardProfilePass" src="https://github.com/user-attachments/assets/ad0b318e-d430-4b8c-8e06-8ae04ba43e71" />

<img width="1872" height="669" alt="adminitorPadd" src="https://github.com/user-attachments/assets/5f0da9bf-ff4f-4d0b-a8bc-8bcac49a24bb" />

Some Screenshots after the fix.

<img width="1871" height="528" alt="adminitratorPAssFIXED" src="https://github.com/user-attachments/assets/4ea77292-64e7-4828-acc3-e4e9cd11bd39" />
<img width="1898" height="407" alt="profilePassFIXED" src="https://github.com/user-attachments/assets/6ff877ab-2ee3-4f69-b3dc-066687f0c722" />

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786626318&installation_id=128408429&pr_number=4969&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4969&signature=2eb3fb94f16851566161792a7b265dfda16761346f7666d7bfe09b7c1aaef8b0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->