### PR TITLE
fix(dashboard): search product variants by name or SKU in relation selectors

### DIFF
--- a/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/default-relation-input.tsx
@@ -192,6 +192,9 @@ const createEntityConfigs = (i18n: any) => ({
 
     ProductVariant: createRelationSelectorConfig({
         ...createBaseEntityConfig('Product Variant', i18n),
+        buildSearchFilter: (term: string) => ({
+            _or: [{ name: { contains: term } }, { sku: { contains: term } }],
+        }),
         listQuery: graphql(`
             query GetProductVariantsForRelationSelector($options: ProductVariantListOptions) {
                 productVariants(options: $options) {


### PR DESCRIPTION
# Description

Product variant relation selectors (promotions, etc.) now search by **name or SKU**, using the same `_or` filter pattern as administrator search. Before this, typing a SKU often returned nothing.

# Breaking changes

Nope!

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4990"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786868750&installation_id=128408429&pr_number=4990&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4990&signature=7a00439e4c3bf683517087eb8e9e89d0167c6bd98454be03d8640838852faf02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->