### PR TITLE
fix(admin-ui): Set transactionId as optional to honor ManualPaymentInput type

### DIFF
--- a/packages/admin-ui/src/lib/order/src/components/add-manual-payment-dialog/add-manual-payment-dialog.component.ts
+++ b/packages/admin-ui/src/lib/order/src/components/add-manual-payment-dialog/add-manual-payment-dialog.component.ts
@@ -6,10 +6,8 @@ import {
     Dialog,
     GetAddManualPaymentMethodListDocument,
     GetAddManualPaymentMethodListQuery,
-    GetPaymentMethodListQuery,
     ItemOf,
     ManualPaymentInput,
-    PAYMENT_METHOD_FRAGMENT,
 } from '@vendure/admin-ui/core';
 import { gql } from 'apollo-angular';
 import { Observable } from 'rxjs';
@@ -46,7 +44,7 @@ export class AddManualPaymentDialogComponent implements OnInit, Dialog<Omit<Manu
     resolveWith: (result?: Omit<ManualPaymentInput, 'orderId'>) => void;
     form = new UntypedFormGroup({
         method: new UntypedFormControl('', Validators.required),
-        transactionId: new UntypedFormControl('', Validators.required),
+        transactionId: new UntypedFormControl(''),
     });
     paymentMethods$: Observable<Array<ItemOf<GetAddManualPaymentMethodListQuery, 'paymentMethods'>>>;
     constructor(private dataService: DataService) {}


### PR DESCRIPTION
# Description

When adding a new payment to an other, the dialog has `transactionId` field marked as required but the graphql type it represents is optional. This change reflects that by removing the `Validators.required` attribute from this specific field.

# Breaking changes

No breaking change.

# Screenshots

This is the dialog that will receive the change
<img width="579" height="285" alt="image" src="https://github.com/user-attachments/assets/09d9da05-8b5b-4e63-b6dd-4a8c1901939d" />

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786762185&installation_id=128408429&pr_number=4977&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4977&signature=df59e6197f7db71344dd68c598dc95777ed0e624dae6d9ce39bb32133754f257"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->