### PR TITLE
fix(dashboard): Refresh customer history after updating customer

### DIFF
--- a/packages/dashboard/e2e/tests/customers/customers.spec.ts
+++ b/packages/dashboard/e2e/tests/customers/customers.spec.ts
@@ -1,4 +1,7 @@
+import { expect, test } from '@playwright/test';
+
 import { createCrudTestSuite } from '../../utils/crud-test-factory.js';
+import { VendureAdminClient } from '../../utils/vendure-admin-client.js';
 
 createCrudTestSuite({
     entityName: 'customer',
@@ -14,4 +17,38 @@ createCrudTestSuite({
     ],
     searchTerm: 'TestCustomer',
     updateFields: [{ label: 'Last name', value: 'TestCustomerUpdated' }],
+});
+
+// #4997 — the history timeline must refresh after updating the customer,
+// without requiring a full page reload
+test('should show new history entries after updating the customer', async ({ page }) => {
+    const client = new VendureAdminClient(page);
+    await client.login();
+    const result = await client.gql(
+        `mutation CreateCustomerForHistoryTest($input: CreateCustomerInput!) {
+            createCustomer(input: $input) {
+                ... on Customer { id }
+                ... on ErrorResult { errorCode message }
+            }
+        }`,
+        {
+            input: {
+                firstName: 'History',
+                lastName: 'RefreshTest',
+                emailAddress: `history-refresh-test-${Date.now()}@example.com`,
+            },
+        },
+    );
+    const customerId = result.createCustomer.id;
+    expect(customerId).toBeTruthy();
+
+    await page.goto(`/customers/${customerId}`);
+    await expect(page.getByRole('heading', { name: 'History RefreshTest' })).toBeVisible();
+    await expect(page.getByText('Customer details updated')).toHaveCount(0);
+
+    await page.getByLabel('Last name').fill('RefreshTestUpdated');
+    await page.getByRole('button', { name: 'Update' }).click();
+    await expect(page.getByText('Successfully updated customer')).toBeVisible();
+
+    await expect(page.getByText('Customer details updated').first()).toBeVisible();
 });

--- a/packages/dashboard/src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_customers/components/customer-history/use-customer-history.ts
@@ -1,7 +1,7 @@
 import { api } from '@/vdb/graphql/api.js';
 import { graphql, ResultOf } from '@/vdb/graphql/graphql.js';
 import { useLingui } from '@lingui/react/macro';
-import { useInfiniteQuery, useMutation } from '@tanstack/react-query';
+import { QueryKey, useInfiniteQuery, useMutation } from '@tanstack/react-query';
 import { useState } from 'react';
 import { toast } from 'sonner';
 
@@ -54,6 +54,10 @@ export interface UseCustomerHistoryResult {
     hasNextPage: boolean;
 }
 
+export function customerHistoryQueryKey(customerId: string): QueryKey {
+    return ['CustomerHistory', customerId];
+}
+
 export function useCustomerHistory({
     customerId,
     pageSize = 10,
@@ -64,7 +68,7 @@ export function useCustomerHistory({
     const [isLoading, setIsLoading] = useState(false);
     const { i18n } = useLingui();
 
-    // Fetch order history
+    // Fetch customer history
     const {
         data,
         isLoading: isLoadingQuery,
@@ -82,7 +86,7 @@ export function useCustomerHistory({
                     take: pageSize,
                 },
             }),
-        queryKey: ['CustomerHistory', customerId],
+        queryKey: customerHistoryQueryKey(customerId),
         initialPageParam: 0,
         getNextPageParam: (lastPage, pages, lastPageParam) => {
             const totalItems = lastPage.customer?.history?.totalItems ?? 0;

--- a/packages/dashboard/src/app/routes/_authenticated/_customers/customers_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customers/customers_.$id.tsx
@@ -36,6 +36,7 @@ import { toast } from 'sonner';
 import { CustomerAddressCard } from './components/customer-address-card.js';
 import { CustomerAddressForm } from './components/customer-address-form.js';
 import { CustomerHistoryContainer } from './components/customer-history/customer-history-container.js';
+import { customerHistoryQueryKey } from './components/customer-history/use-customer-history.js';
 import { CustomerOrderTable } from './components/customer-order-table.js';
 import { CustomerStatusBadge } from './components/customer-status-badge.js';
 import {
@@ -102,7 +103,7 @@ function CustomerDetailPage() {
                 if (creatingNewEntity) {
                     await navigate({ to: `../$id`, params: { id: data.id } });
                 } else {
-                    await queryClient.invalidateQueries({ queryKey: ['CustomerHistory', data.id] });
+                    await queryClient.invalidateQueries({ queryKey: customerHistoryQueryKey(data.id) });
                 }
             } else {
                 toast.error(creatingNewEntity ? t`Failed to create customer` : t`Failed to update customer`, {

--- a/packages/dashboard/src/app/routes/_authenticated/_customers/customers_.$id.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_customers/customers_.$id.tsx
@@ -28,7 +28,7 @@ import { detailPageRouteLoader } from '@/vdb/framework/page/detail-page-route-lo
 import { useDetailPage } from '@/vdb/framework/page/use-detail-page.js';
 import { api } from '@/vdb/graphql/api.js';
 import { Trans, useLingui } from '@lingui/react/macro';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { createFileRoute, useNavigate } from '@tanstack/react-router';
 import { Plus } from 'lucide-react';
 import { useState } from 'react';
@@ -70,6 +70,7 @@ function CustomerDetailPage() {
     const navigate = useNavigate();
     const creatingNewEntity = params.id === NEW_ENTITY_PATH;
     const { t } = useLingui();
+    const queryClient = useQueryClient();
     const [newAddressOpen, setNewAddressOpen] = useState(false);
 
     const { form, submitHandler, entity, isPending, refreshEntity, resetForm } = useDetailPage({
@@ -100,6 +101,8 @@ function CustomerDetailPage() {
                 resetForm();
                 if (creatingNewEntity) {
                     await navigate({ to: `../$id`, params: { id: data.id } });
+                } else {
+                    await queryClient.invalidateQueries({ queryKey: ['CustomerHistory', data.id] });
                 }
             } else {
                 toast.error(creatingNewEntity ? t`Failed to create customer` : t`Failed to update customer`, {


### PR DESCRIPTION
# Description

On the customer detail page, the history timeline was not refreshed after saving changes to the customer — new entries (e.g. `CUSTOMER_DETAIL_UPDATED`) only appeared after a full page reload. The update mutation's `onSuccess` now invalidates the `['CustomerHistory', id]` query so the timeline refetches immediately.

Fixes #4997

# Breaking changes

None.

# Screenshots

N/A

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/4998"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786884034&installation_id=128408429&pr_number=4998&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F4998&signature=0a9f08be770ee04b941ec46a303b5767f93544b4f9b0bc8355f93a19f2b9c2d8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->