### PR TITLE
fix(core): Guard relation custom field resolution against a missing entity id

### DIFF
--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -454,6 +454,51 @@ describe('Custom field relations', () => {
 
                 assertCustomFieldIds(updateCustomerAddress.customFields, 'T_3', ['T_2', 'T_4']);
             });
+
+            // Regression: an OrderAddress (Order.shippingAddress / billingAddress) is an embedded
+            // value object with no `id`, so its relation custom fields cannot be resolved by a parent
+            // entity id. Previously this threw "The loader.load() function must be called with a
+            // value, but got: undefined"; it must now resolve to null / [] instead of crashing.
+            it('order shippingAddress resolves relation custom fields without throwing', async () => {
+                await shopClient.asUserWithCredentials('hayden.zieme12@hotmail.com', 'test');
+                await shopClient.query(gql`
+                    mutation {
+                        addItemToOrder(productVariantId: "T_1", quantity: 1) {
+                            ... on Order {
+                                id
+                            }
+                        }
+                    }
+                `);
+                await shopClient.query(gql`
+                    mutation {
+                        setOrderShippingAddress(
+                            input: {
+                                countryCode: "GB"
+                                streetLine1: "Test Street"
+                                customFields: { singleId: "T_1", multiIds: ["T_1", "T_2"] }
+                            }
+                        ) {
+                            ... on Order {
+                                id
+                            }
+                        }
+                    }
+                `);
+
+                const { activeOrder } = await shopClient.query(gql`
+                    query {
+                        activeOrder {
+                            shippingAddress {
+                                ${customFieldsSelection}
+                            }
+                        }
+                    }
+                `);
+
+                expect(activeOrder.shippingAddress.customFields.single).toBeNull();
+                expect(activeOrder.shippingAddress.customFields.multi).toEqual([]);
+            });
         });
 
         describe('Collection entity', () => {

--- a/packages/core/src/api/common/custom-field-relation-resolver.service.ts
+++ b/packages/core/src/api/common/custom-field-relation-resolver.service.ts
@@ -16,7 +16,7 @@ import { RequestContext } from './request-context';
 
 export interface ResolveRelationConfig {
     ctx: RequestContext;
-    entityId: ID;
+    entityId: ID | undefined;
     entityName: string;
     fieldDef: RelationCustomFieldConfig;
 }
@@ -39,6 +39,15 @@ export class CustomFieldRelationResolverService {
      */
     async resolveRelation(config: ResolveRelationConfig): Promise<VendureEntity | VendureEntity[] | null> {
         const { ctx, entityId, entityName, fieldDef } = config;
+
+        // Embedded value objects such as OrderAddress (Order.shippingAddress / billingAddress) have
+        // no `id`, so `entityId` can be undefined. Passing it to DataLoader.load() would throw
+        // ("The loader.load() function must be called with a value, but got: undefined"); there is
+        // nothing to resolve by id, so return an empty result, matching the behaviour before
+        // relation custom fields were resolved via DataLoader.
+        if (entityId == null) {
+            return fieldDef.list ? [] : null;
+        }
 
         const loader = this.getLoader(ctx, entityName, fieldDef);
         const batchResult = await loader.load(entityId);


### PR DESCRIPTION
## Description

Relation-type custom fields selected on an embedded value object with no database `id` — the canonical case being `OrderAddress` (`Order.shippingAddress` / `billingAddress`) — crash with:

```
The loader.load() function must be called with a value, but got: undefined.
```

This is a regression from #4923 (*perf(core): resolve relation custom fields using request-scoped DataLoader batching*): relation custom fields are now resolved through a DataLoader keyed by the parent entity id. For an `OrderAddress` that id is `undefined` (it is a JSON snapshot with no entity id), so `DataLoader.load(undefined)` throws. It surfaces as a GraphQL error (HTTP 200 with an `errors` array), so it is invisible in server logs and can silently break checkout flows that read the order's shipping/billing address. Before #4923 these relations resolved without DataLoader and returned `null` on an `OrderAddress` rather than throwing.

## Fix

Guard the undefined `entityId` in `CustomFieldRelationResolverService.resolveRelation` and resolve to `null` (or `[]` for a list field) — an embedded value object legitimately has no id. `ResolveRelationConfig.entityId` is widened to `ID | undefined` to reflect what the single call site (`generate-resolvers.ts`, `source[ENTITY_ID_KEY]`) actually passes.

## Reproduction

1. Define a `relation` custom field on `Address` (any target entity).
2. Shop API: create an active order, then `setOrderShippingAddress` with the custom field set.
3. Query `activeOrder { shippingAddress { customFields { <relation> { id } } } }` → GraphQL error.

## Tests

Added an e2e regression test to `custom-field-relations.e2e-spec.ts` (`Address entity` group) that drives the order shipping-address path. Verified locally:

- **With the fix:** the `custom-field-relations` e2e suite passes (62/62).
- **Without the fix:** the new test fails with `The loader.load() function must be called with a value, but got: undefined.`

Fixes #5004

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5006"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787136217&installation_id=128408429&pr_number=5006&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5006&signature=b50f71c9b64d8e10f725a4070d6b8f2930b10c08daa2d1d54cdb708dd79ca7e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->