### PR TITLE
feat(cli): Show one-time GitHub star prompt on shutdown

### DIFF
--- a/packages/cli/src/commands/dev/dev.spec.ts
+++ b/packages/cli/src/commands/dev/dev.spec.ts
@@ -303,16 +303,19 @@ describe('dev command', () => {
         it('resolves SIGINT shutdowns with the canonical signal exit code', async () => {
             const stopFirst = vi.fn();
             const stopSecond = vi.fn();
+            const onShutdownSignal = vi.fn();
             const firstChild = new ManagedDevProcess(stopFirst);
             const secondChild = new ManagedDevProcess(stopSecond);
             const sigintListenerCount = process.listenerCount('SIGINT');
             const sigtermListenerCount = process.listenerCount('SIGTERM');
-            const promise = waitForDevProcesses([firstChild, secondChild]);
+            const promise = waitForDevProcesses([firstChild, secondChild], { onShutdownSignal });
 
             process.emit('SIGINT');
 
             expect(stopFirst).toHaveBeenCalledWith('SIGINT');
             expect(stopSecond).toHaveBeenCalledWith('SIGINT');
+            expect(onShutdownSignal).toHaveBeenCalledOnce();
+            expect(onShutdownSignal).toHaveBeenCalledWith('SIGINT');
             firstChild.emitClose(null, 'SIGINT');
             secondChild.emitClose(0, null);
             await expect(promise).resolves.toBe(130);

--- a/packages/cli/src/commands/dev/dev.ts
+++ b/packages/cli/src/commands/dev/dev.ts
@@ -13,6 +13,7 @@ import {
     resolvePackageBin,
     signalToExitCode,
 } from '../../shared/cli-process-utils';
+import { showStarPromptOnce } from '../../shared/star-prompt';
 import { findPackageJsonWithDependency } from '../../utilities/monorepo-utils';
 
 export type DevTarget = 'all' | 'server' | 'worker' | 'dashboard';
@@ -79,9 +80,15 @@ export async function devCommand(targetArg?: string, options: DevOptions = {}): 
                 reload: options.reload !== false && processDefinition.reloadOnChange,
             }),
         );
-        return await waitForDevProcesses(children, {
+        let shutdownSignal: NodeJS.Signals | undefined;
+        const exitCode = await waitForDevProcesses(children, {
             onError: error => log.error(error.message),
+            onShutdownSignal: signal => (shutdownSignal = signal),
         });
+        if (shutdownSignal === 'SIGINT') {
+            showStarPromptOnce();
+        }
+        return exitCode;
     } catch (e: unknown) {
         log.error(e instanceof Error ? e.message : String(e));
         return 1;
@@ -284,6 +291,7 @@ function startSupervisedDevProcess(
 
 interface WaitForDevProcessesOptions {
     onError?: (error: Error) => void;
+    onShutdownSignal?: (signal: NodeJS.Signals) => void;
 }
 
 export function waitForDevProcesses(
@@ -338,8 +346,12 @@ export function waitForDevProcesses(
                 resolveOnce(firstNonZeroExitCode || (shutdownExitCode ?? exitCode));
             }
         };
-        const handleSigint = () => stopChildren('SIGINT', signalToExitCode('SIGINT'));
-        const handleSigterm = () => stopChildren('SIGTERM', signalToExitCode('SIGTERM'));
+        const handleSignal = (signal: NodeJS.Signals) => {
+            options.onShutdownSignal?.(signal);
+            stopChildren(signal, signalToExitCode(signal));
+        };
+        const handleSigint = () => handleSignal('SIGINT');
+        const handleSigterm = () => handleSignal('SIGTERM');
 
         process.once('SIGINT', handleSigint);
         process.once('SIGTERM', handleSigterm);

--- a/packages/cli/src/shared/star-prompt.spec.ts
+++ b/packages/cli/src/shared/star-prompt.spec.ts
@@ -16,7 +16,11 @@ describe('star prompt', () => {
         try {
             expect(showStarPromptOnce({ configDir, isInteractive: true, color: false, write })).toBe(true);
             expect(write).toHaveBeenCalledOnce();
-            expect(write.mock.calls[0][0]).toContain('Thanks for using Vendure');
+            expect(write.mock.calls[0][0]).toContain('✨ Thanks for using Vendure.');
+            expect(write.mock.calls[0][0]).not.toContain('Vendure. ✨');
+            expect(write.mock.calls[0][0]).toContain(
+                'If you like the experience, please consider starring us on GitHub',
+            );
             expect(write.mock.calls[0][0]).toContain('https://github.com/vendurehq/vendure');
             expect(existsSync(path.join(configDir, 'star-prompted'))).toBe(true);
 

--- a/packages/cli/src/shared/star-prompt.spec.ts
+++ b/packages/cli/src/shared/star-prompt.spec.ts
@@ -1,0 +1,56 @@
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it, vi } from 'vitest';
+
+import { getVendureCliConfigDir, renderStarPrompt, showStarPromptOnce } from './star-prompt';
+
+function createTempDir() {
+    return mkdtempSync(path.join(tmpdir(), 'vendure-cli-star-prompt-'));
+}
+
+describe('star prompt', () => {
+    it('shows once and persists that it was shown', () => {
+        const configDir = createTempDir();
+        const write = vi.fn();
+        try {
+            expect(showStarPromptOnce({ configDir, isInteractive: true, color: false, write })).toBe(true);
+            expect(write).toHaveBeenCalledOnce();
+            expect(write.mock.calls[0][0]).toContain('Thanks for using Vendure');
+            expect(write.mock.calls[0][0]).toContain('https://github.com/vendurehq/vendure');
+            expect(existsSync(path.join(configDir, 'star-prompted'))).toBe(true);
+
+            expect(showStarPromptOnce({ configDir, isInteractive: true, color: false, write })).toBe(false);
+            expect(write).toHaveBeenCalledOnce();
+        } finally {
+            rmSync(configDir, { recursive: true, force: true });
+        }
+    });
+
+    it('does not show or persist the prompt in a non-interactive process', () => {
+        const configDir = createTempDir();
+        const write = vi.fn();
+        try {
+            expect(showStarPromptOnce({ configDir, isInteractive: false, write })).toBe(false);
+            expect(write).not.toHaveBeenCalled();
+            expect(existsSync(path.join(configDir, 'star-prompted'))).toBe(false);
+        } finally {
+            rmSync(configDir, { recursive: true, force: true });
+        }
+    });
+
+    it('uses the configured XDG directory', () => {
+        expect(getVendureCliConfigDir({ XDG_CONFIG_HOME: '/tmp/config' })).toBe(
+            path.join('/tmp/config', 'vendure'),
+        );
+    });
+
+    it('renders a double-line box', () => {
+        const output = renderStarPrompt(false);
+
+        expect(output).toContain('╔═');
+        expect(output).toContain('═╗');
+        expect(output).toContain('╚═');
+        expect(output).toContain('═╝');
+    });
+});

--- a/packages/cli/src/shared/star-prompt.ts
+++ b/packages/cli/src/shared/star-prompt.ts
@@ -57,9 +57,9 @@ export function getVendureCliConfigDir(env: NodeJS.ProcessEnv = process.env): st
 
 export function renderStarPrompt(color = pc.isColorSupported): string {
     const lines = [
-        '✨ Thanks for using Vendure. ✨',
+        '✨ Thanks for using Vendure.',
         '',
-        'If you liked it, please consider starring us on GitHub',
+        'If you like the experience, please consider starring us on GitHub',
         'https://github.com/vendurehq/vendure',
         '',
         'Note: you will not see this message again.',

--- a/packages/cli/src/shared/star-prompt.ts
+++ b/packages/cli/src/shared/star-prompt.ts
@@ -1,0 +1,89 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import path from 'node:path';
+import pc from 'picocolors';
+
+const horizontalPadding = 5;
+const verticalPadding = 5;
+
+export interface ShowStarPromptOptions {
+    configDir?: string;
+    isInteractive?: boolean;
+    color?: boolean;
+    write?: (output: string) => void;
+}
+
+/**
+ * Shows a one-time prompt asking developers to star Vendure on GitHub.
+ *
+ * The marker file is created before writing the prompt so concurrent CLI
+ * processes cannot each display it.
+ */
+export function showStarPromptOnce(options: ShowStarPromptOptions = {}): boolean {
+    const isInteractive = options.isInteractive ?? process.stdout.isTTY === true;
+    if (!isInteractive) {
+        return false;
+    }
+
+    const configDir = options.configDir ?? getVendureCliConfigDir();
+    try {
+        mkdirSync(configDir, { recursive: true });
+        writeFileSync(path.join(configDir, 'star-prompted'), '', { flag: 'wx' });
+    } catch (error: unknown) {
+        if (isAlreadyPromptedError(error)) {
+            return false;
+        }
+        // A promotional prompt should never prevent the CLI from shutting down.
+        return false;
+    }
+
+    const output = renderStarPrompt(options.color ?? pc.isColorSupported);
+    (options.write ?? (message => process.stdout.write(message)))(output);
+    return true;
+}
+
+export function getVendureCliConfigDir(env: NodeJS.ProcessEnv = process.env): string {
+    if (env.VENDURE_CLI_CONFIG_DIR) {
+        return env.VENDURE_CLI_CONFIG_DIR;
+    }
+    if (env.XDG_CONFIG_HOME) {
+        return path.join(env.XDG_CONFIG_HOME, 'vendure');
+    }
+    if (process.platform === 'win32' && env.APPDATA) {
+        return path.join(env.APPDATA, 'vendure');
+    }
+    return path.join(homedir(), '.config', 'vendure');
+}
+
+export function renderStarPrompt(color = pc.isColorSupported): string {
+    const lines = [
+        '✨ Thanks for using Vendure. ✨',
+        '',
+        'If you liked it, please consider starring us on GitHub',
+        'https://github.com/vendurehq/vendure',
+        '',
+        'Note: you will not see this message again.',
+    ];
+    const contentWidth = Math.max(...lines.map(line => line.length));
+    const innerWidth = contentWidth + horizontalPadding * 2;
+    const blue = color ? pc.blue : (value: string) => value;
+    const emptyLine = `${blue('║')}${' '.repeat(innerWidth)}${blue('║')}`;
+    const body = lines.map(
+        line =>
+            `${blue('║')}${' '.repeat(horizontalPadding)}${line.padEnd(contentWidth)}${' '.repeat(horizontalPadding)}${blue('║')}`,
+    );
+
+    return [
+        '',
+        blue(`╔${'═'.repeat(innerWidth)}╗`),
+        ...Array.from({ length: verticalPadding }, () => emptyLine),
+        ...body,
+        ...Array.from({ length: verticalPadding }, () => emptyLine),
+        blue(`╚${'═'.repeat(innerWidth)}╝`),
+        '',
+    ].join('\n');
+}
+
+function isAlreadyPromptedError(error: unknown): boolean {
+    return error instanceof Error && 'code' in error && error.code === 'EEXIST';
+}


### PR DESCRIPTION
## Summary

- show a one-time GitHub star prompt after `vendure dev` is stopped with Ctrl+C
- render the prompt in a blue double-line box inspired by Medusa's CLI
- persist a global marker so the prompt is not displayed again
- skip the prompt for non-interactive output and preserve existing graceful shutdown behavior

## Why

A lightweight, one-time reminder gives developers an easy path to support Vendure after using the development command without adding noise to subsequent runs or CI logs.

## Validation

- `bun run build` in `packages/cli`
- `bun run test` in `packages/cli` — 276 passed, 1 skipped
- repository pre-commit lint and formatting hooks
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4973"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786708953&installation_id=128408429&pr_number=4973&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4973&signature=b0a85e29b368fce3c58717db66f58eb1815dbd82422e1496fdd7d556c19a2e9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->