### PR TITLE
refactor(dashboard): make data table views opt-in

### DIFF
--- a/docs/docs/reference/dashboard/list-views/data-table.mdx
+++ b/docs/docs/reference/dashboard/list-views/data-table.mdx
@@ -45,7 +45,7 @@ interface DataTableProps<TData> {
     defaultColumnVisibility?: VisibilityState;
     facetedFilters?: { [key: string]: FacetedFilter | undefined };
     disableViewOptions?: boolean;
-    hideViewsControls?: boolean;
+    enableViews?: boolean;
     bulkActions?: BulkActionsInput;
     setTableOptions?: (table: TableOptions<TData>) => TableOptions<TData>;
     onRefresh?: () => void;
@@ -152,15 +152,14 @@ e.g. "Search products...". Defaults to a generic "Search...".
 <MemberInfo kind="property" type={`boolean`}   />
 
 
-### hideViewsControls
+### enableViews
 
-<MemberInfo kind="property" type={`boolean`}  since="3.8.0"  />
+<MemberInfo kind="property" type={`boolean`} default={`false`}  since="3.8.0"  />
 
-When true, suppresses the saved-views tabs even when a page context and
-filter handler are present. Useful for tables embedded in a detail page,
-where saved views (keyed only by page id and block id) would otherwise be
-shared across every entity showing that block. Filtering and column
-customization are unaffected.
+Enables saved-view controls for this table. This should be used for tables
+which represent a whole data set, such as top-level list pages. It should
+not be enabled for embedded tables or tables whose query is already scoped
+by a predefined filter.
 ### bulkActions
 
 <MemberInfo kind="property" type={`<a href='/reference/dashboard/list-views/bulk-actions#bulkactionsinput'>BulkActionsInput</a>`}   />

--- a/docs/docs/reference/dashboard/list-views/paginated-list-data-table.mdx
+++ b/docs/docs/reference/dashboard/list-views/paginated-list-data-table.mdx
@@ -149,7 +149,7 @@ interface PaginatedListDataTableProps<T extends TypedDocumentNode<U, V>, U exten
     rowActions?: RowAction<PaginatedListItemFields<T>>[];
     bulkActions?: BulkActionsInput;
     disableViewOptions?: boolean;
-    hideViewsControls?: boolean;
+    enableViews?: boolean;
     transformData?: (data: PaginatedListItemFields<T>[]) => PaginatedListItemFields<T>[];
     setTableOptions?: (table: TableOptions<any>) => TableOptions<any>;
     registerRefresher?: PaginatedListRefresherRegisterFn;
@@ -290,15 +290,14 @@ widgets) that apply preset filters via `transformVariables`.
 <MemberInfo kind="property" type={`boolean`}   />
 
 
-### hideViewsControls
+### enableViews
 
-<MemberInfo kind="property" type={`boolean`}  since="3.8.0"  />
+<MemberInfo kind="property" type={`boolean`} default={`false`}  since="3.8.0"  />
 
-When true, suppresses the saved-views tabs even when a page context and
-filter handler are present. Useful for tables embedded in a detail page,
-where saved views (keyed only by page id and block id) would otherwise be
-shared across every entity showing that block. Filtering and column
-customization are unaffected.
+Enables saved-view controls for this table. This should be used for tables
+which represent a whole data set, such as top-level list pages. It should
+not be enabled for embedded tables or tables whose query is already scoped
+by a predefined filter.
 ### transformData
 
 <MemberInfo kind="property" type={`(data: PaginatedListItemFields<T>[]) => PaginatedListItemFields<T>[]`}   />

--- a/packages/dashboard/e2e/tests/catalog/collections.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/collections.spec.ts
@@ -555,9 +555,9 @@ test.describe('Collection tree toggles, search subtitles & detail breadcrumb', (
         await expect(page.locator('[data-slot="breadcrumb-link"][href^="/collections/"]')).toHaveCount(1);
     });
 
-    // The embedded contents table suppresses the saved-views tabs but keeps its
-    // own search control.
-    test('collection contents table hides saved-views tabs but keeps filtering', async ({ page }) => {
+    // The embedded contents table does not opt into saved views but keeps its own
+    // search control.
+    test('collection contents table omits saved-views tabs but keeps filtering', async ({ page }) => {
         await page.goto(`/collections/${parentId}`);
         await expect(page.getByRole('heading', { name: PARENT_NAME })).toBeVisible({ timeout: 10_000 });
 

--- a/packages/dashboard/e2e/tests/catalog/facets.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/facets.spec.ts
@@ -283,14 +283,14 @@ test.describe('Facet list & detail improvements', () => {
         await expect(smallRow.getByRole('button', { name: /more/i })).toHaveCount(0);
     });
 
-    // The embedded facet-values table on the detail page suppresses the saved-views
-    // tabs but keeps its filter controls working.
-    test('facet detail values table hides saved-views tabs and still filters', async ({ page }) => {
+    // The embedded facet-values table on the detail page does not opt into saved
+    // views, but keeps its filter controls working.
+    test('facet detail values table omits saved-views tabs and still filters', async ({ page }) => {
         await page.goto(`/facets/${bigFacetId}`);
         await expect(page.getByText('Facet values', { exact: true })).toBeVisible({ timeout: 10_000 });
         await expect(page.locator('table tbody tr').first()).toBeVisible({ timeout: 10_000 });
 
-        // Embedded table suppresses the saved-views tabs…
+        // Embedded table does not render the opt-in saved-views tabs…
         await expect(page.getByTestId('dt-views-tabs')).toHaveCount(0);
         // …but keeps its search control: filtering narrows the rows.
         const search = page.getByRole('textbox', { name: /Search facet values/i });

--- a/packages/dashboard/e2e/tests/catalog/products.spec.ts
+++ b/packages/dashboard/e2e/tests/catalog/products.spec.ts
@@ -169,13 +169,13 @@ test.describe('Product detail features', () => {
 
     // Saved views are keyed by page id + block id only, so a view saved on one
     // product's embedded variants table would leak onto every other product. The
-    // embedded table therefore hides the views tabs (via `hideViewsControls`)
-    // while keeping filtering and column customization intact.
+    // embedded table therefore does not opt into views, while keeping filtering
+    // and column customization intact.
     // Note: the e2e fixture doesn't register the DashboardPlugin settings-store
     // fields, so saved-views tabs never render in this environment regardless;
     // the observable guarantees here are that filtering and column customization
     // controls remain, and the views-tabs assertion guards against regressions.
-    test('embedded variants table hides views tabs but keeps filter and column controls', async ({
+    test('embedded variants table omits views tabs but keeps filter and column controls', async ({
         page,
     }) => {
         // Navigate to the seeded "Laptop" product which has variants

--- a/packages/dashboard/src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx
@@ -120,7 +120,6 @@ export function CollectionContentsPreviewTable({
             {hasFilters && (
                 <PaginatedListDataTable
                     title={title}
-                    hideViewsControls
                     listQuery={addCustomFields(previewCollectionContentsDocument)}
                     transformQueryKey={queryKey => {
                         return [...queryKey, JSON.stringify(effectiveFilters), inheritFilters];

--- a/packages/dashboard/src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx
@@ -40,7 +40,6 @@ export function CollectionContentsTable({ collectionId, title }: Readonly<Collec
     return (
         <PaginatedListDataTable
             title={title}
-            hideViewsControls
             listQuery={addCustomFields(collectionContentsDocument)}
             transformVariables={variables => {
                 return {

--- a/packages/dashboard/src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_facets/components/facet-values-table.tsx
@@ -58,7 +58,6 @@ export function FacetValuesTable({ facetId, registerRefresher, title }: Readonly
     return (
         <PaginatedListDataTable
             title={title}
-            hideViewsControls
             actions={
                 <Button render={<Link to={`/facets/${facetId}/values/new`} />} variant="outline" size="sm">
                     <PlusIcon />

--- a/packages/dashboard/src/app/routes/_authenticated/_products/components/product-variants-table.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/components/product-variants-table.tsx
@@ -22,7 +22,6 @@ import { productVariantListDocument } from '../products.graphql.js';
 interface ProductVariantsTableProps {
     productId: string;
     registerRefresher?: PaginatedListRefresherRegisterFn;
-    fromProductDetailPage?: boolean;
     title?: ReactNode;
     actions?: ReactNode;
 }
@@ -30,7 +29,6 @@ interface ProductVariantsTableProps {
 export function ProductVariantsTable({
     productId,
     registerRefresher,
-    fromProductDetailPage,
     title,
     actions,
 }: ProductVariantsTableProps) {
@@ -47,7 +45,6 @@ export function ProductVariantsTable({
         <PaginatedListDataTable
             title={title}
             actions={actions}
-            hideViewsControls={fromProductDetailPage}
             registerRefresher={registerRefresher}
             listQuery={productVariantListDocument}
             transformVariables={variables => ({

--- a/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_products/products_.$id.tsx
@@ -284,7 +284,6 @@ function ProductDetailPage() {
                             registerRefresher={refresher => {
                                 refreshRef.current = refresher;
                             }}
-                            fromProductDetailPage={true}
                             title={<Trans>Product variants</Trans>}
                             actions={
                                 <Button render={<Link to="./variants" />} variant="outline" size="sm">

--- a/packages/dashboard/src/app/routes/_authenticated/_system/settings-store.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_system/settings-store.tsx
@@ -226,6 +226,105 @@ function formatDisplayValue(value: any): string {
     return String(value);
 }
 
+function matchesStringFilter(value: string, filter: Record<string, unknown>): boolean {
+    return Object.entries(filter).every(([operator, operand]) => {
+        switch (operator) {
+            case 'eq':
+                return value === operand;
+            case 'notEq':
+                return value !== operand;
+            case 'contains':
+                return value.includes(String(operand));
+            case 'notContains':
+                return !value.includes(String(operand));
+            case 'in':
+                return Array.isArray(operand) && operand.includes(value);
+            case 'notIn':
+                return Array.isArray(operand) && !operand.includes(value);
+            case 'regex':
+                try {
+                    return new RegExp(String(operand)).test(value);
+                } catch {
+                    return false;
+                }
+            case 'isNull':
+                return operand === false;
+            default:
+                return true;
+        }
+    });
+}
+
+export function filterSettingsStoreFields(
+    fields: FieldDefinition[],
+    search: string,
+    columnFilters: ColumnFilter[],
+) {
+    return fields.filter(field => {
+        if (search && !field.key.toLowerCase().includes(search.toLowerCase())) return false;
+        for (const filter of columnFilters) {
+            if (
+                filter.id === 'key' &&
+                !matchesStringFilter(field.key, filter.value as Record<string, unknown>)
+            ) {
+                return false;
+            }
+            const values = filter.value as string[];
+            if (!values?.length) continue;
+            if (filter.id === 'scopeType' && !values.includes(field.scopeType)) return false;
+            if (filter.id === 'readonly' && !values.includes(String(field.readonly))) return false;
+        }
+        return true;
+    });
+}
+
+export function createSettingsStoreColumns(
+    labels: { key: string; value: string; scope: string; readonly: string },
+    onSetValue: (field: FieldDefinition, value: any) => void,
+) {
+    const columnHelper = createColumnHelper<FieldDefinition>();
+    return [
+        columnHelper.accessor('key', {
+            header: labels.key,
+            meta: { fieldInfo: { type: 'String' } },
+            cell: ({ row }) => (
+                <CopyableText value={row.original.key}>
+                    <code className="text-xs">{row.original.key}</code>
+                </CopyableText>
+            ),
+        }),
+        columnHelper.accessor('currentValue', {
+            header: labels.value,
+            enableColumnFilter: false,
+            cell: ({ row }) => (
+                <ValueCell
+                    field={row.original}
+                    onSave={newValue => onSetValue(row.original, newValue)}
+                />
+            ),
+        }),
+        columnHelper.accessor('scopeType', {
+            header: labels.scope,
+            enableColumnFilter: false,
+            cell: ({ row }) => (
+                <Badge variant={scopeBadgeVariant[row.original.scopeType] ?? 'outline'}>
+                    {row.original.scopeType}
+                </Badge>
+            ),
+        }),
+        columnHelper.accessor('readonly', {
+            header: labels.readonly,
+            enableColumnFilter: false,
+            cell: ({ row }) =>
+                row.original.readonly ? (
+                    <Badge variant="default">
+                        <Trans>Readonly</Trans>
+                    </Badge>
+                ) : null,
+        }),
+    ];
+}
+
 function SettingsStorePage() {
     const { t } = useLingui();
     const [search, setSearch] = useState('');
@@ -252,59 +351,23 @@ function SettingsStorePage() {
     });
 
     const allFields = data?.settingsStoreFieldDefinitions ?? [];
-    const filteredFields = allFields.filter(f => {
-        if (search && !f.key.toLowerCase().includes(search.toLowerCase())) return false;
-        for (const filter of columnFilters) {
-            const values = filter.value as string[];
-            if (!values?.length) continue;
-            if (filter.id === 'scopeType' && !values.includes(f.scopeType)) return false;
-            if (filter.id === 'readonly' && !values.includes(String(f.readonly))) return false;
-        }
-        return true;
-    });
+    const filteredFields = filterSettingsStoreFields(allFields, search, columnFilters);
 
-    const columnHelper = createColumnHelper<FieldDefinition>();
     const columns = useMemo(
-        () => [
-            columnHelper.accessor('key', {
-                header: t`Key`,
-                cell: ({ row }) => (
-                    <CopyableText value={row.original.key}>
-                        <code className="text-xs">{row.original.key}</code>
-                    </CopyableText>
-                ),
-            }),
-            columnHelper.accessor('currentValue', {
-                header: t`Value`,
-                cell: ({ row }) => (
-                    <ValueCell
-                        field={row.original}
-                        onSave={newValue =>
-                            setValue({
-                                input: { key: row.original.key, value: newValue },
-                            })
-                        }
-                    />
-                ),
-            }),
-            columnHelper.accessor('scopeType', {
-                header: t`Scope`,
-                cell: ({ row }) => (
-                    <Badge variant={scopeBadgeVariant[row.original.scopeType] ?? 'outline'}>
-                        {row.original.scopeType}
-                    </Badge>
-                ),
-            }),
-            columnHelper.accessor('readonly', {
-                header: t`Readonly`,
-                cell: ({ row }) =>
-                    row.original.readonly ? (
-                        <Badge variant="default">
-                            <Trans>Readonly</Trans>
-                        </Badge>
-                    ) : null,
-            }),
-        ],
+        () =>
+            createSettingsStoreColumns(
+                {
+                    key: t`Key`,
+                    value: t`Value`,
+                    scope: t`Scope`,
+                    readonly: t`Readonly`,
+                },
+                (field, newValue) => {
+                    setValue({
+                        input: { key: field.key, value: newValue },
+                    });
+                },
+            ),
         [t, setValue],
     );
 
@@ -316,6 +379,7 @@ function SettingsStorePage() {
             <PageLayout>
                 <FullWidthPageBlock blockId="list-table">
                     <DataTable
+                        enableViews
                         onRefresh={invalidateFieldDefinitions}
                         searchPlaceholder={t`Search entries...`}
                         onSearchTermChange={setSearch}

--- a/packages/dashboard/src/app/routes/_authenticated/_system/utils/settings-store-columns.spec.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_system/utils/settings-store-columns.spec.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { createSettingsStoreColumns, filterSettingsStoreFields } from '../settings-store.js';
+
+describe('Settings Store filters', () => {
+    it('renders a label for every table header', () => {
+        const labels = { key: 'Key', value: 'Value', scope: 'Scope', readonly: 'Readonly' };
+        const columns = createSettingsStoreColumns(labels, vi.fn());
+
+        expect(columns.map(column => column.header)).toEqual(['Key', 'Value', 'Scope', 'Readonly']);
+    });
+
+    it('configures only supported generic column filters', () => {
+        const labels = { key: 'Key', value: 'Value', scope: 'Scope', readonly: 'Readonly' };
+        const columns = createSettingsStoreColumns(labels, vi.fn());
+        const [key, currentValue, scopeType, readonly] = columns;
+
+        expect(key.meta).toMatchObject({ fieldInfo: { type: 'String' } });
+        expect(currentValue.enableColumnFilter).toBe(false);
+        expect(scopeType.enableColumnFilter).toBe(false);
+        expect(readonly.enableColumnFilter).toBe(false);
+    });
+
+    it('applies a saved key filter to the settings data', () => {
+        const fields = [
+            { key: 'system.api-key', scopeType: 'GLOBAL', readonly: false, currentValue: null },
+            { key: 'dashboard.table-settings', scopeType: 'USER', readonly: false, currentValue: null },
+        ] as any;
+
+        expect(
+            filterSettingsStoreFields(fields, '', [{ id: 'key', value: { contains: 'dashboard' } }]),
+        ).toEqual([fields[1]]);
+    });
+});

--- a/packages/dashboard/src/i18n/locales/ar.po
+++ b/packages/dashboard/src/i18n/locales/ar.po
@@ -345,7 +345,7 @@ msgstr "هل أنت متأكد من حذف هذا الشكل؟"
 msgid "Failed to create administrator"
 msgstr "فشل في إنشاء المسؤول"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "لا"
@@ -469,8 +469,8 @@ msgstr "إعادة للمخزون"
 msgid "Visibility"
 msgstr "الرؤية"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "متغيرات المنتج"
 
@@ -964,7 +964,7 @@ msgstr "تمت إزالة بند الطلب"
 msgid "Content:"
 msgstr "المحتوى:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "المفتاح"
 
@@ -1195,8 +1195,8 @@ msgstr "طلب مسودة"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "أدخل عنوان بريدك الإلكتروني وسنرسل لك رابطًا لإعادة تعيين كلمة المرور"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "النطاق"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "تغيير حجم الصورة من اليمين"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "متجر الإعدادات"
 
@@ -2182,9 +2182,9 @@ msgstr "فشل تحديث الملاحظة"
 msgid "Refund shipping"
 msgstr "استرداد الشحن"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "للقراءة فقط"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "اختبار طريقة الشحن"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "قيم الخصائص"
 
@@ -2891,11 +2891,11 @@ msgstr "إعادة حساب الشحن"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "الملفات"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "سيؤدي هذا إلى إزالة جميع مجموعات الخيارات من هذا المنتج والعودة إلى اختيار إعداد المتغيرات."
 
@@ -2905,7 +2905,7 @@ msgstr "سيؤدي هذا إلى إزالة جميع مجموعات الخيار
 msgid "Billing address"
 msgstr "عنوان الفوترة"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "إضافة قيمة خاصية"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "تم إنشاء المسؤول بنجاح"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "خيارات المنتج"
 
@@ -3599,7 +3599,7 @@ msgstr "اسحب لإعادة الترتيب"
 msgid "Zones"
 msgstr "المناطق"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "طرق الشحن"
 msgid "Select an address"
 msgstr "حدد عنوانًا"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "نعم"
@@ -3792,7 +3792,7 @@ msgstr "تسوية الدفع"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "إجمالي الضريبة"
 msgid "Draft order status"
 msgstr "حالة طلب المسودة"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "البحث في الأشكال..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "النظام"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "اسم المتغير"
 
@@ -5514,7 +5514,7 @@ msgstr "إزالة"
 msgid "Failed to update customer"
 msgstr "فشل تحديث العميل"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "إزالة مجموعات الخيارات؟"
 
@@ -5925,7 +5925,7 @@ msgstr "العناصر المنفذة ({0})"
 msgid "Create your first product"
 msgstr "أنشئ منتجك الأول"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "تم تحديث القيمة"
 
@@ -6162,7 +6162,7 @@ msgstr "جرّب تحديد نطاق تاريخ مختلف."
 msgid "Successfully created zone"
 msgstr "تم إنشاء المنطقة بنجاح"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "القيمة"
 
@@ -6299,7 +6299,7 @@ msgstr "معرف الاسترداد"
 msgid "Order custom fields updated"
 msgstr "تم تحديث الحقول المخصصة للطلب"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "البحث في الإدخالات..."
 
@@ -6703,7 +6703,7 @@ msgstr "حد نفاد المخزون"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "تمت إزالة المنتج من القناة بنجاح"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "فشل في تحديث القيمة"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "فشل إضافة العميل إلى المجموعة"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "إدارة الأشكال"
 

--- a/packages/dashboard/src/i18n/locales/bg.po
+++ b/packages/dashboard/src/i18n/locales/bg.po
@@ -348,7 +348,7 @@ msgstr "Сигурни ли сте, че искате да изтриете то
 msgid "Failed to create administrator"
 msgstr "Неуспешно създаване на администратор"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Не"
@@ -475,8 +475,8 @@ msgstr "Върни в наличност"
 msgid "Visibility"
 msgstr "Видимост"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Варианти на продукта"
 
@@ -970,7 +970,7 @@ msgstr "Редът за поръчка е премахнат"
 msgid "Content:"
 msgstr "Съдържание:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Ключ"
 
@@ -1201,8 +1201,8 @@ msgstr "Чернова на поръчка"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Въведете имейл адреса си и ще ви изпратим връзка за нулиране на паролата"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Обхват"
 
@@ -1333,7 +1333,7 @@ msgid "Resize image from right"
 msgstr "Преоразмери изображението отдясно"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Настройки на магазина"
 
@@ -2200,9 +2200,9 @@ msgstr "Актуализирането на бележката не бе усп�
 msgid "Refund shipping"
 msgstr "Възстанови доставка"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Само за четене"
 
@@ -2219,7 +2219,7 @@ msgid "Test Shipping Method"
 msgstr "Тестване на метод за доставка"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Атрибутни стойности"
 
@@ -2908,11 +2908,11 @@ msgstr "Преизчисляване на доставката"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Медия"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Това ще премахне всички групи опции от този продукт и ще се върне към избора за настройка на варианти."
 
@@ -2922,7 +2922,7 @@ msgstr "Това ще премахне всички групи опции от �
 msgid "Billing address"
 msgstr "Адрес за фактуриране"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Добавете стойност на аспекта"
@@ -3034,7 +3034,7 @@ msgid "Successfully created administrator"
 msgstr "Успешно създаден администратор"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Опции на продукта"
 
@@ -3619,7 +3619,7 @@ msgstr "Плъзнете, за да пренаредите"
 msgid "Zones"
 msgstr "Зони"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3730,7 +3730,7 @@ msgstr "Методи за доставка"
 msgid "Select an address"
 msgstr "Изберете адрес"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Да"
@@ -3812,7 +3812,7 @@ msgstr "Приклюи плащане"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3943,8 +3943,8 @@ msgstr "Данък общо"
 msgid "Draft order status"
 msgstr "Статус на чернова на поръчка"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Търсене на варианти..."
 
@@ -5529,7 +5529,7 @@ msgid "System"
 msgstr "Система"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Име на варианта"
 
@@ -5543,7 +5543,7 @@ msgstr "Премахнете"
 msgid "Failed to update customer"
 msgstr "Неуспешно актуализиране на клиента"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Премахване на групи опции?"
 
@@ -5957,7 +5957,7 @@ msgstr "Изпълнени елементи ({0})"
 msgid "Create your first product"
 msgstr "Създайте първия си продукт"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Стойността е актуализирана"
 
@@ -6194,7 +6194,7 @@ msgstr "Опитайте да изберете друг период от вре
 msgid "Successfully created zone"
 msgstr "Успешно създадена зона"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Стойност"
 
@@ -6331,7 +6331,7 @@ msgstr "ID за възстановяване"
 msgid "Order custom fields updated"
 msgstr "Персонализираните полета на поръчката са актуализирани"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Търсене на записи..."
 
@@ -6740,7 +6740,7 @@ msgstr "Праг за изчерпани количества"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Продуктът е премахнат успешно от канала"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Неуспешно актуализиране на стойност"
 
@@ -6764,7 +6764,7 @@ msgid "Failed to add customer to group"
 msgstr "Неуспешно добавяне на клиент към групата"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Управление на варианти"
 

--- a/packages/dashboard/src/i18n/locales/cs.po
+++ b/packages/dashboard/src/i18n/locales/cs.po
@@ -345,7 +345,7 @@ msgstr "Opravdu chcete smazat tuto variantu?"
 msgid "Failed to create administrator"
 msgstr "Vytvoření administrátora se nezdařilo"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Ne"
@@ -469,8 +469,8 @@ msgstr "Vrátit na sklad"
 msgid "Visibility"
 msgstr "Viditelnost"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Varianty produktu"
 
@@ -964,7 +964,7 @@ msgstr "Řádek objednávky odebrán"
 msgid "Content:"
 msgstr "Obsah:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Klíč"
 
@@ -1195,8 +1195,8 @@ msgstr "Koncept objednávky"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Zadejte svou e-mailovou adresu a my vám zašleme odkaz pro obnovení hesla"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Rozsah"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Změnit velikost obrázku zprava"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Nastavení obchodu"
 
@@ -2182,9 +2182,9 @@ msgstr "Nepodařilo se aktualizovat poznámku"
 msgid "Refund shipping"
 msgstr "Vrátit dopravu"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Pouze pro čtení"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Testovat způsob dopravy"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Hodnoty vlastností"
 
@@ -2891,11 +2891,11 @@ msgstr "Přepočítat dopravu"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Soubory"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Tímto se odeberou všechny skupiny voleb z tohoto produktu a vrátíte se k výběru nastavení variant."
 
@@ -2905,7 +2905,7 @@ msgstr "Tímto se odeberou všechny skupiny voleb z tohoto produktu a vrátíte 
 msgid "Billing address"
 msgstr "Fakturační adresa"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Přidat hodnotu vlastnosti"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Administrátor byl úspěšně vytvořen"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Volby produktu"
 
@@ -3599,7 +3599,7 @@ msgstr "Přetažením změnit pořadí"
 msgid "Zones"
 msgstr "Zóny"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Způsoby dopravy"
 msgid "Select an address"
 msgstr "Vyberte adresu"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Ano"
@@ -3792,7 +3792,7 @@ msgstr "Vypořádat platbu"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Celková daň"
 msgid "Draft order status"
 msgstr "Stav konceptu objednávky"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Hledat varianty..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "Systém"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Název varianty"
 
@@ -5514,7 +5514,7 @@ msgstr "Odebrat"
 msgid "Failed to update customer"
 msgstr "Nepodařilo se aktualizovat zákazníka"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Odebrat skupiny voleb?"
 
@@ -5925,7 +5925,7 @@ msgstr "Expedované položky ({0})"
 msgid "Create your first product"
 msgstr "Vytvořte svůj první produkt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Hodnota aktualizována"
 
@@ -6162,7 +6162,7 @@ msgstr "Zkuste vybrat jiné časové období."
 msgid "Successfully created zone"
 msgstr "Zóna úspěšně vytvořena"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Hodnota"
 
@@ -6299,7 +6299,7 @@ msgstr "ID refundu"
 msgid "Order custom fields updated"
 msgstr "Vlastní pole objednávky aktualizována"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Hledat záznamy..."
 
@@ -6703,7 +6703,7 @@ msgstr "Práh vyprodání"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produkt byl úspěšně odstraněn z kanálu"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Nepodařilo se aktualizovat hodnotu"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Nepodařilo se přidat zákazníka do skupiny"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Spravovat varianty"
 

--- a/packages/dashboard/src/i18n/locales/de.po
+++ b/packages/dashboard/src/i18n/locales/de.po
@@ -345,7 +345,7 @@ msgstr "Möchten Sie diese Variante wirklich löschen?"
 msgid "Failed to create administrator"
 msgstr "Administrator konnte nicht erstellt werden"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Nein"
@@ -469,8 +469,8 @@ msgstr "Zurück auf Lager"
 msgid "Visibility"
 msgstr "Sichtbarkeit"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Produktvarianten"
 
@@ -964,7 +964,7 @@ msgstr "Bestellzeile entfernt"
 msgid "Content:"
 msgstr "Inhalt:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Schlüssel"
 
@@ -1195,8 +1195,8 @@ msgstr "Entwurfsbestellung"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Geben Sie Ihre E-Mail-Adresse ein und wir senden Ihnen einen Link zum Zurücksetzen Ihres Passworts"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Geltungsbereich"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Bildgröße von rechts ändern"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Einstellungsspeicher"
 
@@ -2182,9 +2182,9 @@ msgstr "Fehler beim Aktualisieren der Notiz"
 msgid "Refund shipping"
 msgstr "Versand erstatten"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Schreibgeschützt"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Versandmethode testen"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Facetten-Werte"
 
@@ -2891,11 +2891,11 @@ msgstr "Versand neu berechnen"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Assets"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Dadurch werden alle Optionsgruppen von diesem Produkt entfernt und Sie kehren zur Varianteneinrichtung zurück."
 
@@ -2905,7 +2905,7 @@ msgstr "Dadurch werden alle Optionsgruppen von diesem Produkt entfernt und Sie k
 msgid "Billing address"
 msgstr "Rechnungsadresse"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Facettenwert hinzufügen"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Administrator erfolgreich erstellt"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Produktoptionen"
 
@@ -3599,7 +3599,7 @@ msgstr "Zum Sortieren ziehen"
 msgid "Zones"
 msgstr "Zonen"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Versandmethoden"
 msgid "Select an address"
 msgstr "Eine Adresse auswählen"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Ja"
@@ -3792,7 +3792,7 @@ msgstr "Zahlung abwickeln"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Steuersumme"
 msgid "Draft order status"
 msgstr "Status des Bestellentwurfs"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Varianten suchen..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "System"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Variantenname"
 
@@ -5514,7 +5514,7 @@ msgstr "Entfernen"
 msgid "Failed to update customer"
 msgstr "Fehler beim Aktualisieren des Kunden"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Optionsgruppen entfernen?"
 
@@ -5925,7 +5925,7 @@ msgstr "Erfüllte Artikel ({0})"
 msgid "Create your first product"
 msgstr "Erstellen Sie Ihr erstes Produkt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Wert aktualisiert"
 
@@ -6162,7 +6162,7 @@ msgstr "Versuchen Sie, einen anderen Zeitraum auszuwählen."
 msgid "Successfully created zone"
 msgstr "Zone erfolgreich erstellt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Wert"
 
@@ -6299,7 +6299,7 @@ msgstr "Rückerstattungs-ID"
 msgid "Order custom fields updated"
 msgstr "Benutzerdefinierte Bestellfelder aktualisiert"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Einträge suchen..."
 
@@ -6703,7 +6703,7 @@ msgstr "Grenzwert für Lagerausfall"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produkt erfolgreich aus Kanal entfernt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Wert konnte nicht aktualisiert werden"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Fehler beim Hinzufügen des Kunden zur Gruppe"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Varianten verwalten"
 

--- a/packages/dashboard/src/i18n/locales/en.po
+++ b/packages/dashboard/src/i18n/locales/en.po
@@ -345,7 +345,7 @@ msgstr "Are you sure you want to delete this variant?"
 msgid "Failed to create administrator"
 msgstr "Failed to create administrator"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "No"
@@ -469,8 +469,8 @@ msgstr "Return to stock"
 msgid "Visibility"
 msgstr "Visibility"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Product variants"
 
@@ -964,7 +964,7 @@ msgstr "Order line removed"
 msgid "Content:"
 msgstr "Content:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Key"
 
@@ -1195,8 +1195,8 @@ msgstr "Draft order"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Enter your email address and we will send you a link to reset your password"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Scope"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Resize image from right"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Settings Store"
 
@@ -2182,9 +2182,9 @@ msgstr "Failed to update note"
 msgid "Refund shipping"
 msgstr "Refund shipping"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Readonly"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Test Shipping Method"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Facet Values"
 
@@ -2891,11 +2891,11 @@ msgstr "Recalculate shipping"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Assets"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "This will remove all option groups from this product and return to the variant setup choice."
 
@@ -2905,7 +2905,7 @@ msgstr "This will remove all option groups from this product and return to the v
 msgid "Billing address"
 msgstr "Billing address"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Add facet value"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Successfully created administrator"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Product Options"
 
@@ -3599,7 +3599,7 @@ msgstr "Drag to reorder"
 msgid "Zones"
 msgstr "Zones"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Shipping Methods"
 msgid "Select an address"
 msgstr "Select an address"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Yes"
@@ -3792,7 +3792,7 @@ msgstr "Settle payment"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Tax total"
 msgid "Draft order status"
 msgstr "Draft order status"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Search variants..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "System"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Variant name"
 
@@ -5514,7 +5514,7 @@ msgstr "Remove"
 msgid "Failed to update customer"
 msgstr "Failed to update customer"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Remove option groups?"
 
@@ -5925,7 +5925,7 @@ msgstr "Fulfilled items ({0})"
 msgid "Create your first product"
 msgstr "Create your first product"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Value updated"
 
@@ -6162,7 +6162,7 @@ msgstr "Try selecting a different date range."
 msgid "Successfully created zone"
 msgstr "Successfully created zone"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Value"
 
@@ -6299,7 +6299,7 @@ msgstr "Refund ID"
 msgid "Order custom fields updated"
 msgstr "Order custom fields updated"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Search entries..."
 
@@ -6703,7 +6703,7 @@ msgstr "Out-of-stock threshold"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Successfully removed product from channel"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Failed to update value"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Failed to add customer to group"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Manage variants"
 

--- a/packages/dashboard/src/i18n/locales/es.po
+++ b/packages/dashboard/src/i18n/locales/es.po
@@ -345,7 +345,7 @@ msgstr "¿Está seguro de que desea eliminar esta variante?"
 msgid "Failed to create administrator"
 msgstr "Error al crear el administrador"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "No"
@@ -469,8 +469,8 @@ msgstr "Devolver al stock"
 msgid "Visibility"
 msgstr "Visibilidad"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Variantes de producto"
 
@@ -964,7 +964,7 @@ msgstr "Línea de pedido eliminada"
 msgid "Content:"
 msgstr "Contenido:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Clave"
 
@@ -1195,8 +1195,8 @@ msgstr "Pedido borrador"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Ingrese su dirección de correo electrónico y le enviaremos un enlace para restablecer su contraseña"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Alcance"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Redimensionar imagen desde la derecha"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Almacén de configuración"
 
@@ -2182,9 +2182,9 @@ msgstr "Error al actualizar nota"
 msgid "Refund shipping"
 msgstr "Reembolsar envío"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Solo lectura"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Probar método de envío"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Valores de Faceta"
 
@@ -2891,11 +2891,11 @@ msgstr "Recalcular envío"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Recursos"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Esto eliminará todos los grupos de opciones de este producto y volverá a la selección de configuración de variantes."
 
@@ -2905,7 +2905,7 @@ msgstr "Esto eliminará todos los grupos de opciones de este producto y volverá
 msgid "Billing address"
 msgstr "Dirección de facturación"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Agregar valor de faceta"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Administrador creado correctamente"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Opciones de Producto"
 
@@ -3599,7 +3599,7 @@ msgstr "Arrastrar para reordenar"
 msgid "Zones"
 msgstr "Zonas"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Métodos de envío"
 msgid "Select an address"
 msgstr "Seleccione una dirección"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Sí"
@@ -3792,7 +3792,7 @@ msgstr "Liquidar pago"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Total de impuestos"
 msgid "Draft order status"
 msgstr "Estado del borrador del pedido"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Buscar variantes..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "Sistema"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Nombre de la variante"
 
@@ -5514,7 +5514,7 @@ msgstr "Quitar"
 msgid "Failed to update customer"
 msgstr "Error al actualizar cliente"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "¿Eliminar grupos de opciones?"
 
@@ -5925,7 +5925,7 @@ msgstr "Elementos cumplidos ({0})"
 msgid "Create your first product"
 msgstr "Cree su primer producto"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Valor actualizado"
 
@@ -6162,7 +6162,7 @@ msgstr "Intente seleccionar un rango de fechas diferente."
 msgid "Successfully created zone"
 msgstr "Zona creada exitosamente"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Valor"
 
@@ -6299,7 +6299,7 @@ msgstr "ID de Reembolso"
 msgid "Order custom fields updated"
 msgstr "Campos personalizados del pedido actualizados"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Buscar entradas..."
 
@@ -6703,7 +6703,7 @@ msgstr "Umbral de agotamiento"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Producto eliminado del canal correctamente"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Error al actualizar el valor"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Error al agregar cliente al grupo"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Gestionar variantes"
 

--- a/packages/dashboard/src/i18n/locales/fa.po
+++ b/packages/dashboard/src/i18n/locales/fa.po
@@ -345,7 +345,7 @@ msgstr "آیا مطمئن هستید که می‌خواهید این نوع را
 msgid "Failed to create administrator"
 msgstr "ایجاد مدیر ناموفق بود"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "خیر"
@@ -469,8 +469,8 @@ msgstr "بازگشت به انبار"
 msgid "Visibility"
 msgstr "قابلیت مشاهده"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "گونه‌های محصول"
 
@@ -964,7 +964,7 @@ msgstr "خط سفارش حذف شد"
 msgid "Content:"
 msgstr "محتوا:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "کلید"
 
@@ -1195,8 +1195,8 @@ msgstr "سفارش پیش‌نویس"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "آدرس ایمیل خود را وارد کنید تا لینکی برای بازنشانی رمز عبور برایتان ارسال کنیم"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "دامنه"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "تغییر اندازه تصویر از راست"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "فروشگاه تنظیمات"
 
@@ -2182,9 +2182,9 @@ msgstr "به‌روزرسانی یادداشت ناموفق بود"
 msgid "Refund shipping"
 msgstr "بازپرداخت هزینه ارسال"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "فقط خواندنی"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "آزمون روش ارسال"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "مقادیر ویژگی"
 
@@ -2891,11 +2891,11 @@ msgstr "محاسبه مجدد هزینه ارسال"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "فایل‌ها"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "این عمل تمام گروه‌های گزینه را از این محصول حذف کرده و به انتخاب تنظیم گونه بازمی‌گردد."
 
@@ -2905,7 +2905,7 @@ msgstr "این عمل تمام گروه‌های گزینه را از این م�
 msgid "Billing address"
 msgstr "آدرس صورتحساب"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "افزودن مقدار ویژگی"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "مدیر با موفقیت ایجاد شد"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "گزینه‌های محصول"
 
@@ -3599,7 +3599,7 @@ msgstr "برای مرتب‌سازی بکشید"
 msgid "Zones"
 msgstr "مناطق"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "روش‌های ارسال"
 msgid "Select an address"
 msgstr "یک آدرس انتخاب کنید"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "بله"
@@ -3792,7 +3792,7 @@ msgstr "تسویه پرداخت"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "مجموع مالیات"
 msgid "Draft order status"
 msgstr "وضعیت پیش‌نویس سفارش"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "جستجوی انواع..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "سیستم"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "نام نوع"
 
@@ -5514,7 +5514,7 @@ msgstr "حذف"
 msgid "Failed to update customer"
 msgstr "به‌روزرسانی مشتری ناموفق بود"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "حذف گروه‌های گزینه؟"
 
@@ -5925,7 +5925,7 @@ msgstr "اقلام تحویل شده ({0})"
 msgid "Create your first product"
 msgstr "اولین محصول خود را ایجاد کنید"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "مقدار به‌روزرسانی شد"
 
@@ -6162,7 +6162,7 @@ msgstr "بازه تاریخ دیگری را انتخاب کنید."
 msgid "Successfully created zone"
 msgstr "منطقه با موفقیت ایجاد شد"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "مقدار"
 
@@ -6299,7 +6299,7 @@ msgstr "شناسه بازپرداخت"
 msgid "Order custom fields updated"
 msgstr "فیلدهای سفارشی سفارش به‌روزرسانی شد"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "جستجوی ورودی‌ها..."
 
@@ -6703,7 +6703,7 @@ msgstr "آستانه اتمام موجودی"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "محصول با موفقیت از کانال حذف شد"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "به‌روزرسانی مقدار ناموفق بود"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "افزودن مشتری به گروه ناموفق بود"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "مدیریت انواع"
 

--- a/packages/dashboard/src/i18n/locales/fr.po
+++ b/packages/dashboard/src/i18n/locales/fr.po
@@ -345,7 +345,7 @@ msgstr "Êtes-vous sûr de vouloir supprimer cette variante ?"
 msgid "Failed to create administrator"
 msgstr "Échec de la création de l'administrateur"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Non"
@@ -469,8 +469,8 @@ msgstr "Retourner au stock"
 msgid "Visibility"
 msgstr "Visibilité"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Variantes de produit"
 
@@ -964,7 +964,7 @@ msgstr "Ligne de commande supprimée"
 msgid "Content:"
 msgstr "Contenu :"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Clé"
 
@@ -1195,8 +1195,8 @@ msgstr "Brouillon de commande"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Saisissez votre adresse e-mail et nous vous enverrons un lien pour réinitialiser votre mot de passe"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Portée"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Redimensionner l'image depuis la droite"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Magasin de paramètres"
 
@@ -2182,9 +2182,9 @@ msgstr "Échec de la mise à jour de la note"
 msgid "Refund shipping"
 msgstr "Rembourser la livraison"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Lecture seule"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Méthode d'Expédition de Test"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Valeurs de facette"
 
@@ -2891,11 +2891,11 @@ msgstr "Recalculer les frais de livraison"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Ressources"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Cela supprimera tous les groupes d'options de ce produit et reviendra au choix de configuration des variantes."
 
@@ -2905,7 +2905,7 @@ msgstr "Cela supprimera tous les groupes d'options de ce produit et reviendra au
 msgid "Billing address"
 msgstr "Adresse de facturation"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Ajouter une valeur de facette"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Administrateur créé avec succès"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Options de produit"
 
@@ -3599,7 +3599,7 @@ msgstr "Faire glisser pour réorganiser"
 msgid "Zones"
 msgstr "Zones"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Méthodes d'expédition"
 msgid "Select an address"
 msgstr "Sélectionner une adresse"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Oui"
@@ -3792,7 +3792,7 @@ msgstr "Régler le paiement"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Total des taxes"
 msgid "Draft order status"
 msgstr "Statut du brouillon de commande"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Rechercher des variantes..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "Système"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Nom de la variante"
 
@@ -5514,7 +5514,7 @@ msgstr "Supprimer"
 msgid "Failed to update customer"
 msgstr "Échec de la mise à jour du client"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Supprimer les groupes d'options ?"
 
@@ -5925,7 +5925,7 @@ msgstr "Éléments exécutés ({0})"
 msgid "Create your first product"
 msgstr "Créez votre premier produit"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Valeur mise à jour"
 
@@ -6162,7 +6162,7 @@ msgstr "Essayez de sélectionner une autre plage de dates."
 msgid "Successfully created zone"
 msgstr "Zone créée avec succès"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Valeur"
 
@@ -6299,7 +6299,7 @@ msgstr "ID de remboursement"
 msgid "Order custom fields updated"
 msgstr "Champs personnalisés de la commande mis à jour"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Rechercher des entrées..."
 
@@ -6703,7 +6703,7 @@ msgstr "Seuil de rupture de stock"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produit supprimé du canal avec succès"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Échec de la mise à jour de la valeur"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Échec de l'ajout du client au groupe"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Gérer les variantes"
 

--- a/packages/dashboard/src/i18n/locales/he.po
+++ b/packages/dashboard/src/i18n/locales/he.po
@@ -345,7 +345,7 @@ msgstr "האם אתה בטוח שברצונך למחוק גרסה זו?"
 msgid "Failed to create administrator"
 msgstr "יצירת מנהל נכשלה"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "לא"
@@ -469,8 +469,8 @@ msgstr "החזר למלאי"
 msgid "Visibility"
 msgstr "נראות"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "גרסאות מוצר"
 
@@ -964,7 +964,7 @@ msgstr "שורת ההזמנה הוסרה"
 msgid "Content:"
 msgstr "תוכן:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "מפתח"
 
@@ -1195,8 +1195,8 @@ msgstr "הזמנת טיוטה"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "הזן את כתובת הדוא\"ל שלך ואנו נשלח לך קישור לאיפוס הסיסמה"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "היקף"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "שנה גודל תמונה מימין"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "חנות הגדרות"
 
@@ -2182,9 +2182,9 @@ msgstr "עדכון ההערה נכשל"
 msgid "Refund shipping"
 msgstr "החזר משלוח"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "לקריאה בלבד"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "בדוק שיטת משלוח"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "ערכי מאפיינים"
 
@@ -2891,11 +2891,11 @@ msgstr "חישוב מחדש של המשלוח"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "קבצים"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "פעולה זו תסיר את כל קבוצות האפשרויות ממוצר זה ותחזור לבחירת הגדרת הגרסאות."
 
@@ -2905,7 +2905,7 @@ msgstr "פעולה זו תסיר את כל קבוצות האפשרויות ממ�
 msgid "Billing address"
 msgstr "כתובת חיוב"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "הוסף ערך מאפיין"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "מנהל נוצר בהצלחה"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "אפשרויות מוצר"
 
@@ -3599,7 +3599,7 @@ msgstr "גרור כדי לסדר מחדש"
 msgid "Zones"
 msgstr "אזורים"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "שיטות משלוח"
 msgid "Select an address"
 msgstr "בחר כתובת"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "כן"
@@ -3792,7 +3792,7 @@ msgstr "סלק תשלום"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "סה\"כ מס"
 msgid "Draft order status"
 msgstr "סטטוס טיוטת הזמנה"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "חיפוש גרסאות..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "מערכת"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "שם הגרסה"
 
@@ -5514,7 +5514,7 @@ msgstr "הסר"
 msgid "Failed to update customer"
 msgstr "עדכון הלקוח נכשל"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "להסיר קבוצות אפשרויות?"
 
@@ -5925,7 +5925,7 @@ msgstr "פריטים שמולאו ({0})"
 msgid "Create your first product"
 msgstr "צור את המוצר הראשון שלך"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "הערך עודכן"
 
@@ -6162,7 +6162,7 @@ msgstr "נסה לבחור טווח תאריכים אחר."
 msgid "Successfully created zone"
 msgstr "האזור נוצר בהצלחה"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "ערך"
 
@@ -6299,7 +6299,7 @@ msgstr "מזהה החזר"
 msgid "Order custom fields updated"
 msgstr "שדות מותאמים אישית של הזמנה עודכנו"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "חיפוש רשומות..."
 
@@ -6703,7 +6703,7 @@ msgstr "סף אזילת מלאי"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "המוצר הוסר בהצלחה מהערוץ"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "עדכון הערך נכשל"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "הוספת הלקוח לקבוצה נכשלה"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "נהל גרסאות"
 

--- a/packages/dashboard/src/i18n/locales/hr.po
+++ b/packages/dashboard/src/i18n/locales/hr.po
@@ -345,7 +345,7 @@ msgstr "Jeste li sigurni da želite obrisati ovu varijantu?"
 msgid "Failed to create administrator"
 msgstr "Neuspješno kreiranje administratora"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Ne"
@@ -469,8 +469,8 @@ msgstr "Vrati na zalihu"
 msgid "Visibility"
 msgstr "Vidljivost"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Varijante proizvoda"
 
@@ -964,7 +964,7 @@ msgstr "Redak narudžbe uklonjen"
 msgid "Content:"
 msgstr "Sadržaj:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Ključ"
 
@@ -1195,8 +1195,8 @@ msgstr "Skica narudžbe"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Unesite svoju adresu e-pošte i poslat ćemo vam poveznicu za resetiranje lozinke"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Opseg"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Promijeni veličinu slike s desne strane"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Pohrana postavki"
 
@@ -2182,9 +2182,9 @@ msgstr "Ažuriranje bilješke nije uspjelo"
 msgid "Refund shipping"
 msgstr "Povrat dostave"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Samo za čitanje"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Testiraj način dostave"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Vrijednosti svojstava"
 
@@ -2891,11 +2891,11 @@ msgstr "Preračunaj dostavu"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Datoteke"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Ovo će ukloniti sve grupe opcija s ovog proizvoda i vratiti se na izbor postavljanja varijanti."
 
@@ -2905,7 +2905,7 @@ msgstr "Ovo će ukloniti sve grupe opcija s ovog proizvoda i vratiti se na izbor
 msgid "Billing address"
 msgstr "Adresa za naplatu"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Dodaj vrijednost svojstva"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Administrator uspješno kreiran"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Opcije proizvoda"
 
@@ -3599,7 +3599,7 @@ msgstr "Povucite za promjenu redoslijeda"
 msgid "Zones"
 msgstr "Zone"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Načini dostave"
 msgid "Select an address"
 msgstr "Odaberite adresu"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Da"
@@ -3792,7 +3792,7 @@ msgstr "Izvrši plaćanje"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Ukupno poreza"
 msgid "Draft order status"
 msgstr "Status nacrta narudžbe"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Pretraži varijante..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "Sustav"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Naziv varijante"
 
@@ -5514,7 +5514,7 @@ msgstr "Ukloni"
 msgid "Failed to update customer"
 msgstr "Ažuriranje kupca nije uspjelo"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Ukloniti grupe opcija?"
 
@@ -5925,7 +5925,7 @@ msgstr "Izvršene stavke ({0})"
 msgid "Create your first product"
 msgstr "Stvorite svoj prvi proizvod"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Vrijednost ažurirana"
 
@@ -6162,7 +6162,7 @@ msgstr "Pokušajte odabrati drugo razdoblje."
 msgid "Successfully created zone"
 msgstr "Zona uspješno stvorena"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Vrijednost"
 
@@ -6299,7 +6299,7 @@ msgstr "ID povrata"
 msgid "Order custom fields updated"
 msgstr "Prilagođena polja narudžbe ažurirana"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Pretraži unose..."
 
@@ -6703,7 +6703,7 @@ msgstr "Prag zaliha"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Proizvod uspješno uklonjen iz kanala"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Ažuriranje vrijednosti nije uspjelo"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Dodavanje kupca u grupu nije uspjelo"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Upravljaj varijantama"
 

--- a/packages/dashboard/src/i18n/locales/hu.po
+++ b/packages/dashboard/src/i18n/locales/hu.po
@@ -345,7 +345,7 @@ msgstr "Biztosan törli ezt a termékváltozatot?"
 msgid "Failed to create administrator"
 msgstr "Rendszergazda létrehozása sikertelen"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Nem"
@@ -469,8 +469,8 @@ msgstr "Visszahelyezés a készletbe"
 msgid "Visibility"
 msgstr "Láthatóság"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Termékvariánsok"
 
@@ -964,7 +964,7 @@ msgstr "Megrendeléssor eltávolítva"
 msgid "Content:"
 msgstr "Tartalom:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Kulcs"
 
@@ -1195,8 +1195,8 @@ msgstr "Piszkozat megrendelés"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Adja meg az e-mail címét, és küldünk egy linket a jelszava visszaállításához"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Hatókör"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Kép átméretezése jobbról"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Beállítástár"
 
@@ -2176,9 +2176,9 @@ msgstr "Megjegyzés frissítése sikertelen"
 msgid "Refund shipping"
 msgstr "Szállítási díj visszatérítése"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Csak olvasható"
 
@@ -2195,7 +2195,7 @@ msgid "Test Shipping Method"
 msgstr "Szállítási mód tesztelése"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Tulajdonságértékek"
 
@@ -2881,11 +2881,11 @@ msgstr "Szállítási díj újraszámítása"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Média"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Ez eltávolítja az összes opciócsoportot ebből a termékből és visszatér a variáns beállítási lehetőséghez."
 
@@ -2895,7 +2895,7 @@ msgstr "Ez eltávolítja az összes opciócsoportot ebből a termékből és vis
 msgid "Billing address"
 msgstr "Számlázási cím"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Tulajdonságérték hozzáadása"
@@ -3007,7 +3007,7 @@ msgid "Successfully created administrator"
 msgstr "A rendszergazda sikeresen létrehozva"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Termékopciók"
 
@@ -3589,7 +3589,7 @@ msgstr "Húzza az átrendezéshez"
 msgid "Zones"
 msgstr "Zónák"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3700,7 +3700,7 @@ msgstr "Szállítási módok"
 msgid "Select an address"
 msgstr "Válasszon egy címet"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Igen"
@@ -3782,7 +3782,7 @@ msgstr "Fizetés rendezése"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3910,8 +3910,8 @@ msgstr "Adó összesen"
 msgid "Draft order status"
 msgstr "Piszkozat megrendelés állapota"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Termékváltozatok keresése..."
 
@@ -5487,7 +5487,7 @@ msgid "System"
 msgstr "Rendszer"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Termékváltozat neve"
 
@@ -5501,7 +5501,7 @@ msgstr "Eltávolítás"
 msgid "Failed to update customer"
 msgstr "Vásárló frissítése sikertelen"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Opciócsoportok eltávolítása?"
 
@@ -5912,7 +5912,7 @@ msgstr "Teljesített tételek ({0})"
 msgid "Create your first product"
 msgstr "Hozza létre első termékét"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Érték frissítve"
 
@@ -6149,7 +6149,7 @@ msgstr "Próbáljon másik dátumtartományt választani."
 msgid "Successfully created zone"
 msgstr "Zóna sikeresen létrehozva"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Érték"
 
@@ -6286,7 +6286,7 @@ msgstr "Visszatérítés ID"
 msgid "Order custom fields updated"
 msgstr "A megrendelés egyéni mezői frissítve"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Bejegyzések keresése..."
 
@@ -6686,7 +6686,7 @@ msgstr "Készlethiány küszöbértéke"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Termék sikeresen eltávolítva a csatornából"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Nem sikerült frissíteni az értéket"
 
@@ -6710,7 +6710,7 @@ msgid "Failed to add customer to group"
 msgstr "Vásárló csoporthoz adása sikertelen"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Termékváltozatok kezelése"
 

--- a/packages/dashboard/src/i18n/locales/it.po
+++ b/packages/dashboard/src/i18n/locales/it.po
@@ -345,7 +345,7 @@ msgstr "Sei sicuro di voler eliminare questa variante?"
 msgid "Failed to create administrator"
 msgstr "Creazione amministratore non riuscita"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "No"
@@ -469,8 +469,8 @@ msgstr "Restituisci a magazzino"
 msgid "Visibility"
 msgstr "Visibilità"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Varianti prodotto"
 
@@ -964,7 +964,7 @@ msgstr "Riga ordine rimossa"
 msgid "Content:"
 msgstr "Contenuto:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Chiave"
 
@@ -1195,8 +1195,8 @@ msgstr "Bozza ordine"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Inserisci il tuo indirizzo email e ti invieremo un link per reimpostare la password"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Scope"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Ridimensiona immagine da destra"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Archivio impostazioni"
 
@@ -2182,9 +2182,9 @@ msgstr "Impossibile aggiornare la nota"
 msgid "Refund shipping"
 msgstr "Rimborsa spedizione"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Sola lettura"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Testa metodo di spedizione"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Valori attributo"
 
@@ -2891,11 +2891,11 @@ msgstr "Ricalcola spedizione"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Risorse"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Questa azione rimuoverà tutti i gruppi di opzioni da questo prodotto e tornerai alla scelta di configurazione delle varianti."
 
@@ -2905,7 +2905,7 @@ msgstr "Questa azione rimuoverà tutti i gruppi di opzioni da questo prodotto e 
 msgid "Billing address"
 msgstr "Indirizzo di fatturazione"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Aggiungi valore attributo"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Amministratore creato con successo"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Opzioni prodotto"
 
@@ -3599,7 +3599,7 @@ msgstr "Trascina per riordinare"
 msgid "Zones"
 msgstr "Zone"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Metodi di spedizione"
 msgid "Select an address"
 msgstr "Seleziona un indirizzo"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Sì"
@@ -3792,7 +3792,7 @@ msgstr "Completa pagamento"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Totale IVA"
 msgid "Draft order status"
 msgstr "Stato della bozza dell'ordine"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Cerca varianti..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "Sistema"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Nome variante"
 
@@ -5514,7 +5514,7 @@ msgstr "Rimuovi"
 msgid "Failed to update customer"
 msgstr "Impossibile aggiornare cliente"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Rimuovere i gruppi di opzioni?"
 
@@ -5925,7 +5925,7 @@ msgstr "Articoli evasi ({0})"
 msgid "Create your first product"
 msgstr "Crea il tuo primo prodotto"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Valore aggiornato"
 
@@ -6162,7 +6162,7 @@ msgstr "Prova a selezionare un intervallo di date diverso."
 msgid "Successfully created zone"
 msgstr "Zona creata con successo"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Valore"
 
@@ -6299,7 +6299,7 @@ msgstr "ID rimborso"
 msgid "Order custom fields updated"
 msgstr "Campi personalizzati ordine aggiornati"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Cerca voci..."
 
@@ -6703,7 +6703,7 @@ msgstr "Soglia esaurimento scorte"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Prodotto rimosso dal canale con successo"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Impossibile aggiornare il valore"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Impossibile aggiungere cliente al gruppo"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Gestisci varianti"
 

--- a/packages/dashboard/src/i18n/locales/ja.po
+++ b/packages/dashboard/src/i18n/locales/ja.po
@@ -345,7 +345,7 @@ msgstr "このバリエーションを削除してもよろしいですか？"
 msgid "Failed to create administrator"
 msgstr "管理者の作成に失敗しました"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "いいえ"
@@ -469,8 +469,8 @@ msgstr "在庫に戻す"
 msgid "Visibility"
 msgstr "公開設定"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "商品バリエーション"
 
@@ -964,7 +964,7 @@ msgstr "注文ラインを削除しました"
 msgid "Content:"
 msgstr "内容:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "キー"
 
@@ -1195,8 +1195,8 @@ msgstr "下書き注文"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "メールアドレスを入力すると、パスワードリセット用のリンクをお送りします"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "スコープ"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "画像を右からリサイズ"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "設定ストア"
 
@@ -2182,9 +2182,9 @@ msgstr "メモの更新に失敗しました"
 msgid "Refund shipping"
 msgstr "送料を返金"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "読み取り専用"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "配送方法をテスト"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "ファセット値"
 
@@ -2891,11 +2891,11 @@ msgstr "送料を再計算"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "アセット"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "この商品からすべてのオプショングループが削除され、バリエーション設定の選択に戻ります。"
 
@@ -2905,7 +2905,7 @@ msgstr "この商品からすべてのオプショングループが削除され
 msgid "Billing address"
 msgstr "請求先住所"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "ファセット値を追加"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "管理者を正常に作成しました"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "商品オプション"
 
@@ -3599,7 +3599,7 @@ msgstr "ドラッグして並べ替え"
 msgid "Zones"
 msgstr "ゾーン"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "配送方法"
 msgid "Select an address"
 msgstr "住所を選択"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "はい"
@@ -3792,7 +3792,7 @@ msgstr "支払いを決済"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "税合計"
 msgid "Draft order status"
 msgstr "下書き注文のステータス"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "バリエーションを検索..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "システム"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "バリエーション名"
 
@@ -5514,7 +5514,7 @@ msgstr "削除"
 msgid "Failed to update customer"
 msgstr "顧客の更新に失敗しました"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "オプショングループを削除しますか？"
 
@@ -5925,7 +5925,7 @@ msgstr "フルフィルメント済みアイテム（{0}）"
 msgid "Create your first product"
 msgstr "最初の商品を作成しましょう"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "値が更新されました"
 
@@ -6162,7 +6162,7 @@ msgstr "別の日付範囲を選択してみてください。"
 msgid "Successfully created zone"
 msgstr "ゾーンを作成しました"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "値"
 
@@ -6299,7 +6299,7 @@ msgstr "返金ID"
 msgid "Order custom fields updated"
 msgstr "注文カスタムフィールドが更新されました"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "エントリーを検索..."
 
@@ -6703,7 +6703,7 @@ msgstr "在庫切れしきい値"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "チャネルから商品を正常に削除しました"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "値の更新に失敗しました"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "顧客のグループへの追加に失敗しました"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "バリエーションを管理"
 

--- a/packages/dashboard/src/i18n/locales/nb.po
+++ b/packages/dashboard/src/i18n/locales/nb.po
@@ -345,7 +345,7 @@ msgstr "Er du sikker på at du vil slette denne varianten?"
 msgid "Failed to create administrator"
 msgstr "Kunne ikke opprette administrator"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Nei"
@@ -469,8 +469,8 @@ msgstr "Returner til lager"
 msgid "Visibility"
 msgstr "Synlighet"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Produktvarianter"
 
@@ -964,7 +964,7 @@ msgstr "Bestillingslinje fjernet"
 msgid "Content:"
 msgstr "Innhold:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Nøkkel"
 
@@ -1195,8 +1195,8 @@ msgstr "Utkastbestilling"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Skriv inn e-postadressen din, så sender vi deg en lenke for å tilbakestille passordet ditt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Omfang"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Endre størrelse på bildet fra høyre"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Innstillingslager"
 
@@ -2182,9 +2182,9 @@ msgstr "Kunne ikke oppdatere notat"
 msgid "Refund shipping"
 msgstr "Refunder frakt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Skrivebeskyttet"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Test fraktmetode"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Fasettverdier"
 
@@ -2891,11 +2891,11 @@ msgstr "Beregn frakt på nytt"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Ressurser"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Dette vil fjerne alle opsjonsgrupper fra dette produktet og returnere til variantoppsettsvalget."
 
@@ -2905,7 +2905,7 @@ msgstr "Dette vil fjerne alle opsjonsgrupper fra dette produktet og returnere ti
 msgid "Billing address"
 msgstr "Fakturaadresse"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Legg til fasettverdi"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Administrator opprettet"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Produktopsjoner"
 
@@ -3599,7 +3599,7 @@ msgstr "Dra for å endre rekkefølge"
 msgid "Zones"
 msgstr "Soner"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Fraktmetoder"
 msgid "Select an address"
 msgstr "Velg en adresse"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Ja"
@@ -3792,7 +3792,7 @@ msgstr "Gjennomfør betaling"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Mva totalt"
 msgid "Draft order status"
 msgstr "Utkast til ordrestatus"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Søk etter varianter..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "System"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Variantnavn"
 
@@ -5514,7 +5514,7 @@ msgstr "Fjern"
 msgid "Failed to update customer"
 msgstr "Kunne ikke oppdatere kunde"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Fjerne opsjonsgrupper?"
 
@@ -5925,7 +5925,7 @@ msgstr "Oppfylte varer ({0})"
 msgid "Create your first product"
 msgstr "Opprett ditt første produkt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Verdi oppdatert"
 
@@ -6162,7 +6162,7 @@ msgstr "Prøv å velge et annet datointervall."
 msgid "Successfully created zone"
 msgstr "Sone opprettet"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Verdi"
 
@@ -6299,7 +6299,7 @@ msgstr "Refusjons-ID"
 msgid "Order custom fields updated"
 msgstr "Egendefinerte ordrefelt oppdatert"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Søk etter oppføringer..."
 
@@ -6703,7 +6703,7 @@ msgstr "Utsolgt-terskel"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produkt fjernet fra kanal"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Kunne ikke oppdatere verdi"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Kunne ikke legge til kunde i gruppe"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Administrer varianter"
 

--- a/packages/dashboard/src/i18n/locales/ne.po
+++ b/packages/dashboard/src/i18n/locales/ne.po
@@ -345,7 +345,7 @@ msgstr "के तपाईं निश्चित हुनुहुन्छ
 msgid "Failed to create administrator"
 msgstr "प्रशासक सिर्जना गर्न असफल"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "होइन"
@@ -469,8 +469,8 @@ msgstr "स्टकमा फिर्ता"
 msgid "Visibility"
 msgstr "दृश्यता"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "उत्पादन भेरियन्टहरू"
 
@@ -964,7 +964,7 @@ msgstr "अर्डर लाइन हटाइयो"
 msgid "Content:"
 msgstr "सामग्री:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "कुञ्जी"
 
@@ -1195,8 +1195,8 @@ msgstr "मस्यौदा अर्डर"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "तपाईंको इमेल ठेगाना प्रविष्ट गर्नुहोस्, हामी तपाईंलाई पासवर्ड रिसेट गर्ने लिङ्क पठाउनेछौं"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "दायरा"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "दायाँबाट छविको आकार परिवर्तन गर्नुहोस्"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "सेटिङ स्टोर"
 
@@ -2182,9 +2182,9 @@ msgstr "टिप्पणी अपडेट गर्न असफल"
 msgid "Refund shipping"
 msgstr "ढुवानी फिर्ता"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "पढ्न मात्र"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "ढुवानी विधि परीक्षण गर्नुहोस्"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "विशेषता मानहरू"
 
@@ -2891,11 +2891,11 @@ msgstr "ढुवानी पुन: गणना गर्नुहोस्"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "सम्पत्तिहरू"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "यसले यो उत्पादनबाट सबै विकल्प समूहहरू हटाउनेछ र भेरियन्ट सेटअप छनोटमा फर्काउनेछ।"
 
@@ -2905,7 +2905,7 @@ msgstr "यसले यो उत्पादनबाट सबै विक�
 msgid "Billing address"
 msgstr "बिलिङ ठेगाना"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "विशेषता मान थप्नुहोस्"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "प्रशासक सफलतापूर्वक सिर्जना गरियो"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "उत्पादन विकल्पहरू"
 
@@ -3599,7 +3599,7 @@ msgstr "पुनः क्रम गर्न तान्नुहोस्"
 msgid "Zones"
 msgstr "क्षेत्रहरू"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "ढुवानी विधिहरू"
 msgid "Select an address"
 msgstr "ठेगाना चयन गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "हो"
@@ -3792,7 +3792,7 @@ msgstr "भुक्तानी सम्पन्न गर्नुहोस�
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "कर कुल"
 msgid "Draft order status"
 msgstr "ड्राफ्ट अर्डर स्थिति"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "भेरियन्टहरू खोज्नुहोस्..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "प्रणाली"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "भिन्नता नाम"
 
@@ -5514,7 +5514,7 @@ msgstr "हटाउनुहोस्"
 msgid "Failed to update customer"
 msgstr "ग्राहक अपडेट गर्न असफल"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "विकल्प समूहहरू हटाउने हो?"
 
@@ -5925,7 +5925,7 @@ msgstr "पूरा गरिएका वस्तुहरू ({0})"
 msgid "Create your first product"
 msgstr "आफ्नो पहिलो उत्पादन सिर्जना गर्नुहोस्"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "मान अपडेट गरियो"
 
@@ -6162,7 +6162,7 @@ msgstr "फरक मिति दायरा चयन गर्ने प्�
 msgid "Successfully created zone"
 msgstr "क्षेत्र सफलतापूर्वक सिर्जना गरियो"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "मान"
 
@@ -6299,7 +6299,7 @@ msgstr "रिफन्ड ID"
 msgid "Order custom fields updated"
 msgstr "अर्डर अनुकूलन फिल्डहरू अद्यावधिक गरियो"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "प्रविष्टिहरू खोज्नुहोस्..."
 
@@ -6703,7 +6703,7 @@ msgstr "स्टक बाहिर थ्रेसहोल्ड"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "च्यानलबाट उत्पादन सफलतापूर्वक हटाइयो"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "मान अपडेट गर्न असफल भयो"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "समूहमा ग्राहक थप्न असफल"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "भेरियन्टहरू व्यवस्थापन गर्नुहोस्"
 

--- a/packages/dashboard/src/i18n/locales/nl.po
+++ b/packages/dashboard/src/i18n/locales/nl.po
@@ -345,7 +345,7 @@ msgstr "Weet u zeker dat u deze variant wilt verwijderen?"
 msgid "Failed to create administrator"
 msgstr "Aanmaken van beheerder mislukt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Nee"
@@ -469,8 +469,8 @@ msgstr "Terugbrengen naar voorraad"
 msgid "Visibility"
 msgstr "Zichtbaarheid"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Productvarianten"
 
@@ -964,7 +964,7 @@ msgstr "Bestelregel verwijderd"
 msgid "Content:"
 msgstr "Inhoud:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Sleutel"
 
@@ -1199,8 +1199,8 @@ msgstr "Conceptbestelling"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Voer uw e-mailadres in en we sturen u een link om uw wachtwoord opnieuw in te stellen"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Bereik"
 
@@ -1331,7 +1331,7 @@ msgid "Resize image from right"
 msgstr "Afbeeldingsgrootte vanaf rechts aanpassen"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Instellingenopslag"
 
@@ -2180,9 +2180,9 @@ msgstr "Notitie bijwerken mislukt"
 msgid "Refund shipping"
 msgstr "Verzendkosten restitueren"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Alleen-lezen"
 
@@ -2199,7 +2199,7 @@ msgid "Test Shipping Method"
 msgstr "Verzendmethode testen"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Facetwaarden"
 
@@ -2885,11 +2885,11 @@ msgstr "Verzendkosten herberekenen"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Middelen"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Dit verwijdert alle optiegroepen van dit product en keert terug naar de variantkeuze."
 
@@ -2899,7 +2899,7 @@ msgstr "Dit verwijdert alle optiegroepen van dit product en keert terug naar de 
 msgid "Billing address"
 msgstr "Factuuradres"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Facetwaarde toevoegen"
@@ -3011,7 +3011,7 @@ msgid "Successfully created administrator"
 msgstr "Beheerder succesvol aangemaakt"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Productopties"
 
@@ -3593,7 +3593,7 @@ msgstr "Slepen om opnieuw te ordenen"
 msgid "Zones"
 msgstr "Zones"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3704,7 +3704,7 @@ msgstr "Verzendmethoden"
 msgid "Select an address"
 msgstr "Selecteer een adres"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Ja"
@@ -3786,7 +3786,7 @@ msgstr "Betaling afhandelen"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3914,8 +3914,8 @@ msgstr "Totale belasting"
 msgid "Draft order status"
 msgstr "Status conceptbestelling"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Varianten zoeken..."
 
@@ -5495,7 +5495,7 @@ msgid "System"
 msgstr "Systeem"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Variantnaam"
 
@@ -5509,7 +5509,7 @@ msgstr "Verwijderen"
 msgid "Failed to update customer"
 msgstr "Klant bijwerken mislukt"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Optiegroepen verwijderen?"
 
@@ -5920,7 +5920,7 @@ msgstr "Afgehandelde items ({0})"
 msgid "Create your first product"
 msgstr "Maak uw eerste product aan"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Waarde bijgewerkt"
 
@@ -6157,7 +6157,7 @@ msgstr "Probeer een ander datumbereik te selecteren."
 msgid "Successfully created zone"
 msgstr "Zone succesvol aangemaakt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Waarde"
 
@@ -6294,7 +6294,7 @@ msgstr "Terugbetalings-ID"
 msgid "Order custom fields updated"
 msgstr "Aangepaste velden van bestelling bijgewerkt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Items zoeken..."
 
@@ -6698,7 +6698,7 @@ msgstr "Uitverkocht-drempelwaarde"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Product succesvol uit kanaal verwijderd"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Bijwerken van waarde mislukt"
 
@@ -6722,7 +6722,7 @@ msgid "Failed to add customer to group"
 msgstr "Klant toevoegen aan groep mislukt"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Varianten beheren"
 

--- a/packages/dashboard/src/i18n/locales/pl.po
+++ b/packages/dashboard/src/i18n/locales/pl.po
@@ -345,7 +345,7 @@ msgstr "Czy na pewno chcesz usunąć ten wariant?"
 msgid "Failed to create administrator"
 msgstr "Nie udało się utworzyć administratora"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Nie"
@@ -469,8 +469,8 @@ msgstr "Zwróć na stan"
 msgid "Visibility"
 msgstr "Widoczność"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Warianty produktu"
 
@@ -964,7 +964,7 @@ msgstr "Usunięto wiersz zamówienia"
 msgid "Content:"
 msgstr "Zawartość:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Klucz"
 
@@ -1195,8 +1195,8 @@ msgstr "Zamówienie robocze"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Wpisz swój adres e-mail, a wyślemy Ci link do zresetowania hasła"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Zakres"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Zmień rozmiar obrazu od prawej"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Ustawienia sklepu"
 
@@ -2182,9 +2182,9 @@ msgstr "Nie udało się zaktualizować notatki"
 msgid "Refund shipping"
 msgstr "Zwróć koszt wysyłki"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Tylko do odczytu"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Testuj metodę wysyłki"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Wartości aspektów"
 
@@ -2891,11 +2891,11 @@ msgstr "Przelicz wysyłkę"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Zasoby"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Spowoduje to usunięcie wszystkich grup opcji z tego produktu i powrót do wyboru konfiguracji wariantów."
 
@@ -2905,7 +2905,7 @@ msgstr "Spowoduje to usunięcie wszystkich grup opcji z tego produktu i powrót 
 msgid "Billing address"
 msgstr "Adres rozliczeniowy"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Dodaj wartość aspektu"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Pomyślnie utworzono administratora"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Opcje produktu"
 
@@ -3599,7 +3599,7 @@ msgstr "Przeciągnij, aby zmienić kolejność"
 msgid "Zones"
 msgstr "Strefy"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Metody wysyłki"
 msgid "Select an address"
 msgstr "Wybierz adres"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Tak"
@@ -3792,7 +3792,7 @@ msgstr "Rozlicz płatność"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Suma podatków"
 msgid "Draft order status"
 msgstr "Status wersji roboczej zamówienia"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Szukaj wariantów..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "System"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Nazwa wariantu"
 
@@ -5514,7 +5514,7 @@ msgstr "Usuń"
 msgid "Failed to update customer"
 msgstr "Nie udało się zaktualizować klienta"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Usunąć grupy opcji?"
 
@@ -5925,7 +5925,7 @@ msgstr "Zrealizowane pozycje ({0})"
 msgid "Create your first product"
 msgstr "Utwórz swój pierwszy produkt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Wartość zaktualizowana"
 
@@ -6162,7 +6162,7 @@ msgstr "Spróbuj wybrać inny zakres dat."
 msgid "Successfully created zone"
 msgstr "Pomyślnie utworzono strefę"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Wartość"
 
@@ -6299,7 +6299,7 @@ msgstr "ID zwrotu"
 msgid "Order custom fields updated"
 msgstr "Niestandardowe pola zamówienia zaktualizowane"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Szukaj wpisów..."
 
@@ -6703,7 +6703,7 @@ msgstr "Próg braku w magazynie"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produkt został pomyślnie usunięty z kanału"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Nie udało się zaktualizować wartości"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Nie udało się dodać klienta do grupy"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Zarządzaj wariantami"
 

--- a/packages/dashboard/src/i18n/locales/pt_BR.po
+++ b/packages/dashboard/src/i18n/locales/pt_BR.po
@@ -345,7 +345,7 @@ msgstr "Tem certeza de que deseja excluir esta variante?"
 msgid "Failed to create administrator"
 msgstr "Falha ao criar administrador"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Nao"
@@ -469,8 +469,8 @@ msgstr "Devolver ao estoque"
 msgid "Visibility"
 msgstr "Visibilidade"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Variantes do produto"
 
@@ -964,7 +964,7 @@ msgstr "Linha de pedido removida"
 msgid "Content:"
 msgstr "Conteúdo:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Chave"
 
@@ -1195,8 +1195,8 @@ msgstr "Pedido rascunho"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Digite seu endereço de e-mail e enviaremos um link para redefinir sua senha"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Escopo"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Redimensionar imagem pela direita"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Loja de Configuracoes"
 
@@ -2182,9 +2182,9 @@ msgstr "Falha ao atualizar nota"
 msgid "Refund shipping"
 msgstr "Reembolsar frete"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Somente leitura"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Testar método de envio"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Valores de faceta"
 
@@ -2891,11 +2891,11 @@ msgstr "Recalcular frete"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Recursos"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Isso removera todos os grupos de opcoes deste produto e retornara a escolha de configuracao de variantes."
 
@@ -2905,7 +2905,7 @@ msgstr "Isso removera todos os grupos de opcoes deste produto e retornara a esco
 msgid "Billing address"
 msgstr "Endereço de cobrança"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Adicionar valor de faceta"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Administrador criado com sucesso"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Opções de produto"
 
@@ -3599,7 +3599,7 @@ msgstr "Arraste para reordenar"
 msgid "Zones"
 msgstr "Zonas"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Métodos de envio"
 msgid "Select an address"
 msgstr "Selecione um endereço"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Sim"
@@ -3792,7 +3792,7 @@ msgstr "Liquidar pagamento"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Total de impostos"
 msgid "Draft order status"
 msgstr "Status do rascunho do pedido"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Pesquisar variantes..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "Sistema"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Nome da variante"
 
@@ -5514,7 +5514,7 @@ msgstr "Remover"
 msgid "Failed to update customer"
 msgstr "Falha ao atualizar cliente"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Remover grupos de opcoes?"
 
@@ -5925,7 +5925,7 @@ msgstr "Itens atendidos ({0})"
 msgid "Create your first product"
 msgstr "Crie seu primeiro produto"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Valor atualizado"
 
@@ -6162,7 +6162,7 @@ msgstr "Tente selecionar um intervalo de datas diferente."
 msgid "Successfully created zone"
 msgstr "Zona criada com sucesso"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Valor"
 
@@ -6299,7 +6299,7 @@ msgstr "ID de reembolso"
 msgid "Order custom fields updated"
 msgstr "Campos personalizados do pedido atualizados"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Pesquisar entradas..."
 
@@ -6703,7 +6703,7 @@ msgstr "Limite de fora de estoque"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produto removido do canal com sucesso"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Falha ao atualizar valor"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Falha ao adicionar cliente ao grupo"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Gerenciar variantes"
 

--- a/packages/dashboard/src/i18n/locales/pt_PT.po
+++ b/packages/dashboard/src/i18n/locales/pt_PT.po
@@ -345,7 +345,7 @@ msgstr "Tem a certeza de que deseja eliminar esta variante?"
 msgid "Failed to create administrator"
 msgstr "Falha ao criar administrador"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Nao"
@@ -469,8 +469,8 @@ msgstr "Devolver ao stock"
 msgid "Visibility"
 msgstr "Visibilidade"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Variantes do produto"
 
@@ -964,7 +964,7 @@ msgstr "Linha de encomenda removida"
 msgid "Content:"
 msgstr "Conteúdo:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Chave"
 
@@ -1195,8 +1195,8 @@ msgstr "Encomenda rascunho"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Introduza o seu endereço de e-mail e enviaremos uma ligação para repor a sua palavra-passe"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Ambito"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Redimensionar imagem a partir da direita"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Loja de Definicoes"
 
@@ -2182,9 +2182,9 @@ msgstr "Falha ao atualizar nota"
 msgid "Refund shipping"
 msgstr "Reembolsar envio"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Apenas de leitura"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Testar método de envio"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Valores de faceta"
 
@@ -2891,11 +2891,11 @@ msgstr "Recalcular envio"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Recursos"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Isto removera todos os grupos de opcoes deste produto e regressara a escolha de configuracao de variantes."
 
@@ -2905,7 +2905,7 @@ msgstr "Isto removera todos os grupos de opcoes deste produto e regressara a esc
 msgid "Billing address"
 msgstr "Morada de faturação"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Adicionar valor de faceta"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Administrador criado com sucesso"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Opções de produto"
 
@@ -3599,7 +3599,7 @@ msgstr "Arrastar para reordenar"
 msgid "Zones"
 msgstr "Zonas"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Métodos de envio"
 msgid "Select an address"
 msgstr "Selecione uma morada"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Sim"
@@ -3792,7 +3792,7 @@ msgstr "Liquidar pagamento"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Total de IVA"
 msgid "Draft order status"
 msgstr "Estado do rascunho da encomenda"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Pesquisar variantes..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "Sistema"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Nome da variante"
 
@@ -5514,7 +5514,7 @@ msgstr "Remover"
 msgid "Failed to update customer"
 msgstr "Falha ao atualizar cliente"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Remover grupos de opcoes?"
 
@@ -5925,7 +5925,7 @@ msgstr "Itens atendidos ({0})"
 msgid "Create your first product"
 msgstr "Crie o seu primeiro produto"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Valor atualizado"
 
@@ -6162,7 +6162,7 @@ msgstr "Tente selecionar um intervalo de datas diferente."
 msgid "Successfully created zone"
 msgstr "Zona criada com sucesso"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Valor"
 
@@ -6299,7 +6299,7 @@ msgstr "ID de reembolso"
 msgid "Order custom fields updated"
 msgstr "Campos personalizados da encomenda atualizados"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Pesquisar entradas..."
 
@@ -6703,7 +6703,7 @@ msgstr "Limite de esgotado"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produto removido do canal com sucesso"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Falha ao atualizar valor"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Falha ao adicionar cliente ao grupo"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Gerir variantes"
 

--- a/packages/dashboard/src/i18n/locales/ro.po
+++ b/packages/dashboard/src/i18n/locales/ro.po
@@ -321,7 +321,7 @@ msgstr "Ești sigur că vrei să ștergi această variantă?"
 msgid "Failed to create administrator"
 msgstr "Nu s-a putut crea administratorul"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Nu"
@@ -445,8 +445,8 @@ msgstr "Returnează în stoc"
 msgid "Visibility"
 msgstr "Vizibilitate"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Variante de produs"
 
@@ -936,7 +936,7 @@ msgstr "Linie comandă eliminată"
 msgid "Content:"
 msgstr "Conținut:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Cheie"
 
@@ -1163,8 +1163,8 @@ msgstr "Comandă ciornă"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Introdu adresa ta de email și îți vom trimite un link pentru a-ți reseta parola"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Domeniu"
 
@@ -1291,7 +1291,7 @@ msgid "Resize image from right"
 msgstr "Redimensionează imaginea din dreapta"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Stocare setări"
 
@@ -2115,9 +2115,9 @@ msgstr "Nu s-a putut actualiza nota"
 msgid "Refund shipping"
 msgstr "Rambursează livrarea"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Doar citire"
 
@@ -2134,7 +2134,7 @@ msgid "Test Shipping Method"
 msgstr "Testare metodă de livrare"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Valori atribute"
 
@@ -2812,11 +2812,11 @@ msgstr "Recalculează livrarea"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Resurse"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Se vor elimina toate grupurile de opțiuni de pe acest produs și veți reveni la alegerea configurării variantelor."
 
@@ -2826,7 +2826,7 @@ msgstr "Se vor elimina toate grupurile de opțiuni de pe acest produs și veți 
 msgid "Billing address"
 msgstr "Adresă de facturare"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Adaugă valoare pentru atribut"
@@ -2933,7 +2933,7 @@ msgid "Successfully created administrator"
 msgstr "Administratorul a fost creat cu succes"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Opțiuni Produs"
 
@@ -3507,7 +3507,7 @@ msgstr "Trage pentru a reordona"
 msgid "Zones"
 msgstr "Zone"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3618,7 +3618,7 @@ msgstr "Metode de livrare"
 msgid "Select an address"
 msgstr "Selectează o adresă"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Da"
@@ -3696,7 +3696,7 @@ msgstr "Finalizează plata"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3820,8 +3820,8 @@ msgstr "Total taxe"
 msgid "Draft order status"
 msgstr "Starea ciornei comenzii"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Caută variante..."
 
@@ -5336,7 +5336,7 @@ msgid "System"
 msgstr "Sistem"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Nume variantă"
 
@@ -5350,7 +5350,7 @@ msgstr "Elimină"
 msgid "Failed to update customer"
 msgstr "Nu s-a putut actualiza clientul"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Eliminați grupurile de opțiuni?"
 
@@ -5741,7 +5741,7 @@ msgstr "Articole livrate ({0})"
 msgid "Create your first product"
 msgstr "Creează primul tău produs"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Valoarea a fost actualizată"
 
@@ -5970,7 +5970,7 @@ msgstr "Încearcă să selectezi un alt interval de date."
 msgid "Successfully created zone"
 msgstr "Zona a fost creată cu succes"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Valoare"
 
@@ -6103,7 +6103,7 @@ msgstr "ID rambursare"
 msgid "Order custom fields updated"
 msgstr "Câmpuri personalizate comandă actualizate"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Caută intrări..."
 
@@ -6495,7 +6495,7 @@ msgstr "Nu s-au putut șterge {failed} {entityName}"
 msgid "Out-of-stock threshold"
 msgstr "Prag stoc epuizat"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Nu s-a putut actualiza valoarea"
 
@@ -6519,7 +6519,7 @@ msgid "Failed to add customer to group"
 msgstr "Nu s-a putut adăuga clientul la grup"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Gestionează variante"
 

--- a/packages/dashboard/src/i18n/locales/ru.po
+++ b/packages/dashboard/src/i18n/locales/ru.po
@@ -345,7 +345,7 @@ msgstr "Вы уверены, что хотите удалить этот вар�
 msgid "Failed to create administrator"
 msgstr "Не удалось создать администратора"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Нет"
@@ -469,8 +469,8 @@ msgstr "Вернуть на склад"
 msgid "Visibility"
 msgstr "Видимость"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Варианты товара"
 
@@ -964,7 +964,7 @@ msgstr "Строка заказа удалена"
 msgid "Content:"
 msgstr "Содержимое:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Ключ"
 
@@ -1195,8 +1195,8 @@ msgstr "Черновик заказа"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Введите свой адрес электронной почты, и мы отправим вам ссылку для сброса пароля"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Область действия"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Изменить размер изображения справа"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Хранилище настроек"
 
@@ -2182,9 +2182,9 @@ msgstr "Не удалось обновить заметку"
 msgid "Refund shipping"
 msgstr "Вернуть стоимость доставки"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Только для чтения"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Проверить способ доставки"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Значения фасета"
 
@@ -2891,11 +2891,11 @@ msgstr "Пересчитать доставку"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Ресурсы"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Это удалит все группы опций из этого товара и вернёт к выбору настройки вариантов."
 
@@ -2905,7 +2905,7 @@ msgstr "Это удалит все группы опций из этого то�
 msgid "Billing address"
 msgstr "Адрес выставления счёта"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Добавить значение фасета"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Администратор успешно создан"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Опции товара"
 
@@ -3599,7 +3599,7 @@ msgstr "Перетащите для изменения порядка"
 msgid "Zones"
 msgstr "Зоны"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Способы доставки"
 msgid "Select an address"
 msgstr "Выберите адрес"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Да"
@@ -3792,7 +3792,7 @@ msgstr "Провести платёж"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Итого налог"
 msgid "Draft order status"
 msgstr "Статус черновика заказа"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Поиск вариантов..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "Система"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Название варианта"
 
@@ -5514,7 +5514,7 @@ msgstr "Удалить"
 msgid "Failed to update customer"
 msgstr "Не удалось обновить клиента"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Удалить группы опций?"
 
@@ -5925,7 +5925,7 @@ msgstr "Выполненные товары ({0})"
 msgid "Create your first product"
 msgstr "Создайте свой первый товар"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Значение обновлено"
 
@@ -6162,7 +6162,7 @@ msgstr "Попробуйте выбрать другой диапазон дат
 msgid "Successfully created zone"
 msgstr "Зона успешно создана"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Значение"
 
@@ -6299,7 +6299,7 @@ msgstr "ID возврата"
 msgid "Order custom fields updated"
 msgstr "Пользовательские поля заказа обновлены"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Поиск записей..."
 
@@ -6703,7 +6703,7 @@ msgstr "Порог отсутствия на складе"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Товар успешно удалён из канала"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Не удалось обновить значение"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Не удалось добавить клиента в группу"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Управление вариантами"
 

--- a/packages/dashboard/src/i18n/locales/sv.po
+++ b/packages/dashboard/src/i18n/locales/sv.po
@@ -345,7 +345,7 @@ msgstr "Är du säker på att du vill ta bort denna variant?"
 msgid "Failed to create administrator"
 msgstr "Misslyckades med att skapa administratör"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Nej"
@@ -469,8 +469,8 @@ msgstr "Returnera till lager"
 msgid "Visibility"
 msgstr "Synlighet"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Produktvarianter"
 
@@ -964,7 +964,7 @@ msgstr "Beställningsrad borttagen"
 msgid "Content:"
 msgstr "Innehåll:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Nyckel"
 
@@ -1195,8 +1195,8 @@ msgstr "Utkast till beställning"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Ange din e-postadress så skickar vi en länk för att återställa ditt lösenord"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Omfattning"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Ändra bildstorlek från höger"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Inställningslager"
 
@@ -2182,9 +2182,9 @@ msgstr "Misslyckades att uppdatera anteckning"
 msgid "Refund shipping"
 msgstr "Återbetala frakt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Skrivskyddad"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Testa fraktmetod"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Facettvärden"
 
@@ -2891,11 +2891,11 @@ msgstr "Beräkna om frakt"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Tillgångar"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Detta tar bort alla alternativgrupper från produkten och återgår till variantval."
 
@@ -2905,7 +2905,7 @@ msgstr "Detta tar bort alla alternativgrupper från produkten och återgår till
 msgid "Billing address"
 msgstr "Fakturaadress"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Lägg till facettvärde"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Administratör har skapats"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Produktalternativ"
 
@@ -3599,7 +3599,7 @@ msgstr "Dra för att ändra ordning"
 msgid "Zones"
 msgstr "Zoner"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Fraktmetoder"
 msgid "Select an address"
 msgstr "Välj en adress"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Ja"
@@ -3792,7 +3792,7 @@ msgstr "Genomför betalning"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Totalt skatt"
 msgid "Draft order status"
 msgstr "Utkastbeställningsstatus"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Sök varianter..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "System"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Variantnamn"
 
@@ -5514,7 +5514,7 @@ msgstr "Ta bort"
 msgid "Failed to update customer"
 msgstr "Misslyckades att uppdatera kund"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Ta bort alternativgrupper?"
 
@@ -5925,7 +5925,7 @@ msgstr "Levererade artiklar ({0})"
 msgid "Create your first product"
 msgstr "Skapa din första produkt"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Värde uppdaterat"
 
@@ -6162,7 +6162,7 @@ msgstr "Prova att välja ett annat datumintervall."
 msgid "Successfully created zone"
 msgstr "Zon skapad"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Värde"
 
@@ -6299,7 +6299,7 @@ msgstr "Återbetalnings-ID"
 msgid "Order custom fields updated"
 msgstr "Anpassade orderfält uppdaterade"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Sök poster..."
 
@@ -6703,7 +6703,7 @@ msgstr "Utlagd tröskel"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Produkt borttagen från kanal"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Misslyckades med att uppdatera värde"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Misslyckades att lägga till kund i grupp"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Hantera varianter"
 

--- a/packages/dashboard/src/i18n/locales/tr.po
+++ b/packages/dashboard/src/i18n/locales/tr.po
@@ -345,7 +345,7 @@ msgstr "Bu varyantı silmek istediğinizden emin misiniz?"
 msgid "Failed to create administrator"
 msgstr "Yönetici oluşturulamadı"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Hayır"
@@ -469,8 +469,8 @@ msgstr "Stoka iade et"
 msgid "Visibility"
 msgstr "Görünürlük"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Ürün varyantları"
 
@@ -964,7 +964,7 @@ msgstr "Sipariş satırı kaldırıldı"
 msgid "Content:"
 msgstr "İçerik:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Anahtar"
 
@@ -1195,8 +1195,8 @@ msgstr "Taslak sipariş"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "E-posta adresinizi girin, şifrenizi sıfırlamanız için size bir bağlantı gönderelim"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Kapsam"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Görseli sağdan boyutlandır"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Ayarlar Deposu"
 
@@ -2182,9 +2182,9 @@ msgstr "Not güncellenemedi"
 msgid "Refund shipping"
 msgstr "Kargo iadesi"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Salt Okunur"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Kargo Yöntemini Test Et"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Özellik Değerleri"
 
@@ -2891,11 +2891,11 @@ msgstr "Kargoyu yeniden hesapla"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Varlıklar"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Bu, bu üründeki tüm seçenek gruplarını kaldıracak ve varyant kurulum seçimine geri dönecektir."
 
@@ -2905,7 +2905,7 @@ msgstr "Bu, bu üründeki tüm seçenek gruplarını kaldıracak ve varyant kuru
 msgid "Billing address"
 msgstr "Fatura adresi"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Özellik değeri ekle"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Yönetici başarıyla oluşturuldu"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Ürün Seçenekleri"
 
@@ -3599,7 +3599,7 @@ msgstr "Yeniden sıralamak için sürükleyin"
 msgid "Zones"
 msgstr "Bölgeler"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Kargo Yöntemleri"
 msgid "Select an address"
 msgstr "Bir adres seçin"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Evet"
@@ -3792,7 +3792,7 @@ msgstr "Ödemeyi tamamla"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Toplam vergi"
 msgid "Draft order status"
 msgstr "Taslak sipariş durumu"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Varyant ara..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "Sistem"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Varyant adı"
 
@@ -5514,7 +5514,7 @@ msgstr "Kaldır"
 msgid "Failed to update customer"
 msgstr "Müşteri güncellenemedi"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Seçenek grupları kaldırılsın mı?"
 
@@ -5925,7 +5925,7 @@ msgstr "Teslim edilen ürünler ({0})"
 msgid "Create your first product"
 msgstr "İlk ürününüzü oluşturun"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Değer güncellendi"
 
@@ -6162,7 +6162,7 @@ msgstr "Farklı bir tarih aralığı seçmeyi deneyin."
 msgid "Successfully created zone"
 msgstr "Bölge başarıyla oluşturuldu"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Değer"
 
@@ -6299,7 +6299,7 @@ msgstr "İade ID"
 msgid "Order custom fields updated"
 msgstr "Sipariş özel alanları güncellendi"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Kayıt ara..."
 
@@ -6703,7 +6703,7 @@ msgstr "Stok tükenmesi eşiği"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Ürün kanaldan başarıyla kaldırıldı"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Değer güncellenemedi"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Müşteri gruba eklenemedi"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Varyantları yönet"
 

--- a/packages/dashboard/src/i18n/locales/uk.po
+++ b/packages/dashboard/src/i18n/locales/uk.po
@@ -345,7 +345,7 @@ msgstr "Ви впевнені, що хочете видалити цей вар�
 msgid "Failed to create administrator"
 msgstr "Не вдалося створити адміністратора"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Ні"
@@ -469,8 +469,8 @@ msgstr "Повернути на склад"
 msgid "Visibility"
 msgstr "Видимість"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Варіанти товару"
 
@@ -964,7 +964,7 @@ msgstr "Рядок замовлення видалено"
 msgid "Content:"
 msgstr "Вміст:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Ключ"
 
@@ -1195,8 +1195,8 @@ msgstr "Чернетка замовлення"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Введіть свою адресу електронної пошти, і ми надішлемо вам посилання для скидання пароля"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Область дії"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "Змінити розмір зображення справа"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Сховище налаштувань"
 
@@ -2182,9 +2182,9 @@ msgstr "Не вдалося оновити примітку"
 msgid "Refund shipping"
 msgstr "Повернути вартість доставки"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Лише для читання"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "Перевірити спосіб доставки"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Значення фасетів"
 
@@ -2891,11 +2891,11 @@ msgstr "Перерахувати доставку"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Ресурси"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Це видалить усі групи опцій з цього товару та поверне до вибору налаштування варіантів."
 
@@ -2905,7 +2905,7 @@ msgstr "Це видалить усі групи опцій з цього тов�
 msgid "Billing address"
 msgstr "Адреса виставлення рахунку"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Додати значення фасету"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "Адміністратора успішно створено"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Опції товару"
 
@@ -3599,7 +3599,7 @@ msgstr "Перетягніть для зміни порядку"
 msgid "Zones"
 msgstr "Зони"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "Способи доставки"
 msgid "Select an address"
 msgstr "Виберіть адресу"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Так"
@@ -3792,7 +3792,7 @@ msgstr "Провести платіж"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "Разом податок"
 msgid "Draft order status"
 msgstr "Статус чернетки замовлення"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Пошук варіантів..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "Система"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Назва варіанта"
 
@@ -5514,7 +5514,7 @@ msgstr "Видалити"
 msgid "Failed to update customer"
 msgstr "Не вдалося оновити клієнта"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Видалити групи опцій?"
 
@@ -5925,7 +5925,7 @@ msgstr "Виконані товари ({0})"
 msgid "Create your first product"
 msgstr "Створіть свій перший товар"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Значення оновлено"
 
@@ -6162,7 +6162,7 @@ msgstr "Спробуйте вибрати інший діапазон дат."
 msgid "Successfully created zone"
 msgstr "Зону успішно створено"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Значення"
 
@@ -6299,7 +6299,7 @@ msgstr "ID повернення"
 msgid "Order custom fields updated"
 msgstr "Користувацькі поля замовлення оновлено"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Пошук записів..."
 
@@ -6703,7 +6703,7 @@ msgstr "Поріг відсутності на складі"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "Товар успішно видалено з каналу"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Не вдалося оновити значення"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "Не вдалося додати клієнта до групи"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Керування варіантами"
 

--- a/packages/dashboard/src/i18n/locales/uz.po
+++ b/packages/dashboard/src/i18n/locales/uz.po
@@ -321,7 +321,7 @@ msgstr "Ushbu variant o'chirilsinmi?"
 msgid "Failed to create administrator"
 msgstr "Administrator yaratib bo'lmadi"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "Yo'q"
@@ -445,8 +445,8 @@ msgstr "Zaxiraga qaytarish"
 msgid "Visibility"
 msgstr "Ko'rinish"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "Mahsulot variantlari"
 
@@ -936,7 +936,7 @@ msgstr "Buyurtma qatori olib tashlandi"
 msgid "Content:"
 msgstr "Tarkib:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "Kalit"
 
@@ -1163,8 +1163,8 @@ msgstr "Qoralama buyurtma"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "Elektron pochta manzilingizni kiriting, parolingizni tiklash uchun sizga havola yuboramiz"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "Qamrov"
 
@@ -1291,7 +1291,7 @@ msgid "Resize image from right"
 msgstr "Rasm o'lchamini o'ngdan o'zgartirish"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "Sozlamalar do'koni"
 
@@ -2115,9 +2115,9 @@ msgstr "Eslatmani yangilab bo'lmadi"
 msgid "Refund shipping"
 msgstr "Yetkazib berish uchun pul qaytarish"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "Faqat o'qish uchun"
 
@@ -2134,7 +2134,7 @@ msgid "Test Shipping Method"
 msgstr "Yetkazib berish usulini sinash"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "Faset qiymatlari"
 
@@ -2812,11 +2812,11 @@ msgstr "Yetkazib berishni qayta hisoblash"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "Assetlar"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "Bu mahsulotdagi barcha optsiya guruhlarini olib tashlaydi va variant sozlash tanloviga qaytaradi."
 
@@ -2826,7 +2826,7 @@ msgstr "Bu mahsulotdagi barcha optsiya guruhlarini olib tashlaydi va variant soz
 msgid "Billing address"
 msgstr "Hisob-faktura manzili"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "Faset qiymatini qoʻshish"
@@ -2933,7 +2933,7 @@ msgid "Successfully created administrator"
 msgstr "Administrator yaratildi"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "Mahsulot opsiyalari"
 
@@ -3507,7 +3507,7 @@ msgstr "Qayta tartiblash uchun torting"
 msgid "Zones"
 msgstr "Hududlar"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3618,7 +3618,7 @@ msgstr "Yetkazib berish usullari"
 msgid "Select an address"
 msgstr "Manzilni tanlang"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "Ha"
@@ -3696,7 +3696,7 @@ msgstr "To'lovni yakunlash"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3820,8 +3820,8 @@ msgstr "Jami soliq"
 msgid "Draft order status"
 msgstr "Qoralama buyurtma holati"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "Variantlarni qidirish..."
 
@@ -5336,7 +5336,7 @@ msgid "System"
 msgstr "Tizim"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "Variant nomi"
 
@@ -5350,7 +5350,7 @@ msgstr "Olib tashlash"
 msgid "Failed to update customer"
 msgstr "Mijozni yangilab bo'lmadi"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "Optsiya guruhlari olib tashlansinmi?"
 
@@ -5741,7 +5741,7 @@ msgstr "Bajarilgan elementlar ({0})"
 msgid "Create your first product"
 msgstr "Birinchi mahsulotingizni yarating"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "Qiymat yangilandi"
 
@@ -5970,7 +5970,7 @@ msgstr "Boshqa sana oralig'ini tanlab ko'ring."
 msgid "Successfully created zone"
 msgstr "Hudud muvaffaqiyatli yaratildi"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "Qiymat"
 
@@ -6103,7 +6103,7 @@ msgstr "Pul qaytarish ID"
 msgid "Order custom fields updated"
 msgstr "Buyurtmaning maxsus maydonlari yangilandi"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "Yozuvlarni qidirish..."
 
@@ -6495,7 +6495,7 @@ msgstr "{failed} ta {entityName} ni o'chirish amalga oshmadi"
 msgid "Out-of-stock threshold"
 msgstr "Zaxira tugash chegarasi"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "Qiymatni yangilash amalga oshmadi"
 
@@ -6519,7 +6519,7 @@ msgid "Failed to add customer to group"
 msgstr "Mijozni guruhga qo'shish amalga oshmadi"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "Variantlarni boshqarish"
 

--- a/packages/dashboard/src/i18n/locales/zh_Hans.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hans.po
@@ -345,7 +345,7 @@ msgstr "确定要删除此变体吗？"
 msgid "Failed to create administrator"
 msgstr "创建管理员失败"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "否"
@@ -469,8 +469,8 @@ msgstr "退回库存"
 msgid "Visibility"
 msgstr "可见性"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "产品变体"
 
@@ -964,7 +964,7 @@ msgstr "订单行已删除"
 msgid "Content:"
 msgstr "内容:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "密钥"
 
@@ -1195,8 +1195,8 @@ msgstr "草稿订单"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "输入您的电子邮件地址，我们将向您发送重置密码的链接"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "范围"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "从右侧调整图片大小"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "设置商店"
 
@@ -2182,9 +2182,9 @@ msgstr "更新备注失败"
 msgid "Refund shipping"
 msgstr "退还运费"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "只读"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "测试配送方式"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "属性值"
 
@@ -2891,11 +2891,11 @@ msgstr "重新计算运费"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "资源"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "这将移除此产品的所有选项组并返回变体设置选择。"
 
@@ -2905,7 +2905,7 @@ msgstr "这将移除此产品的所有选项组并返回变体设置选择。"
 msgid "Billing address"
 msgstr "账单地址"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "添加属性值"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "成功创建管理员"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "商品选项"
 
@@ -3599,7 +3599,7 @@ msgstr "拖动以重新排序"
 msgid "Zones"
 msgstr "区域"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "配送方式"
 msgid "Select an address"
 msgstr "选择一个地址"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "是"
@@ -3792,7 +3792,7 @@ msgstr "完成支付"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "税费总计"
 msgid "Draft order status"
 msgstr "草稿订单状态"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "搜索变体..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "系统"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "变体名称"
 
@@ -5514,7 +5514,7 @@ msgstr "删除"
 msgid "Failed to update customer"
 msgstr "更新客户失败"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "移除选项组？"
 
@@ -5925,7 +5925,7 @@ msgstr "已履行的项目 ({0})"
 msgid "Create your first product"
 msgstr "创建您的第一个商品"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "值已更新"
 
@@ -6162,7 +6162,7 @@ msgstr "请尝试选择其他日期范围。"
 msgid "Successfully created zone"
 msgstr "已成功创建区域"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "值"
 
@@ -6299,7 +6299,7 @@ msgstr "退款 ID"
 msgid "Order custom fields updated"
 msgstr "订单自定义字段已更新"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "搜索条目..."
 
@@ -6703,7 +6703,7 @@ msgstr "缺货阈值"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "已成功从渠道移除产品"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "更新值失败"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "将客户添加到组失败"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "管理变体"
 

--- a/packages/dashboard/src/i18n/locales/zh_Hant.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hant.po
@@ -345,7 +345,7 @@ msgstr "確定要刪除此變體嗎？"
 msgid "Failed to create administrator"
 msgstr "建立管理員失敗"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:338
+#: src/app/routes/_authenticated/_system/settings-store.tsx:402
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "No"
 msgstr "否"
@@ -469,8 +469,8 @@ msgstr "退回庫存"
 msgid "Visibility"
 msgstr "可見性"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:288
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:302
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:287
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:301
 msgid "Product variants"
 msgstr "產品變體"
 
@@ -964,7 +964,7 @@ msgstr "訂單行已移除"
 msgid "Content:"
 msgstr "內容:"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:270
+#: src/app/routes/_authenticated/_system/settings-store.tsx:360
 msgid "Key"
 msgstr "金鑰"
 
@@ -1195,8 +1195,8 @@ msgstr "草稿訂單"
 msgid "Enter your email address and we will send you a link to reset your password"
 msgstr "輸入您的電子郵件地址，我們將傳送重設密碼的連結給您"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:291
-#: src/app/routes/_authenticated/_system/settings-store.tsx:325
+#: src/app/routes/_authenticated/_system/settings-store.tsx:362
+#: src/app/routes/_authenticated/_system/settings-store.tsx:389
 msgid "Scope"
 msgstr "範圍"
 
@@ -1327,7 +1327,7 @@ msgid "Resize image from right"
 msgstr "從右側調整圖片大小"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:37
-#: src/app/routes/_authenticated/_system/settings-store.tsx:314
+#: src/app/routes/_authenticated/_system/settings-store.tsx:377
 msgid "Settings Store"
 msgstr "設定商店"
 
@@ -2182,9 +2182,9 @@ msgstr "更新備註失敗"
 msgid "Refund shipping"
 msgstr "退還運費"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:299
-#: src/app/routes/_authenticated/_system/settings-store.tsx:303
-#: src/app/routes/_authenticated/_system/settings-store.tsx:335
+#: src/app/routes/_authenticated/_system/settings-store.tsx:321
+#: src/app/routes/_authenticated/_system/settings-store.tsx:363
+#: src/app/routes/_authenticated/_system/settings-store.tsx:399
 msgid "Readonly"
 msgstr "唯讀"
 
@@ -2201,7 +2201,7 @@ msgid "Test Shipping Method"
 msgstr "測試配送方式"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:767
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:348
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:347
 msgid "Facet Values"
 msgstr "屬性值"
 
@@ -2891,11 +2891,11 @@ msgstr "重新計算運費"
 #: src/app/routes/_authenticated/_assets/assets.tsx:40
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:248
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:777
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:381
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:380
 msgid "Assets"
 msgstr "資源"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:321
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
 msgid "This will remove all option groups from this product and return to the variant setup choice."
 msgstr "這將移除此產品的所有選項群組並返回變體設定選擇。"
 
@@ -2905,7 +2905,7 @@ msgstr "這將移除此產品的所有選項群組並返回變體設定選擇。
 msgid "Billing address"
 msgstr "帳單地址"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:65
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:64
 #: src/app/routes/_authenticated/_products/components/assign-facet-values-dialog.tsx:173
 msgid "Add facet value"
 msgstr "新增屬性值"
@@ -3017,7 +3017,7 @@ msgid "Successfully created administrator"
 msgstr "成功建立管理員"
 
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:196
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:329
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:328
 msgid "Product Options"
 msgstr "商品選項"
 
@@ -3599,7 +3599,7 @@ msgstr "拖曳以重新排序"
 msgid "Zones"
 msgstr "區域"
 
-#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:112
+#: src/app/routes/_authenticated/_facets/components/facet-values-table.tsx:111
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:151
 #: src/lib/components/shared/facet-value-selector.tsx:124
 msgid "Search facet values..."
@@ -3710,7 +3710,7 @@ msgstr "配送方式"
 msgid "Select an address"
 msgstr "選取一個地址"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:337
+#: src/app/routes/_authenticated/_system/settings-store.tsx:401
 #: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
 msgid "Yes"
 msgstr "是"
@@ -3792,7 +3792,7 @@ msgstr "完成付款"
 #: src/app/routes/_authenticated/_channels/channels.tsx:15
 #: src/app/routes/_authenticated/_channels/channels.tsx:24
 #: src/app/routes/_authenticated/_option-groups/option-groups_.$id.tsx:210
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:358
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:357
 #: src/app/routes/_authenticated/_roles/roles_.$id.tsx:111
 #: src/lib/components/layout/channel-switcher.tsx:146
 msgid "Channels"
@@ -3923,8 +3923,8 @@ msgstr "稅金總計"
 msgid "Draft order status"
 msgstr "草稿訂單狀態"
 
-#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:167
-#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:80
+#: src/app/routes/_authenticated/_collections/components/collection-contents-preview-table.tsx:166
+#: src/app/routes/_authenticated/_collections/components/collection-contents-table.tsx:79
 msgid "Search variants..."
 msgstr "搜尋變體..."
 
@@ -5500,7 +5500,7 @@ msgid "System"
 msgstr "系統"
 
 #: src/app/routes/_authenticated/_product-variants/product-variants_.$id.tsx:563
-#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:88
+#: src/app/routes/_authenticated/_products/components/product-variants-table.tsx:85
 msgid "Variant name"
 msgstr "變體名稱"
 
@@ -5514,7 +5514,7 @@ msgstr "移除"
 msgid "Failed to update customer"
 msgstr "更新客戶失敗"
 
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:320
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:319
 msgid "Remove option groups?"
 msgstr "移除選項群組？"
 
@@ -5925,7 +5925,7 @@ msgstr "已履行的項目 ({0})"
 msgid "Create your first product"
 msgstr "建立您的第一個商品"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:246
+#: src/app/routes/_authenticated/_system/settings-store.tsx:345
 msgid "Value updated"
 msgstr "值已更新"
 
@@ -6162,7 +6162,7 @@ msgstr "請嘗試選擇其他日期範圍。"
 msgid "Successfully created zone"
 msgstr "已成功建立區域"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:278
+#: src/app/routes/_authenticated/_system/settings-store.tsx:361
 msgid "Value"
 msgstr "值"
 
@@ -6299,7 +6299,7 @@ msgstr "退款 ID"
 msgid "Order custom fields updated"
 msgstr "訂單自訂欄位已更新"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:320
+#: src/app/routes/_authenticated/_system/settings-store.tsx:384
 msgid "Search entries..."
 msgstr "搜尋條目..."
 
@@ -6703,7 +6703,7 @@ msgstr "缺貨臨界值"
 #~ msgid "Successfully removed product from channel"
 #~ msgstr "已成功從頻道移除產品"
 
-#: src/app/routes/_authenticated/_system/settings-store.tsx:249
+#: src/app/routes/_authenticated/_system/settings-store.tsx:348
 msgid "Failed to update value"
 msgstr "更新值失敗"
 
@@ -6727,7 +6727,7 @@ msgid "Failed to add customer to group"
 msgstr "將客戶新增至群組失敗"
 
 #: src/app/routes/_authenticated/_products/products_.$id_.variants.tsx:338
-#: src/app/routes/_authenticated/_products/products_.$id.tsx:292
+#: src/app/routes/_authenticated/_products/products_.$id.tsx:291
 msgid "Manage variants"
 msgstr "管理變體"
 

--- a/packages/dashboard/src/lib/components/data-table/data-table.stories.tsx
+++ b/packages/dashboard/src/lib/components/data-table/data-table.stories.tsx
@@ -169,6 +169,7 @@ export const Playground: Story = {
                     <PageLayout>
                         <FullWidthPageBlock blockId="test-block">
                             <DataTable
+                                enableViews
                                 columns={columns}
                                 data={paginatedData}
                                 totalItems={totalItems}

--- a/packages/dashboard/src/lib/components/data-table/data-table.tsx
+++ b/packages/dashboard/src/lib/components/data-table/data-table.tsx
@@ -153,15 +153,15 @@ interface DataTableProps<TData> {
     disableViewOptions?: boolean;
     /**
      * @description
-     * When true, suppresses the saved-views tabs even when a page context and
-     * filter handler are present. Useful for tables embedded in a detail page,
-     * where saved views (keyed only by page id and block id) would otherwise be
-     * shared across every entity showing that block. Filtering and column
-     * customization are unaffected.
+     * Enables saved-view controls for this table. This should be used for tables
+     * which represent a whole data set, such as top-level list pages. It should
+     * not be enabled for embedded tables or tables whose query is already scoped
+     * by a predefined filter.
      *
+     * @default false
      * @since 3.8.0
      */
-    hideViewsControls?: boolean;
+    enableViews?: boolean;
     bulkActions?: BulkActionsInput;
     /**
      * @description
@@ -261,7 +261,7 @@ export function DataTable<TData>({
     defaultColumnVisibility,
     facetedFilters,
     disableViewOptions,
-    hideViewsControls,
+    enableViews,
     bulkActions,
     setTableOptions,
     onRefresh,
@@ -453,7 +453,7 @@ export function DataTable<TData>({
         return merged;
     };
 
-    const showViewsControls = !hideViewsControls && !!pageId && !!onFilterChange;
+    const showViewsControls = !!enableViews && !!pageId && !!onFilterChange;
     const hasHeaderControls = actions != null || !disableViewOptions || onRefresh != null;
     // With a title, the icon controls and CTAs move up next to it (header band
     // line 1) and the toolbar row carries only search/filters. Without a title,

--- a/packages/dashboard/src/lib/components/shared/paginated-list-data-table.stories.tsx
+++ b/packages/dashboard/src/lib/components/shared/paginated-list-data-table.stories.tsx
@@ -64,6 +64,7 @@ export const Playground: Story = {
                     <PageLayout>
                         <FullWidthPageBlock blockId="test-block">
                             <PaginatedListDataTable
+                                enableViews
                                 listQuery={productsListDocument}
                                 defaultVisibility={{
                                     id: false,

--- a/packages/dashboard/src/lib/components/shared/paginated-list-data-table.tsx
+++ b/packages/dashboard/src/lib/components/shared/paginated-list-data-table.tsx
@@ -228,15 +228,15 @@ export interface PaginatedListDataTableProps<
     disableViewOptions?: boolean;
     /**
      * @description
-     * When true, suppresses the saved-views tabs even when a page context and
-     * filter handler are present. Useful for tables embedded in a detail page,
-     * where saved views (keyed only by page id and block id) would otherwise be
-     * shared across every entity showing that block. Filtering and column
-     * customization are unaffected.
+     * Enables saved-view controls for this table. This should be used for tables
+     * which represent a whole data set, such as top-level list pages. It should
+     * not be enabled for embedded tables or tables whose query is already scoped
+     * by a predefined filter.
      *
+     * @default false
      * @since 3.8.0
      */
-    hideViewsControls?: boolean;
+    enableViews?: boolean;
     transformData?: (data: PaginatedListItemFields<T>[]) => PaginatedListItemFields<T>[];
     setTableOptions?: (table: TableOptions<any>) => TableOptions<any>;
     /**
@@ -451,7 +451,7 @@ export function PaginatedListDataTable<
     rowActions,
     bulkActions,
     disableViewOptions,
-    hideViewsControls,
+    enableViews,
     setTableOptions,
     transformData,
     registerRefresher,
@@ -599,7 +599,7 @@ export function PaginatedListDataTable<
                     defaultColumnVisibility={columnVisibility}
                     facetedFilters={facetedFilters}
                     disableViewOptions={disableViewOptions}
-                    hideViewsControls={hideViewsControls}
+                    enableViews={enableViews}
                     bulkActions={bulkActions}
                     setTableOptions={setTableOptions}
                     onRefresh={refetchPaginatedList}

--- a/packages/dashboard/src/lib/framework/page/list-page.tsx
+++ b/packages/dashboard/src/lib/framework/page/list-page.tsx
@@ -637,6 +637,7 @@ export function ListPage<
                 <FullWidthPageBlock blockId="list-table">
                     <PaginatedListDataTable
                         {...commonTableProps}
+                        enableViews
                         onReorder={onReorder}
                         disableDragAndDrop={disableDragAndDrop}
                     />


### PR DESCRIPTION
# Description

Makes saved data-table views opt-in via `enableViews`, with `ListPage` and the Settings Store opting in while scoped detail tables remain view-free by default. This prevents saved filters from leaking across entity-specific embedded tables and fixes the Settings Store's manual filter metadata, key filtering, and translated column headers. Regression coverage, Storybook examples, E2E expectations, and i18n source references are updated accordingly.

# Breaking changes

`hideViewsControls` is replaced by the opt-in `enableViews` prop on `DataTable` and `PaginatedListDataTable`.

# Screenshots

Not included.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786873464&installation_id=128408429&pr_number=4993&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4993&signature=197c4a107e6b44949a5b1138f8ff95fa283387154e455f9e21d96af3e15e9446"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->