### PR TITLE
fix(admin-ui): Fix missing currency button on initial load (#4140)

### DIFF
--- a/packages/admin-ui/src/lib/catalog/src/components/product-variant-detail/product-variant-detail.component.ts
+++ b/packages/admin-ui/src/lib/catalog/src/components/product-variant-detail/product-variant-detail.component.ts
@@ -31,6 +31,7 @@ import {
     mergeMap,
     shareReplay,
     skip,
+    startWith,
     switchMap,
     switchMapTo,
     take,
@@ -138,7 +139,10 @@ export class ProductVariantDetailComponent
             tap(data => (this.channelDefaultCurrencyCode = data.activeChannel.defaultCurrencyCode)),
             map(data => data.activeChannel.availableCurrencyCodes),
         );
-        this.unusedCurrencyCodes$ = combineLatest(this.pricesForm.valueChanges, availableCurrencyCodes$).pipe(
+        this.unusedCurrencyCodes$ = combineLatest([
+            this.pricesForm.valueChanges.pipe(startWith(this.pricesForm.value)),
+            availableCurrencyCodes$
+        ]).pipe(
             map(([prices, currencyCodes]) =>
                 currencyCodes.filter(code => !prices.map(p => p.currencyCode).includes(code)),
             ),


### PR DESCRIPTION
# Description

Fixes #4140.

The "Add a price in another currency" button in the Product Variant detail view was failing to render on the initial page load. 

**Root Cause:** The button's visibility is controlled by the `unusedCurrencyCodes$` observable, which utilized a `combineLatest` stream containing `this.pricesForm.valueChanges`. Because Angular's `valueChanges` does not emit on initialization, the stream was blocked until the form was manually interacted with or a different variant was selected.

**Fix:** Appended the RxJS `startWith` operator to `this.pricesForm.valueChanges`, forcing it to immediately emit the form's initial state. This unblocks the `combineLatest` stream and ensures the button renders correctly on the first paint.

# Breaking changes

None.

# Screenshots

*(Feel free to drag and drop a screenshot of the working button here if you'd like, otherwise you can delete this section.)*

# Checklist

🚀 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](# "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5002"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786974792&installation_id=128408429&pr_number=5002&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5002&signature=5c8d7a4195e2271cedb1580d0e0b36c1c59b89bea20996c2fc29fc550bf67375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->