### PR TITLE
fix(core): Hydrate relations missing from only some array elements

### DIFF
--- a/packages/core/e2e/entity-hydrator.e2e-spec.ts
+++ b/packages/core/e2e/entity-hydrator.e2e-spec.ts
@@ -405,6 +405,50 @@ describe('Entity hydration', () => {
         expect(order!.lines[1].productVariant.product.facetValues[0].facet).toBeDefined();
     });
 
+    // https://github.com/vendurehq/vendure/issues/4537
+    // A relation can be loaded on some elements of an array relation but not others, which
+    // is what plugin code (e.g. an OrderInterceptor) commonly encounters. Hydration must
+    // populate every element, regardless of what was loaded beforehand.
+    it('hydrates a relation that is present on only some order lines', async () => {
+        // Fresh anonymous order so we're not appending to another test's active order.
+        await shopClient.asAnonymousUser();
+        // Two variants belonging to different products (T_1 = Laptop, T_5 = Curvy Monitor),
+        // so each line has its own ProductVariant and Product instance.
+        await shopClient.query(addItemToOrderDocument, {
+            productVariantId: 'T_1',
+            quantity: 1,
+        });
+        const { addItemToOrder } = await shopClient.query(addItemToOrderDocument, {
+            productVariantId: 'T_5',
+            quantity: 1,
+        });
+        orderResultGuard.assertSuccess(addItemToOrder);
+        expect(addItemToOrder.lines.length).toBe(2);
+
+        const internalOrderId = +addItemToOrder.id.replace(/^\D+/g, '');
+        const ctx = await server.app.get(RequestContextService).create({ apiType: 'admin' });
+        const order = await server.app
+            .get(OrderService)
+            .findOne(ctx, internalOrderId, ['lines.productVariant.product']);
+
+        // Model the unevenly-loaded tree: the first line has its product, the second does not.
+        delete (order!.lines[1].productVariant as any).product;
+
+        await server.app.get(EntityHydrator).hydrate(ctx, order!, {
+            relations: ['lines.productVariant.product'],
+        });
+
+        // Before the fix, only the first array element was inspected, so the relation was
+        // considered present for the whole array and nothing was fetched, leaving the second
+        // line's product undefined.
+        expect(order!.lines[0].productVariant.product).toBeDefined();
+        expect(order!.lines[1].productVariant.product).toBeDefined();
+        // Each line must end up with its own product (T_1 => Laptop, T_5 => Curvy Monitor),
+        // not a copy of the first line's product.
+        expect(order!.lines[0].productVariant.product.id).toBe(1);
+        expect(order!.lines[1].productVariant.product.id).toBe(2);
+    });
+
     // https://github.com/vendurehq/vendure/issues/2546
     it('Preserves ordering when merging arrays of relations', async () => {
         await shopClient.asUserWithCredentials('trevor_donnelly96@hotmail.com', 'test');

--- a/packages/core/e2e/entity-hydrator.e2e-spec.ts
+++ b/packages/core/e2e/entity-hydrator.e2e-spec.ts
@@ -406,47 +406,52 @@ describe('Entity hydration', () => {
     });
 
     // https://github.com/vendurehq/vendure/issues/4537
-    // A relation can be loaded on some elements of an array relation but not others, which
-    // is what plugin code (e.g. an OrderInterceptor) commonly encounters. Hydration must
-    // populate every element, regardless of what was loaded beforehand.
-    it('hydrates a relation that is present on only some order lines', async () => {
+    // A relation can be present on some elements of an array relation but not others. This is
+    // reachable through the public API: plugin code (e.g. an OrderInterceptor, see
+    // order-interceptor.ts:168) hydrates a relation onto a *single* line's variant, leaving the
+    // array unevenly loaded as [present, missing] — exactly what the reporter described. Hydrating
+    // the whole array must then populate every element, not just sample the first. Producing the
+    // uneven state through a real hydrate() call (rather than editing the entity by hand) verifies
+    // the fix against a shape a real code path actually generates.
+    it("hydrates lines after a plugin hydrated one line's variant", async () => {
         // Fresh anonymous order so we're not appending to another test's active order.
         await shopClient.asAnonymousUser();
         // Two variants belonging to different products (T_1 = Laptop, T_5 = Curvy Monitor),
         // so each line has its own ProductVariant and Product instance.
-        await shopClient.query(addItemToOrderDocument, {
-            productVariantId: 'T_1',
-            quantity: 1,
-        });
+        await shopClient.query(addItemToOrderDocument, { productVariantId: 'T_1', quantity: 1 });
         const { addItemToOrder } = await shopClient.query(addItemToOrderDocument, {
             productVariantId: 'T_5',
             quantity: 1,
         });
         orderResultGuard.assertSuccess(addItemToOrder);
-        expect(addItemToOrder.lines.length).toBe(2);
 
         const internalOrderId = +addItemToOrder.id.replace(/^\D+/g, '');
         const ctx = await server.app.get(RequestContextService).create({ apiType: 'admin' });
+        const hydrator = server.app.get(EntityHydrator);
         const order = await server.app
             .get(OrderService)
-            .findOne(ctx, internalOrderId, ['lines.productVariant.product']);
+            .findOne(ctx, internalOrderId, ['lines.productVariant']);
 
-        // Model the unevenly-loaded tree: the first line has its product, the second does not.
-        delete (order!.lines[1].productVariant as any).product;
+        expect(order!.lines[0].productVariant.product).toBeUndefined();
+        expect(order!.lines[1].productVariant.product).toBeUndefined();
 
-        await server.app.get(EntityHydrator).hydrate(ctx, order!, {
-            relations: ['lines.productVariant.product'],
-        });
+        // A plugin acts on one line and hydrates just that line's variant.
+        await hydrator.hydrate(ctx, order!.lines[0].productVariant, { relations: ['product'] });
 
-        // Before the fix, only the first array element was inspected, so the relation was
-        // considered present for the whole array and nothing was fetched, leaving the second
-        // line's product undefined.
+        // The array is now unevenly loaded: [present, missing].
+        expect(order!.lines[0].productVariant.product).toBeDefined();
+        expect(order!.lines[1].productVariant.product).toBeUndefined();
+
+        await hydrator.hydrate(ctx, order!, { relations: ['lines.productVariant.product'] });
+
+        // Before the fix, only lines[0] was sampled, so the relation was considered present for
+        // the whole array and nothing was fetched, leaving lines[1]'s product undefined.
         expect(order!.lines[0].productVariant.product).toBeDefined();
         expect(order!.lines[1].productVariant.product).toBeDefined();
-        // Each line must end up with its own product (T_1 => Laptop, T_5 => Curvy Monitor),
-        // not a copy of the first line's product.
-        expect(order!.lines[0].productVariant.product.id).toBe(1);
-        expect(order!.lines[1].productVariant.product.id).toBe(2);
+        // Assert against each variant's own productId rather than a hardcoded id, so the test
+        // isn't coupled to fixture CSV row order or the id strategy.
+        expect(order!.lines[0].productVariant.product.id).toBe(order!.lines[0].productVariant.productId);
+        expect(order!.lines[1].productVariant.product.id).toBe(order!.lines[1].productVariant.productId);
     });
 
     // https://github.com/vendurehq/vendure/issues/2546

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
@@ -115,11 +115,103 @@ describe('EntityHydrator', () => {
             // Spreading a very large array into push() (`push(...value)`) exceeds V8's argument
             // limit and throws "RangeError: Maximum call stack size exceeded"; a plain loop must
             // be used instead. Reproduces e.g. `collections.productVariants` on a big catalog.
+            //
+            // The path must run PAST the large array: a relation at the end of the path is only
+            // checked for presence, so its elements are never collected and the spread this test
+            // guards against would not be reached.
             const collection = {
-                productVariants: Array.from({ length: 200_000 }, (_, i) => ({ id: i })),
+                productVariants: Array.from({ length: 200_000 }, (_, i) => ({
+                    id: i,
+                    product: { id: i },
+                })),
             };
-            expect(() => getMissingRelations(collection, ['productVariants'])).not.toThrow();
-            expect(getMissingRelations(collection, ['productVariants'])).toEqual([]);
+            expect(() => getMissingRelations(collection, ['productVariants.product'])).not.toThrow();
+            expect(getMissingRelations(collection, ['productVariants.product'])).toEqual([]);
+        });
+
+        // A relation at the end of the path only needs to be checked for presence, so the walk
+        // must not descend into the entities it points to. Descending is wasted work proportional
+        // to the size of the relation, e.g. `collections.productVariants` on a big catalog.
+        it('does not walk into the elements of an array at the end of the path', () => {
+            class CountingArray extends Array {
+                walked = 0;
+                [Symbol.iterator]() {
+                    this.walked++;
+                    return super[Symbol.iterator]();
+                }
+            }
+            const productVariants = new CountingArray();
+            productVariants.push({ id: 1 }, { id: 2 }, { id: 3 });
+
+            expect(getMissingRelations({ productVariants }, ['productVariants'])).toEqual([]);
+            expect(productVariants.walked).toBe(0);
+        });
+
+        // Once one element is found to be missing the relation, the whole path is already known to
+        // be missing, so there is nothing to learn from the remaining elements.
+        it('stops checking array elements once one is found to be missing', () => {
+            const visited = new Set<number>();
+            // The relation is missing from an element in the middle rather than the first one, so
+            // this also fails an implementation that only samples element [0] — issue #4537 itself.
+            const missingAt = 7;
+            const lines = Array.from({ length: 100 }, (_, i) => ({
+                get productVariant() {
+                    visited.add(i);
+                    return i === missingAt ? undefined : { id: i };
+                },
+            }));
+
+            expect(getMissingRelations({ lines }, ['lines.productVariant'])).toEqual([
+                'lines',
+                'lines.productVariant',
+            ]);
+            expect(visited.size).toBe(missingAt + 1);
+        });
+
+        // An `undefined` element settles the path on its own, so the walk must stop at it rather
+        // than carry on reading the relation off every remaining element. Distinct from the test
+        // above: that one exits on a present element whose relation is undefined, this one exits
+        // on an element that is itself an `undefined` hole (issue #4955).
+        it('stops walking the frontier at an undefined array element', () => {
+            const read = new Set<number>();
+            const lines: Array<Record<string, any> | undefined> = Array.from({ length: 100 }, (_, i) => ({
+                get productVariant() {
+                    read.add(i);
+                    return { id: i };
+                },
+            }));
+            lines[0] = undefined;
+
+            expect(getMissingRelations({ lines }, ['lines.productVariant'])).toEqual([
+                'lines',
+                'lines.productVariant',
+            ]);
+            expect(read.size).toBe(0);
+        });
+
+        // An empty array mid-path leaves nothing to check further down, which settles the rest of
+        // the path as missing, so the walk must stop there too.
+        it('stops walking the frontier at an empty array mid-path', () => {
+            const read = new Set<number>();
+            const lines: Array<Record<string, any>> = Array.from({ length: 100 }, (_, i) => ({
+                get assets() {
+                    read.add(i);
+                    return [{ asset: { id: i } }];
+                },
+            }));
+            lines[0] = {
+                get assets() {
+                    read.add(0);
+                    return [];
+                },
+            };
+
+            expect(getMissingRelations({ lines }, ['lines.assets.asset'])).toEqual([
+                'lines',
+                'lines.assets',
+                'lines.assets.asset',
+            ]);
+            expect(read.size).toBe(1);
         });
     });
 

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
@@ -98,6 +98,29 @@ describe('EntityHydrator', () => {
                 'lines.productVariant',
             ]);
         });
+
+        // https://github.com/vendurehq/vendure/issues/4955
+        // Relation arrays can contain `undefined` holes (e.g. payments/surcharges/shippingLines
+        // after OrderPlacedEvent). An `undefined` element was never fetched and must be reported
+        // missing; only `null` counts as loaded.
+        it('reports missing when the array has an undefined leading hole', () => {
+            const order = { payments: [undefined, { refunds: [{ id: 1 }] }] };
+            expect(getMissingRelations(order, ['payments.refunds'])).toEqual([
+                'payments',
+                'payments.refunds',
+            ]);
+        });
+
+        it('does not crash when a loaded relation array is very large', () => {
+            // Spreading a very large array into push() (`push(...value)`) exceeds V8's argument
+            // limit and throws "RangeError: Maximum call stack size exceeded"; a plain loop must
+            // be used instead. Reproduces e.g. `collections.productVariants` on a big catalog.
+            const collection = {
+                productVariants: Array.from({ length: 200_000 }, (_, i) => ({ id: i })),
+            };
+            expect(() => getMissingRelations(collection, ['productVariants'])).not.toThrow();
+            expect(getMissingRelations(collection, ['productVariants'])).toEqual([]);
+        });
     });
 
     describe('getRelationEntityAtPath()', () => {

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
@@ -3,6 +3,103 @@ import { describe, expect, it } from 'vitest';
 import { EntityHydrator } from './entity-hydrator.service';
 
 describe('EntityHydrator', () => {
+    describe('getMissingRelations()', () => {
+        function getMissingRelations(target: any, relations: string[]): string[] {
+            const hydrator = new EntityHydrator(undefined as any, undefined as any, undefined as any);
+            return (hydrator as any).getMissingRelations(target, { relations });
+        }
+
+        // https://github.com/vendurehq/vendure/issues/4537
+        it('detects a relation missing from a later array element', () => {
+            const order = {
+                lines: [
+                    { productVariant: { product: { id: 1 } } },
+                    { productVariant: { product: undefined } },
+                ],
+            };
+
+            expect(getMissingRelations(order, ['lines.productVariant.product'])).toEqual([
+                'lines',
+                'lines.productVariant',
+                'lines.productVariant.product',
+            ]);
+        });
+
+        // https://github.com/vendurehq/vendure/issues/4537
+        it('detects an intermediate relation missing from a later array element', () => {
+            const order = {
+                lines: [{ productVariant: { product: { id: 1 } } }, { productVariant: undefined }],
+            };
+
+            expect(getMissingRelations(order, ['lines.productVariant.product'])).toEqual([
+                'lines',
+                'lines.productVariant',
+                'lines.productVariant.product',
+            ]);
+        });
+
+        it('detects a relation missing from a nested array element', () => {
+            const order = {
+                lines: [
+                    {
+                        productVariant: {
+                            assets: [{ asset: { id: 1 } }, { asset: undefined }],
+                        },
+                    },
+                ],
+            };
+
+            expect(getMissingRelations(order, ['lines.productVariant.assets.asset'])).toEqual([
+                'lines',
+                'lines.productVariant',
+                'lines.productVariant.assets',
+                'lines.productVariant.assets.asset',
+            ]);
+        });
+
+        it('reports nothing when every array element has the relation', () => {
+            const order = {
+                lines: [
+                    { productVariant: { product: { id: 1 } } },
+                    { productVariant: { product: { id: 2 } } },
+                ],
+            };
+
+            expect(getMissingRelations(order, ['lines.productVariant.product'])).toEqual([]);
+        });
+
+        it('treats a relation that is null in the database as loaded', () => {
+            const order = {
+                lines: [{ productVariant: { product: null } }, { productVariant: { product: null } }],
+            };
+
+            expect(getMissingRelations(order, ['lines.productVariant.product'])).toEqual([]);
+        });
+
+        it('reports a relation missing from a sibling of a null relation', () => {
+            const order = {
+                lines: [{ productVariant: { product: null } }, { productVariant: { product: undefined } }],
+            };
+
+            expect(getMissingRelations(order, ['lines.productVariant.product'])).toEqual([
+                'lines',
+                'lines.productVariant',
+                'lines.productVariant.product',
+            ]);
+        });
+
+        it('reports nothing for a loaded empty array', () => {
+            expect(getMissingRelations({ lines: [] }, ['lines'])).toEqual([]);
+        });
+
+        it('reports deeper relations of a loaded empty array as missing', () => {
+            expect(getMissingRelations({ lines: [] }, ['lines.productVariant'])).toEqual([
+                'lines',
+                'lines.productVariant',
+            ]);
+        });
+    });
+
     describe('getRelationEntityAtPath()', () => {
         // https://github.com/vendurehq/vendure/issues/4661
         it('treats undefined intermediate relations as terminal values', () => {

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -225,33 +225,40 @@ export class EntityHydrator {
                             // path must be reported missing rather than skipped.
                             if (entity === undefined) {
                                 isMissing = true;
-                                continue;
+                                break;
                             }
                             // null = the relation has been fetched but was null in the database.
                             if (entity === null || entity[part] === null) {
                                 continue;
                             }
-                            if (entity[part]) {
-                                const value = entity[part];
-                                if (Array.isArray(value)) {
-                                    if (value.length === 0 && path.length < parts.length) {
+                            const value = entity[part];
+                            if (!value) {
+                                isMissing = true;
+                                break;
+                            }
+                            // At the last segment of the path we only need to know whether the
+                            // relation is present; the entities it points to are never inspected,
+                            // so there is no point collecting them.
+                            const isLastPart = path.length === parts.length;
+                            if (Array.isArray(value)) {
+                                if (value.length === 0) {
+                                    if (!isLastPart) {
                                         // An empty array leaves nothing to check further down the
                                         // path, so treat the rest of the path as missing.
                                         isMissing = true;
-                                    } else {
-                                        // Use a plain loop rather than push(...value): spreading a
-                                        // very large array (e.g. collections.productVariants on a
-                                        // big catalog) exceeds V8's argument limit and throws
-                                        // RangeError, even when everything is already loaded.
-                                        for (const element of value) {
-                                            nextEntities.push(element);
-                                        }
+                                        break;
                                     }
-                                } else {
-                                    nextEntities.push(value);
+                                } else if (!isLastPart) {
+                                    // Use a plain loop rather than push(...value): spreading a
+                                    // very large array (e.g. collections.productVariants on a
+                                    // big catalog) exceeds V8's argument limit and throws
+                                    // RangeError, even when everything is already loaded.
+                                    for (const element of value) {
+                                        nextEntities.push(element);
+                                    }
                                 }
-                            } else {
-                                isMissing = true;
+                            } else if (!isLastPart) {
+                                nextEntities.push(value);
                             }
                         }
                         entities = nextEntities;

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -220,9 +220,15 @@ export class EntityHydrator {
                     if (!isMissing) {
                         const nextEntities: Array<Record<string, any>> = [];
                         for (const entity of entities) {
+                            // undefined = this array element (or relation) was never fetched,
+                            // e.g. an `undefined` hole in a relation array, so the rest of the
+                            // path must be reported missing rather than skipped.
+                            if (entity === undefined) {
+                                isMissing = true;
+                                continue;
+                            }
                             // null = the relation has been fetched but was null in the database.
-                            // undefined = the relation has not been fetched.
-                            if (!entity || entity[part] === null) {
+                            if (entity === null || entity[part] === null) {
                                 continue;
                             }
                             if (entity[part]) {
@@ -233,7 +239,13 @@ export class EntityHydrator {
                                         // path, so treat the rest of the path as missing.
                                         isMissing = true;
                                     } else {
-                                        nextEntities.push(...value);
+                                        // Use a plain loop rather than push(...value): spreading a
+                                        // very large array (e.g. collections.productVariants on a
+                                        // big catalog) exceeds V8's argument limit and throws
+                                        // RangeError, even when everything is already loaded.
+                                        for (const element of value) {
+                                            nextEntities.push(element);
+                                        }
                                     }
                                 } else {
                                     nextEntities.push(value);

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -208,18 +208,43 @@ export class EntityHydrator {
         for (const relation of options.relations.slice().sort()) {
             if (typeof relation === 'string') {
                 const parts = relation.split('.');
-                let entity: Record<string, any> | undefined = target;
+                // The entities found at the current depth of the relation path. An array-valued
+                // relation can be loaded unevenly, e.g. `order.lines[0].productVariant` is present
+                // but `order.lines[1].productVariant` is not, so every entity at a given depth must
+                // be checked rather than just the first.
+                let entities: Array<Record<string, any>> = [target];
                 const path = [];
+                let isMissing = false;
                 for (const part of parts) {
                     path.push(part);
-                    // null = the relation has been fetched but was null in the database.
-                    // undefined = the relation has not been fetched.
-                    if (entity && entity[part] === null) {
-                        break;
+                    if (!isMissing) {
+                        const nextEntities: Array<Record<string, any>> = [];
+                        for (const entity of entities) {
+                            // null = the relation has been fetched but was null in the database.
+                            // undefined = the relation has not been fetched.
+                            if (!entity || entity[part] === null) {
+                                continue;
+                            }
+                            if (entity[part]) {
+                                const value = entity[part];
+                                if (Array.isArray(value)) {
+                                    if (value.length === 0 && path.length < parts.length) {
+                                        // An empty array leaves nothing to check further down the
+                                        // path, so treat the rest of the path as missing.
+                                        isMissing = true;
+                                    } else {
+                                        nextEntities.push(...value);
+                                    }
+                                } else {
+                                    nextEntities.push(value);
+                                }
+                            } else {
+                                isMissing = true;
+                            }
+                        }
+                        entities = nextEntities;
                     }
-                    if (entity && entity[part]) {
-                        entity = Array.isArray(entity[part]) ? entity[part][0] : entity[part];
-                    } else {
+                    if (isMissing) {
                         const allParts = path.reduce((result, p, i) => {
                             if (i === 0) {
                                 return [p];
@@ -228,7 +253,6 @@ export class EntityHydrator {
                             }
                         }, [] as string[]);
                         missingRelations.push(...allParts);
-                        entity = undefined;
                     }
                 }
             }


### PR DESCRIPTION
# Description

Fixes #4537.

`EntityHydrator.hydrate()` promises that the requested relations are populated, regardless of how the entity was loaded beforehand. It does not hold for array relations that are loaded unevenly.

`getMissingRelations()` walks each relation path with a single cursor, and descends into an array by sampling its first element:

```ts
entity = Array.isArray(entity[part]) ? entity[part][0] : entity[part];
```

So if `order.lines[0].productVariant` happens to be loaded, the whole `lines.productVariant` path is treated as present: nothing is reported missing, no query is issued, and `lines[1..n].productVariant` stay unloaded. As the reporter puts it, the assumption is _"Oh, we have 1 productVariant.product relation, the rest will be there as well"_ — which nothing actually guarantees, since the lines of an order need not have travelled the same loading path.

## The fix

Check **every** entity at each depth of the path rather than just the first, reporting the path as missing if any one of them lacks the relation.

This is the approach the sibling method `getRelationEntityAtPath()` in the same file already takes (`for (const item of target) { visit(item, ...) }`), after it was fixed for the same class of partial-array bug in #4661. This change brings `getMissingRelations()` in line with it.

Semantics deliberately kept unchanged:

- `null` (fetched, but null in the DB) is still terminal and is not reported missing; `undefined` (not fetched) is. The only difference is that a `null` now skips just that entity instead of abandoning the whole path, so a relation genuinely missing from a *sibling* of a `null` one is now detected.
- A loaded-but-empty array still reports deeper path segments as missing, exactly as before. Walking every element would have let us skip that (arguably wasted) query, but that is a behaviour change beyond this bug, so I left it alone and pinned it with tests.

# Breaking changes

None. Hydration now issues a query in cases where it previously (incorrectly) skipped one, so unevenly-loaded relations get populated instead of staying `undefined`. Fully-loaded arrays are unaffected and still short-circuit without a query — covered by a test.

# Testing

**Unit** (`entity-hydrator.service.spec.ts`, 8 new cases, no DB):

- 3 cover the bug itself (relation missing from a later array element, an intermediate relation missing, and a nested array-within-array).
- 2 cover the `null` semantics, including a relation missing from the sibling of a `null` one.
- 3 pin behaviour that must *not* change: a fully-loaded array still reports nothing, plus the two empty-array cases above. These pass both before and after the fix.

**e2e** (`entity-hydrator.e2e-spec.ts`, 1 new case): builds an order with two lines from different products (T_1 Laptop, T_5 Curvy Monitor), drops the `product` relation from the second line's variant to model the partially-populated tree plugin code sees, then hydrates and asserts both lines end up with their own correct product.

What I ran:

| | Result |
|---|---|
| `entity-hydrator.service.spec.ts` before the fix | 4 failed / 5 passed |
| `entity-hydrator.service.spec.ts` after | 9 passed |
| `entity-hydrator.e2e-spec.ts` before the fix | 1 failed / 24 passed (only the new case) |
| `entity-hydrator.e2e-spec.ts` after | 25 passed |
| Full core unit suite | 74 files, 1043 passed |
| Full core e2e suite | 101 files, 1947 passed, 2 failed |

The 2 e2e failures (`custom-fields > validation > invalid datetime` and `ErrorHandlerStrategy > invokes the worker handler`) are unrelated to this change and reproduce identically on a clean `master` with my changes stashed. Same for a pre-existing type error in `order.service.ts:1460` that stops `npm run build` locally.

### 🤖 AI assistance

I used Claude Code while working on this. I have reviewed every line of the change myself, and the testing table above reflects test runs I actually performed and observed — including verifying that each new test fails without the fix and passes with it.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786850217&installation_id=128408429&pr_number=4986&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4986&signature=a30b14b28201acf67eea9f6f1abe6a0f901e4ebee67dedad544de8d32311245a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->