### PR TITLE
perf(dev-server): Reduce agent dev startup builds

### DIFF
--- a/packages/dev-server/README.md
+++ b/packages/dev-server/README.md
@@ -41,8 +41,8 @@ uses:
 The Dashboard calls its matching worktree API directly. Browser sessions are isolated by the
 worktree-specific API hostname, while Docker resources and database data remain shared.
 
-Before starting any long-running process, `dev` builds the packages required by the dev server and
-creates a clean static Dashboard build in `packages/dev-server/dist/dashboard`. It then supervises:
+Before starting any long-running process, `dev` builds the package entry points required by the API
+and Dashboard Vite server. It then supervises:
 
 - the Vendure API server;
 - the Dashboard Vite development server;
@@ -52,8 +52,10 @@ creates a clean static Dashboard build in `packages/dev-server/dist/dashboard`. 
 Successful dependency rebuilds restart the process that loaded those compiled modules. Dashboard
 application changes continue to use Vite HMR.
 
-The server's `/dashboard` route remains available using the clean static build. For active Dashboard
-development, use the Portless Dashboard URL above.
+The workflow keeps the Dashboard backend plugin active for its API and settings features, but does
+not build or serve a second static Dashboard. Use the Portless Dashboard URL above. It also skips
+the standalone GraphiQL frontend. Running `dev:server` directly retains static Dashboard and
+GraphiQL serving for workflows that have already built their frontend assets.
 
 ### Agent-driven development
 
@@ -74,7 +76,6 @@ compilation and these endpoints respond successfully:
 
 - the API health endpoint;
 - the Dashboard Vite URL;
-- the server-served `/dashboard` URL.
 
 Watcher-triggered process restarts move the lifecycle back to `starting` until the restarted
 endpoint is accepting requests again.
@@ -94,7 +95,6 @@ The output has this shape:
     "worktreePath": "/path/to/worktree",
     "apiUrl": "https://fix-order-list.vendure.localhost",
     "dashboardUrl": "https://fix-order-list.dashboard.vendure.localhost/dashboard/",
-    "serverDashboardUrl": "https://fix-order-list.vendure.localhost/dashboard/",
     "statusFile": "/path/to/worktree/.vendure/dev-server.json"
 }
 ```

--- a/packages/dev-server/dev-config.ts
+++ b/packages/dev-server/dev-config.ts
@@ -18,16 +18,19 @@ import {
 } from '@vendure/core';
 import { DashboardPlugin } from '@vendure/dashboard/plugin';
 import { defaultEmailHandlers, EmailPlugin, FileBasedTemplateLoader } from '@vendure/email-plugin';
-import { GraphiqlPlugin } from '@vendure/graphiql-plugin';
-import { TelemetryPlugin } from '@vendure/telemetry-plugin';
 import 'dotenv/config';
+import { createRequire } from 'node:module';
 import path from 'path';
 import { DataSourceOptions } from 'typeorm';
+
 import { NavModifierPlugin } from './test-plugins/nav-modifier-plugin/nav-modifier-plugin';
 // import { FieldTestPlugin } from './test-plugins/field-test/field-test-plugin';
 import { ReviewsPlugin } from './test-plugins/reviews/reviews-plugin';
 
 const IS_INSTRUMENTED = process.env.IS_INSTRUMENTED === 'true';
+const SERVE_GRAPHIQL = process.env.VENDURE_SERVE_GRAPHIQL !== 'false';
+const SERVE_STATIC_DASHBOARD = process.env.VENDURE_SERVE_STATIC_DASHBOARD !== 'false';
+const loadPackage = createRequire(__filename);
 const dashboardUrl = process.env.VENDURE_DASHBOARD_URL || 'http://localhost:3000/dashboard';
 const dashboardAppDir =
     path.basename(__dirname) === 'dist'
@@ -128,7 +131,7 @@ export const devConfig: VendureConfig = {
         ReviewsPlugin,
         // FieldTestPlugin,
         NavModifierPlugin,
-        GraphiqlPlugin.init(),
+        ...(SERVE_GRAPHIQL ? [loadPackage('@vendure/graphiql-plugin').GraphiqlPlugin.init()] : []),
         AssetServerPlugin.init({
             route: 'assets',
             assetUploadDir: path.join(__dirname, 'assets'),
@@ -151,11 +154,13 @@ export const devConfig: VendureConfig = {
                 changeEmailAddressUrl: `${dashboardUrl}/change-email-address`,
             },
         }),
-        ...(IS_INSTRUMENTED ? [TelemetryPlugin.init({})] : []),
-        DashboardPlugin.init({
-            route: 'dashboard',
-            appDir: dashboardAppDir,
-        }),
+        ...(IS_INSTRUMENTED ? [loadPackage('@vendure/telemetry-plugin').TelemetryPlugin.init({})] : []),
+        SERVE_STATIC_DASHBOARD
+            ? DashboardPlugin.init({
+                  route: 'dashboard',
+                  appDir: dashboardAppDir,
+              })
+            : DashboardPlugin,
     ],
 };
 

--- a/packages/dev-server/scripts/dev-network-config.mjs
+++ b/packages/dev-server/scripts/dev-network-config.mjs
@@ -15,8 +15,9 @@ export function resolveDevelopmentNetwork({ mode, ensurePortlessProxy, getPortle
         apiOrigin,
         dashboardOrigin,
         dashboardUrl,
-        serverDashboardUrl: `${apiOrigin}/dashboard/`,
         sharedEnv: {
+            VENDURE_SERVE_GRAPHIQL: 'false',
+            VENDURE_SERVE_STATIC_DASHBOARD: 'false',
             VENDURE_DASHBOARD_URL: dashboardUrl,
             VITE_ADMIN_API_HOST: usePortless ? `${apiUrl.protocol}//${apiUrl.hostname}` : 'http://localhost',
             VITE_ADMIN_API_PORT: usePortless ? DASHBOARD_API_PORT_FROM_PAGE : '3000',

--- a/packages/dev-server/scripts/dev-network-config.spec.mjs
+++ b/packages/dev-server/scripts/dev-network-config.spec.mjs
@@ -27,6 +27,8 @@ test('does not duplicate a custom Portless proxy port in Dashboard API URLs', ()
 
     assert.equal(network.sharedEnv.VITE_ADMIN_API_HOST, 'https://vendure.localhost');
     assert.equal(network.sharedEnv.VITE_ADMIN_API_PORT, DASHBOARD_API_PORT_FROM_PAGE);
+    assert.equal(network.sharedEnv.VENDURE_SERVE_GRAPHIQL, 'false');
+    assert.equal(network.sharedEnv.VENDURE_SERVE_STATIC_DASHBOARD, 'false');
     assert.equal(
         getDashboardApiBaseUrl(network.sharedEnv, 'https://dashboard.vendure.localhost:1355'),
         'https://vendure.localhost:1355',

--- a/packages/dev-server/scripts/dev-status.mjs
+++ b/packages/dev-server/scripts/dev-status.mjs
@@ -75,7 +75,6 @@ function output(value) {
     if (value.apiUrl) {
         console.log(`API:              ${value.apiUrl}`);
         console.log(`Dashboard:        ${value.dashboardUrl}`);
-        console.log(`Server Dashboard: ${value.serverDashboardUrl}`);
     }
     console.log(`Status file:      ${value.statusFile}`);
     if (value.error) {

--- a/packages/dev-server/scripts/dev-workflow.mjs
+++ b/packages/dev-server/scripts/dev-workflow.mjs
@@ -1,5 +1,4 @@
 import { spawn, spawnSync } from 'node:child_process';
-import { rmSync } from 'node:fs';
 import { get as httpGet } from 'node:http';
 import { get as httpsGet } from 'node:https';
 import { createRequire } from 'node:module';
@@ -43,7 +42,6 @@ const {
     usePortless,
     apiOrigin,
     dashboardUrl,
-    serverDashboardUrl,
     sharedEnv: sharedDevelopmentEnv,
     serverEnv,
     dashboardEnv,
@@ -66,7 +64,6 @@ if (agentMode) {
                 mode,
                 apiUrl: apiOrigin,
                 dashboardUrl: `${dashboardUrl}/`,
-                serverDashboardUrl,
                 ...(process.env.DB ? { database: process.env.DB } : {}),
             },
         });
@@ -146,10 +143,7 @@ const server = new RestartableProcess({
     onRestarting: beginRestart,
     onRestarted: (_label, token) =>
         restartReadiness?.complete('server', token, () =>
-            Promise.all([
-                waitForHttp(`${apiOrigin}/health`, 'API health endpoint'),
-                waitForHttp(serverDashboardUrl, 'server-served Dashboard'),
-            ]),
+            waitForHttp(`${apiOrigin}/health`, 'API health endpoint'),
         ),
     onRestartFailure: handleReadinessFailure,
 });
@@ -284,9 +278,6 @@ async function buildPrerequisites(env) {
         ['@vendure/cli', path.join(repoRoot, 'packages/cli')],
         ['@vendure/asset-server-plugin', path.join(repoRoot, 'packages/asset-server-plugin')],
         ['@vendure/email-plugin', path.join(repoRoot, 'packages/email-plugin')],
-        ['@vendure/graphiql-plugin', path.join(repoRoot, 'packages/graphiql-plugin')],
-        ['@vendure/telemetry-plugin', path.join(repoRoot, 'packages/telemetry-plugin')],
-        ['@vendure/dashboard', path.join(repoRoot, 'packages/dashboard')],
     ];
 
     console.log('Building dev-server prerequisites...');
@@ -295,9 +286,19 @@ async function buildPrerequisites(env) {
         await runForeground(packageManager, ['run', '--cwd', cwd, 'build']);
     }
 
-    console.log('\nBuilding a clean server-served Dashboard...');
-    rmSync(path.join(devServerDir, 'dist'), { recursive: true, force: true });
-    await runForeground(packageManager, ['run', 'build:dashboard'], env);
+    console.log('\nBuilding the Dashboard Vite plugin...');
+    await runForeground(
+        packageManager,
+        ['run', '--cwd', path.join(repoRoot, 'packages/dashboard'), 'build:vite'],
+        env,
+    );
+
+    console.log('\nBuilding the Dashboard server plugin...');
+    await runForeground(
+        packageManager,
+        ['run', '--cwd', path.join(repoRoot, 'packages/dashboard'), 'build:plugin'],
+        env,
+    );
 }
 
 function runForeground(command, args, env = {}) {
@@ -408,7 +409,6 @@ async function waitForReadiness(activeWatchers) {
         ...activeWatchers.map(watcher => watcher.ready),
         waitForHttp(`${apiOrigin}/health`, 'API health endpoint'),
         waitForHttp(`${dashboardUrl}/`, 'Dashboard Vite server'),
-        waitForHttp(serverDashboardUrl, 'server-served Dashboard'),
     ]);
 }
 


### PR DESCRIPTION
# Description

Reduces `dev:agent` startup work to the artifacts required for the API server and Vite Dashboard. The workflow no longer builds or serves a duplicate static Dashboard, GraphiQL frontend, or telemetry plugin, while keeping the Dashboard backend plugin active for its GraphQL and settings features. Validated with PostgreSQL: the agent lifecycle reached ready, both HTTP endpoints returned 200, and Admin API introspection included `dashboardMetricSummary`. No related issue.

# Breaking changes

No breaking changes.

# Screenshots

Not applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed
