### PR TITLE
docs: Add missing 3.7.1 changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 #### Fixes
 
+* **asset-server-plugin** Save and serve files with correct Content-Type (#4404) ([c729cb8](https://github.com/vendurehq/vendure/commit/c729cb8)), closes [#4404](https://github.com/vendurehq/vendure/issues/4404)
+* **core** Assign facets to channel when re-importing products via CSV (#4713) ([f9d5896](https://github.com/vendurehq/vendure/commit/f9d5896)), closes [#4713](https://github.com/vendurehq/vendure/issues/4713) [#4673](https://github.com/vendurehq/vendure/issues/4673)
 * **core** Deliver public API type dependencies to consumers (#4947) ([c4ed7a0](https://github.com/vendurehq/vendure/commit/c4ed7a0)), closes [#4947](https://github.com/vendurehq/vendure/issues/4947)
 * **core** Export and register Province entity and ProvinceService (#4857) ([c1b5b3d](https://github.com/vendurehq/vendure/commit/c1b5b3d)), closes [#4857](https://github.com/vendurehq/vendure/issues/4857)
 * **core** Merge shared entity instances into every hydration target (#4945) ([aa5859e](https://github.com/vendurehq/vendure/commit/aa5859e)), closes [#4945](https://github.com/vendurehq/vendure/issues/4945)


### PR DESCRIPTION
## Description

Two user-facing fixes released in 3.7.1 were missing from `CHANGELOG.md`. This adds them under the existing `3.7.1` heading, matching the generated entry format.

They were dropped because `scripts/changelogs/generate-changelog.ts` only includes a commit when it has **both** a valid type (`feat`/`fix`/`perf`) **and** a recognised scope:

- **#4404** — squashed as `[FIX] Save and serve files with correct Content-Type`. The `[FIX]` prefix isn't parsed as a conventional type, so it failed the type check. (asset-server-plugin: PDFs were served as `application/octet-stream`; S3 content-type wasn't set.)
- **#4713** — squashed as `fix: assign facets to channel when re-importing products via CSV`. Valid `fix:` type but **no scope**, so it failed the scope check. (core: importer facet caches persisted across import calls, so a second import into a new channel lost facets.)

Both are visible in the 3.7.1 GitHub release's auto-generated "What's Changed" (which lists every PR), but were silently filtered out of the committed changelog.

`Fix typo in channel-aware entities description` (#4927) was also non-conventional, but it's a code-comment typo and correctly excluded — no changelog entry needed.

## Breaking changes

No — docs-only change to `CHANGELOG.md`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786631281&installation_id=128408429&pr_number=4971&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4971&signature=e6bab0901840f0b61bc8d0ed6b6c0e3220c48c981b6d7dea53c8a792a0de9395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->