### PR TITLE
docs(dashboard): Document contributing UI translations to the Dashboard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ In order to make the best use of both your time and that of the Vendure maintain
   - [Release Process](#release-process)
 - [Specific Contributions](#specific-contributions)
   - [Contributing to the documentation](#contributing-to-the-documentation)
-  - [Contributing to the Admin UI translations](#contributing-to-the-admin-ui-translations)
+  - [Contributing to the Dashboard / Admin UI translations](#contributing-to-the-dashboard--admin-ui-translations)
 - [Help & Support](#help--support)
   - [Where to get help](#where-to-get-help)
   - [Contributor License Agreement](#contributor-license-agreement)
@@ -507,9 +507,12 @@ docs/docs
 > [!NOTE]
 > Files in the [reference](https://docs.vendure.io/reference/) directory are auto-generated. To edit reference documentation, modify the [JSDoc](https://jsdoc.app/about-getting-started) comments in the source code and run `bun run docs:build` from the project root directory.
 
-### Contributing to the Admin UI translations
+### Contributing to the Dashboard / Admin UI translations
 
-If you wish to contribute translations of the Admin UI into another language (or improve an existing set of translations), please see the [Localization guide](https://github.com/vendurehq/vendure/blob/master/packages/admin-ui/README.md#localization) in the admin-ui package.
+If you wish to contribute translations into another language (or improve an existing set of translations):
+
+- **React Dashboard** (`@vendure/dashboard`) — see [Contributing a translation of the Dashboard itself](https://docs.vendure.io/guides/extending-the-dashboard/localization/#contributing-a-translation-of-the-dashboard-itself) in the Localization guide.
+- **Legacy Angular Admin UI** (`@vendure/admin-ui`) — see the [Localization guide](https://github.com/vendurehq/vendure/blob/master/packages/admin-ui/README.md#localization) in the admin-ui package.
 
 ## Help & Support
 

--- a/docs/docs/guides/extending-the-dashboard/localization/index.mdx
+++ b/docs/docs/guides/extending-the-dashboard/localization/index.mdx
@@ -91,3 +91,59 @@ open up the `de.po` file and add German translations for each of the strings, by
 msgid "Welcome to Dashboard"
 msgstr "Willkommen zum Dashboard" # [!code highlight]
 ```
+
+## Contributing a translation of the Dashboard itself
+
+The sections above cover localizing **your own** extensions. If instead you want to translate the
+built-in Dashboard UI into a new language — or improve an existing translation — those catalogs live
+in the Vendure repository and the change is contributed via a pull request.
+
+:::note
+This is for the **React Dashboard** (`@vendure/dashboard`). The legacy Angular Admin UI has its own
+[separate translation workflow](https://github.com/vendurehq/vendure/blob/master/packages/admin-ui/README.md#localization).
+:::
+
+The Dashboard's own message catalogs live at `packages/dashboard/src/i18n/locales/{locale}.po`, one
+`.po` file per supported language. The English catalog (`en.po`) is the source and is always complete;
+the others are translations of it.
+
+### Improving an existing translation
+
+Open the catalog for the language you want to improve — for example `de.po` for German — and fill in
+or correct the `msgstr` values. An empty `msgstr` means that string is not yet translated and falls
+back to English at runtime.
+
+### Adding a new language
+
+1. Add the [locale code](https://lingui.dev/misc/faq#which-locales-and-formats-are-supported) to the
+   `locales` array in `packages/dashboard/lingui.config.js`.
+2. From `packages/dashboard`, generate the catalog:
+
+   ```bash
+   npm run i18n:extract
+   ```
+
+   This creates `src/i18n/locales/{locale}.po` containing every UI string with empty `msgstr` values.
+3. Fill in the `msgstr` values with your translations. There is nothing else to wire up — the
+   Dashboard loads catalogs by globbing that directory, so the new file is picked up automatically.
+
+### Testing your translation locally
+
+Run the development server so you can see your translations in the running Dashboard:
+
+```bash
+cd packages/dev-server
+bun run populate   # first time only, to seed test data
+bun run dev
+```
+
+Open the Dashboard (`http://localhost:3000/dashboard`), then switch the UI language from the user menu
+at the bottom of the sidebar → **Display language**, and choose your locale. The interface re-renders
+with your catalog; any string you left untranslated shows the English source.
+
+### Opening the pull request
+
+Commit the changed `.po` file(s) (and the `lingui.config.js` change, for a new language) and open a PR
+against `master`. A translation change is a `fix`, so title it accordingly, e.g.
+`fix(dashboard): Add Ukrainian UI translations`. Translations are always welcome, including partial
+ones — you don't have to translate every string to contribute.

--- a/docs/docs/guides/extending-the-dashboard/localization/index.mdx
+++ b/docs/docs/guides/extending-the-dashboard/localization/index.mdx
@@ -1,7 +1,7 @@
 ---
 title: 'Localization'
 metaTitle: "Localizing Vendure Dashboard Extensions with Lingui"
-metaDescription: "Add multi-language support to your Vendure Dashboard extensions using Lingui for string extraction, translation catalogs, and ICU MessageFormat."
+metaDescription: "Localize your Vendure Dashboard extensions with Lingui, and contribute UI translations of the Dashboard itself via a pull request."
 ---
 
 :::note
@@ -115,17 +115,22 @@ back to English at runtime.
 
 ### Adding a new language
 
-1. Add the [locale code](https://lingui.dev/misc/faq#which-locales-and-formats-are-supported) to the
-   `locales` array in `packages/dashboard/lingui.config.js`.
-2. From `packages/dashboard`, generate the catalog:
+1. Add the locale code to the `locales` array in `packages/dashboard/lingui.config.js`. It must be a
+   valid [`LanguageCode`](https://docs.vendure.io/reference/typescript-api/common/language-code/)
+   value, which uses underscores for region variants (`zh_Hans`, `pt_BR`).
+2. Add the same locale to `defaultAvailableLanguages` in `packages/dashboard/vite/constants.ts`. The
+   **Display language** selector is built from this list, so a catalog missing from it can never be
+   selected.
+3. From `packages/dashboard`, generate the catalog:
 
    ```bash
-   npm run i18n:extract
+   npx lingui extract
    ```
 
-   This creates `src/i18n/locales/{locale}.po` containing every UI string with empty `msgstr` values.
-3. Fill in the `msgstr` values with your translations. There is nothing else to wire up — the
-   Dashboard loads catalogs by globbing that directory, so the new file is picked up automatically.
+   This creates `src/i18n/locales/{locale}.po` with every UI string and empty `msgstr` values. Use
+   `npx lingui extract` rather than `npm run i18n:extract`, which also runs an LLM helper that writes
+   an untracked `missing-translations.txt`.
+4. Fill in the `msgstr` values. The Dashboard globs that directory, so nothing else needs registering.
 
 ### Testing your translation locally
 
@@ -137,13 +142,18 @@ bun run populate   # first time only, to seed test data
 bun run dev
 ```
 
-Open the Dashboard (`http://localhost:3000/dashboard`), then switch the UI language from the user menu
-at the bottom of the sidebar → **Display language**, and choose your locale. The interface re-renders
-with your catalog; any string you left untranslated shows the English source.
+`bun run dev` prints the Dashboard URL when it starts — open that. It serves from Vite, so `.po` edits
+are picked up on reload (the static build served by `DashboardPlugin` would need a rebuild). Then switch
+the UI language from the user menu at the bottom of the sidebar → **Display language**, and choose your
+locale. The interface re-renders with your catalog; any string you left untranslated shows the English source.
 
 ### Opening the pull request
 
-Commit the changed `.po` file(s) (and the `lingui.config.js` change, for a new language) and open a PR
-against `master`. A translation change is a `fix`, so title it accordingly, e.g.
-`fix(dashboard): Add Ukrainian UI translations`. Translations are always welcome, including partial
-ones — you don't have to translate every string to contribute.
+Commit the changed `.po` file(s) (and, for a new language, the `lingui.config.js` and
+`vite/constants.ts` changes) and open a PR against `master`. A translation change is a `fix`, so title
+it accordingly, e.g. `fix(dashboard): Add Ukrainian UI translations`. Translations are always welcome,
+including partial ones — you don't have to translate every string to contribute.
+
+Two CI checks gate a translation PR: **`dashboard i18n sync`** (runs `lingui extract` and fails if the
+committed catalogs are out of date) and **`i18n:check`** (per-locale catalog validation). Run
+`npx lingui extract` from `packages/dashboard` and commit the result so the sync check stays green.


### PR DESCRIPTION
## Summary

Adds documentation for translating the built-in React Dashboard UI into a new language, a contributor workflow that was undocumented. Resolves #3989.

## Background

Per Michael's note on the issue, the extension-localization docs already exist (`extending-the-dashboard/localization`), and CONTRIBUTING pointed translation contributors at the **legacy Angular Admin UI** readme. The gap was the **core React Dashboard** contributor workflow: which `.po` catalogs to edit in `packages/dashboard`, how to run the dashboard locally in a target locale to test, and the PR process. That guidance did not exist.

## Change

- **Localization guide** — new "Contributing a translation of the Dashboard itself" section, distinct from the existing extension-localization content it follows:
  - catalogs live at `packages/dashboard/src/i18n/locales/{locale}.po`
  - improving an existing translation (fill in `msgstr`)
  - adding a new language: add the locale to `packages/dashboard/lingui.config.js` and run `npm run i18n:extract`; the loader globs the directory (`import.meta.glob('*.po')`), so nothing else needs wiring
  - testing locally: dev-server, then the user menu → **Display language**
  - opening the PR (a translation is a `fix`)
- **CONTRIBUTING.md** — the translations section now points at both the Dashboard guide and the legacy Admin UI one, instead of only the latter.

## Test plan

- `docs` `test:mdx` — 830 files, 0 errors
- Every claim verified against the source rather than assumed:
  - the loader auto-discovers catalogs via `import.meta.glob('../../i18n/locales/*.po')` (`load-i18n-messages.ts`)
  - `i18n:extract` script exists in `packages/dashboard/package.json`
  - the "Display language" control exists in `language-dialog.tsx`
  - the dev-server serves the dashboard (`DashboardPlugin`, route `dashboard`)
- Docs-only change; no code affected.

Fixes #3989

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5010"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787222283&installation_model_id=20193&pr_number=5010&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5010&signature=f2a4c07ca6b0aa09b615ad33b387bae95c83f865e15325a630031e624756774e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->