### PR TITLE
docs(core): Document creating a RequestContext for a specific user

### DIFF
--- a/docs/docs/guides/developer-guide/plugins/index.mdx
+++ b/docs/docs/guides/developer-guide/plugins/index.mdx
@@ -111,6 +111,34 @@ If you have code that should only run either in the server context or worker con
 you can inject the [ProcessContext provider](/reference/typescript-api/common/process-context/).
 :::
 
+A plugin can implement these hooks directly, rather than only on the providers it defines:
+
+```ts title="src/plugins/my-plugin/my.plugin.ts"
+import { OnApplicationBootstrap } from '@nestjs/common';
+import { PluginCommonModule, ProcessContext, VendurePlugin } from '@vendure/core';
+
+@VendurePlugin({
+    imports: [PluginCommonModule],
+})
+export class MyPlugin implements OnApplicationBootstrap {
+    constructor(private processContext: ProcessContext) {}
+
+    async onApplicationBootstrap() {
+        // Without this guard the work below would run twice: once in the
+        // server and once in the worker.
+        if (this.processContext.isWorker) {
+            return;
+        }
+        // Do something on the server only
+    }
+}
+```
+
+If that startup work needs to call Vendure's services, it will need a `RequestContext`, which
+outside of the request-response cycle you create yourself — see
+[Creating a RequestContext](/guides/developer-guide/stand-alone-scripts/#creating-a-requestcontext),
+including how to give it a user so that permission checks pass.
+
 ### Configure
 
 Another hook that is not strictly a lifecycle hook, but which can be useful to know is the [`configure` method](https://docs.nestjs.com/middleware#applying-middleware) which is

--- a/docs/docs/guides/developer-guide/stand-alone-scripts/index.mdx
+++ b/docs/docs/guides/developer-guide/stand-alone-scripts/index.mdx
@@ -113,3 +113,37 @@ async function getProductCount() {
     const { totalItems } = await productService.findAll(ctx, {take: 0});
 }
 ```
+
+### Acting as a specific user
+
+The context above is anonymous — it carries no user, and therefore no permissions. That is fine for
+services which do not check them, but services such as the [`RoleService`](/reference/typescript-api/services/role-service/)
+will reject it.
+
+To act as a particular user, pass that user in the `user` option. The example below loads the
+superadmin, which is usually what you want for an administrative script:
+
+```ts title="src/get-product-count.ts"
+// ...
+import { ConfigService, RequestContextService, TransactionalConnection, User } from '@vendure/core';
+
+async function getProductCount() {
+    const { app } = await bootstrapWorker(config);
+
+    // Load the user the script should act as. Any User will do — the superadmin is used here
+    // because an administrative script generally needs unrestricted permissions.
+    const { superadminCredentials } = app.get(ConfigService).authOptions; // [!code highlight]
+    const superAdminUser = await app // [!code highlight]
+        .get(TransactionalConnection) // [!code highlight]
+        .rawConnection.getRepository(User) // [!code highlight]
+        .findOneOrFail({ where: { identifier: superadminCredentials.identifier } }); // [!code highlight]
+
+    const ctx = await app.get(RequestContextService).create({
+        apiType: 'admin',
+        user: superAdminUser, // [!code highlight]
+    });
+
+    // `ctx` now carries the superadmin's permissions, so permission-checking
+    // services will accept it.
+}
+```

--- a/docs/docs/guides/developer-guide/stand-alone-scripts/index.mdx
+++ b/docs/docs/guides/developer-guide/stand-alone-scripts/index.mdx
@@ -136,7 +136,12 @@ async function getProductCount() {
     const superAdminUser = await app // [!code highlight]
         .get(TransactionalConnection) // [!code highlight]
         .rawConnection.getRepository(User) // [!code highlight]
-        .findOneOrFail({ where: { identifier: superadminCredentials.identifier } }); // [!code highlight]
+        .findOneOrFail({ // [!code highlight]
+            where: { identifier: superadminCredentials.identifier }, // [!code highlight]
+            // The roles (and their channels) must be loaded, or the resulting context // [!code highlight]
+            // has the user's id but no permissions. // [!code highlight]
+            relations: { roles: { channels: true } }, // [!code highlight]
+        }); // [!code highlight]
 
     const ctx = await app.get(RequestContextService).create({
         apiType: 'admin',
@@ -147,3 +152,10 @@ async function getProductCount() {
     // services will accept it.
 }
 ```
+
+:::note
+Loading the `roles` relation (and its `channels`) is what gives the context its permissions. Omit
+it and the context still has the user's id — enough for services that reload the user by id, but
+its `channelPermissions` are empty, so any check that reads them directly (for example the entity
+access-control checks behind `connection.getRepository(ctx, Entity)`) will deny access.
+:::

--- a/docs/docs/reference/typescript-api/request/request-context-service.mdx
+++ b/docs/docs/reference/typescript-api/request/request-context-service.mdx
@@ -30,6 +30,22 @@ class RequestContextService {
 Creates a RequestContext based on the config provided. This can be useful when interacting
 with services outside the request-response cycle, for example in stand-alone scripts or in
 worker jobs.
+
+Without a `user`, the resulting context is anonymous and carries no permissions, which
+services that perform permission checks will reject. Pass the `User` the context should act
+as — commonly the superadmin for administrative scripts:
+
+```ts
+const { superadminCredentials } = this.configService.authOptions;
+const superAdminUser = await this.connection.rawConnection
+    .getRepository(User)
+    .findOneOrFail({ where: { identifier: superadminCredentials.identifier } });
+
+const ctx = await this.requestContextService.create({
+    apiType: 'admin',
+    user: superAdminUser,
+});
+```
 ### fromRequest
 
 <MemberInfo kind="method" type={`(req: Request, info?: GraphQLResolveInfo, requiredPermissions?: <a href='/reference/typescript-api/common/permission#permission'>Permission</a>[], session?: <a href='/reference/typescript-api/auth/session-cache-strategy#cachedsession'>CachedSession</a>) => Promise<<a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>>`}   />

--- a/docs/docs/reference/typescript-api/request/request-context-service.mdx
+++ b/docs/docs/reference/typescript-api/request/request-context-service.mdx
@@ -37,9 +37,12 @@ as — commonly the superadmin for administrative scripts:
 
 ```ts
 const { superadminCredentials } = this.configService.authOptions;
-const superAdminUser = await this.connection.rawConnection
-    .getRepository(User)
-    .findOneOrFail({ where: { identifier: superadminCredentials.identifier } });
+const superAdminUser = await this.connection.rawConnection.getRepository(User).findOneOrFail({
+    where: { identifier: superadminCredentials.identifier },
+    // The roles (and their channels) must be loaded, or the resulting context
+    // has the user's id but no permissions.
+    relations: { roles: { channels: true } },
+});
 
 const ctx = await this.requestContextService.create({
     apiType: 'admin',

--- a/packages/core/src/service/helpers/request-context/request-context.service.ts
+++ b/packages/core/src/service/helpers/request-context/request-context.service.ts
@@ -36,6 +36,22 @@ export class RequestContextService {
      * with services outside the request-response cycle, for example in stand-alone scripts or in
      * worker jobs.
      *
+     * Without a `user`, the resulting context is anonymous and carries no permissions, which
+     * services that perform permission checks will reject. Pass the `User` the context should act
+     * as — commonly the superadmin for administrative scripts:
+     *
+     * ```ts
+     * const { superadminCredentials } = this.configService.authOptions;
+     * const superAdminUser = await this.connection.rawConnection
+     *     .getRepository(User)
+     *     .findOneOrFail({ where: { identifier: superadminCredentials.identifier } });
+     *
+     * const ctx = await this.requestContextService.create({
+     *     apiType: 'admin',
+     *     user: superAdminUser,
+     * });
+     * ```
+     *
      * @since 1.5.0
      */
     async create(config: {

--- a/packages/core/src/service/helpers/request-context/request-context.service.ts
+++ b/packages/core/src/service/helpers/request-context/request-context.service.ts
@@ -42,9 +42,12 @@ export class RequestContextService {
      *
      * ```ts
      * const { superadminCredentials } = this.configService.authOptions;
-     * const superAdminUser = await this.connection.rawConnection
-     *     .getRepository(User)
-     *     .findOneOrFail({ where: { identifier: superadminCredentials.identifier } });
+     * const superAdminUser = await this.connection.rawConnection.getRepository(User).findOneOrFail({
+     *     where: { identifier: superadminCredentials.identifier },
+     *     // The roles (and their channels) must be loaded, or the resulting context
+     *     // has the user's id but no permissions.
+     *     relations: { roles: { channels: true } },
+     * });
      *
      * const ctx = await this.requestContextService.create({
      *     apiType: 'admin',


### PR DESCRIPTION
## Summary

Documents how to give a manually-created `RequestContext` a user (and therefore permissions), which was previously undocumented. Resolves #3132.

## Root cause

`RequestContextService.create()` accepts a `user` option, but it was not mentioned anywhere in the docs or in the method's own doc block. Without it the created context is anonymous, and services that check permissions — e.g. `RoleService` — reject it. The reporter only discovered the option by reading the source.

## Change

- **Stand-alone scripts guide** — new "Acting as a specific user" section: load the superadmin and pass it to `create()`.
- **`RequestContextService.create()` doc block** — note the consequence of omitting `user`, with the same snippet; reference page regenerated.
- **Plugin lifecycle guide** — show the lifecycle hooks implemented on the plugin itself with a `ProcessContext` guard, linking on to the RequestContext section for startup work that calls services. (The existing `ProcessContext` example lives on the worker/job-queue page at *service* level; the reporter specifically asked for a *plugin*-level example, so this complements it rather than duplicating it.)

### A note on the user lookup

The reporter's original snippet used `getRepository(RequestContext.empty(), User)`. I used `rawConnection.getRepository(User)` instead: the two-arg `getRepository(ctx, …)` runs results through the entity access-control proxy, which with an empty context could filter out the very superadmin being fetched. `rawConnection` bypasses that, which is correct for a bootstrap lookup.

The lookup loads `relations: { roles: { channels: true } }` — without the roles (and their channels) the context would carry the user's id but an empty permission set, which passes id-reloading checks like `RoleService` but silently fails checks that read session permissions directly (e.g. the entity access-control checks behind `connection.getRepository(ctx, Entity)`).

## Test plan

- `docs` `test:mdx` — 830 files, 4748 code blocks, 0 errors
- `docs` `typecheck` (`tsc --noEmit`) — passes
- `@vendure/core` `build:core-common` — passes; the only source change is a JSDoc comment (verified: the diff outside comment lines is empty), reference page regenerated from it
- eslint on the touched core file — clean
- Every code sample's API surface verified against the source: `rawConnection` and `ConfigService.authOptions` are public; `ProcessContext` is injectable into a plugin class (global provider, re-exported by `PluginCommonModule`) and `isWorker` is a real getter; the `relations` are exactly what `getChannelPermissions` reads.

No runtime code changed, so there is nothing to e2e.

Fixes #3132

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5008"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787149447&installation_id=128408429&pr_number=5008&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5008&signature=0c71533cd66523cad57be2b2d61b3084dc04c5a23a04348d3a994b465de36480"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->