### PR TITLE
feat(core): Add entity id properties for relation custom fields

### DIFF
--- a/docs/docs/guides/developer-guide/custom-fields/index.mdx
+++ b/docs/docs/guides/developer-guide/custom-fields/index.mdx
@@ -246,6 +246,36 @@ await this.entityHydrator.hydrate(ctx, customer, { relations: ['customFields.ava
 console.log(customer.avatar);
 ```
 
+### Relation ids
+
+From Vendure v3.8, single (non-list) relation custom fields also expose the id of the related entity directly
+on the entity, named `'<field name>Id'`. This means that when you only need the id of the related entity - for
+example to compare it against the active user id - no join is required:
+
+```ts
+const customer = await this.connection.getRepository(ctx, Customer).findOne({
+    where: { id: 1 },
+});
+// No join needed to access the id of the related Asset
+console.log(customer.customFields.avatarId);
+```
+
+The id property maps to the same database column which is used by the relation itself, so no
+migration is required.
+
+The id property can also be used to set the relation when writing to the database:
+
+```ts
+customer.customFields.avatarId = 42;
+await this.connection.getRepository(ctx, Customer).save(customer);
+```
+
+:::caution
+If the relation property itself (`customFields.avatar` in this example) is set to an entity object or `null`,
+it takes precedence over the id property when saving. To avoid surprises, do not set both properties
+to conflicting values on the same entity.
+:::
+
 ## Custom field config properties
 
 ### Common properties

--- a/docs/docs/reference/typescript-api/common/bootstrap.mdx
+++ b/docs/docs/reference/typescript-api/common/bootstrap.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## bootstrap
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="190" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="191" packageName="@vendure/core" />
 
 Bootstraps the Vendure server. This is the entry point to the application.
 
@@ -76,7 +76,7 @@ Parameters
 
 ## BootstrapOptions
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="45" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="46" packageName="@vendure/core" since="2.2.0" />
 
 Additional options that can be used to configure the bootstrap process of the
 Vendure server.

--- a/docs/docs/reference/typescript-api/worker/bootstrap-worker.mdx
+++ b/docs/docs/reference/typescript-api/worker/bootstrap-worker.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## bootstrapWorker
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="256" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="257" packageName="@vendure/core" />
 
 Bootstraps a Vendure worker. Resolves to a [VendureWorker](/reference/typescript-api/worker/vendure-worker#vendureworker) object containing a reference to the underlying
 NestJs [standalone application](https://docs.nestjs.com/standalone-applications) as well as convenience
@@ -41,7 +41,7 @@ Parameters
 
 ## BootstrapWorkerOptions
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="115" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="116" packageName="@vendure/core" since="2.2.0" />
 
 Additional options that can be used to configure the bootstrap process of the
 Vendure worker.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -236,7 +236,7 @@
           "title": "Custom Fields",
           "slug": "custom-fields",
           "file": "docs/guides/developer-guide/custom-fields/index.mdx",
-          "lastModified": "2026-02-12T16:47:03+01:00"
+          "lastModified": "2026-07-21T12:10:34+02:00"
         },
         {
           "title": "Error Handling",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1192,7 +1192,7 @@
                   "title": "Bootstrap",
                   "slug": "bootstrap",
                   "file": "docs/reference/typescript-api/common/bootstrap.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-21T14:00:42Z"
                 },
                 {
                   "title": "CurrencyCode",
@@ -3452,7 +3452,7 @@
                   "title": "BootstrapWorker",
                   "slug": "bootstrap-worker",
                   "file": "docs/reference/typescript-api/worker/bootstrap-worker.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-21T14:00:42Z"
                 },
                 {
                   "title": "VendureWorker",

--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -1485,6 +1485,139 @@ describe('Custom field relations', () => {
         });
     });
 
+    // https://github.com/vendurehq/vendure/issues/2031
+    describe('relation id columns', () => {
+        it('id columns map to the existing join columns rather than creating new ones', () => {
+            const connection = server.app.get(TransactionalConnection);
+            const productMetadata = connection.rawConnection.getMetadata(Product);
+            const relationCustomFieldNames = [
+                'single',
+                'cfCollection',
+                'cfCountry',
+                'cfFacetValue',
+                'cfFacet',
+                'cfProductOptionGroup',
+                'cfProductOption',
+                'cfProductVariant',
+                'cfProduct',
+                'cfShippingMethod',
+                'cfInternalAsset',
+            ];
+            for (const name of relationCustomFieldNames) {
+                const idColumns = productMetadata.columns.filter(
+                    c => c.propertyPath === `customFields.${name}Id`,
+                );
+                // The explicit id property must exist as a column, and it must be the
+                // join column itself (same database column), not an additional column.
+                expect(idColumns.length).toBe(1);
+                expect(idColumns[0].relationMetadata?.propertyPath).toBe(`customFields.${name}`);
+                const columnsWithSameDbName = productMetadata.columns.filter(
+                    c => c.databaseName === idColumns[0].databaseName,
+                );
+                expect(columnsWithSameDbName.length).toBe(1);
+            }
+        });
+
+        it('relation id is available without joining the relation', async () => {
+            await adminClient.query(gql`
+                mutation {
+                    updateProduct(input: { id: "T_1", customFields: { singleId: "T_2" } }) {
+                        id
+                    }
+                }
+            `);
+
+            const connection = server.app.get(TransactionalConnection);
+            const product = await connection.rawConnection.getRepository(Product).findOne({
+                where: { id: 1 },
+                loadEagerRelations: false,
+            });
+
+            expect((product?.customFields as any).single).toBeUndefined();
+            expect((product?.customFields as any).singleId).toBe(2);
+        });
+
+        it('updating the relation updates the id column', async () => {
+            await adminClient.query(gql`
+                mutation {
+                    updateProduct(input: { id: "T_1", customFields: { singleId: "T_3" } }) {
+                        id
+                    }
+                }
+            `);
+
+            const connection = server.app.get(TransactionalConnection);
+            const product = await connection.rawConnection.getRepository(Product).findOne({
+                where: { id: 1 },
+                loadEagerRelations: false,
+            });
+
+            expect((product?.customFields as any).singleId).toBe(3);
+        });
+
+        it('setting the relation to null clears the id column', async () => {
+            await adminClient.query(gql`
+                mutation {
+                    updateProduct(input: { id: "T_1", customFields: { singleId: null } }) {
+                        id
+                    }
+                }
+            `);
+
+            const connection = server.app.get(TransactionalConnection);
+            const product = await connection.rawConnection.getRepository(Product).findOne({
+                where: { id: 1 },
+                loadEagerRelations: false,
+            });
+
+            expect((product?.customFields as any).singleId).toBeNull();
+        });
+
+        // The following tests cover the ways in which plugin code may directly assign
+        // relation custom field values on an entity before saving it.
+        it('assigning a relation object directly persists the relation', async () => {
+            const connection = server.app.get(TransactionalConnection);
+            const repository = connection.rawConnection.getRepository(Product);
+            const product = await repository.findOneOrFail({ where: { id: 1 }, loadEagerRelations: false });
+
+            (product.customFields as any).single = { id: 2 };
+            await repository.save(product, { reload: false });
+
+            const result = await repository.findOne({ where: { id: 1 }, loadEagerRelations: false });
+            expect((result?.customFields as any).singleId).toBe(2);
+        });
+
+        it('assigning null to the relation clears it, even with a stale id value', async () => {
+            const connection = server.app.get(TransactionalConnection);
+            const repository = connection.rawConnection.getRepository(Product);
+            const product = await repository.findOneOrFail({ where: { id: 1 }, loadEagerRelations: false });
+            expect((product.customFields as any).singleId).toBe(2);
+
+            (product.customFields as any).single = null;
+            await repository.save(product, { reload: false });
+
+            const result = await repository.findOne({ where: { id: 1 }, loadEagerRelations: false });
+            expect((result?.customFields as any).singleId).toBeNull();
+        });
+
+        it('assigning to the id column directly persists the relation', async () => {
+            const connection = server.app.get(TransactionalConnection);
+            const repository = connection.rawConnection.getRepository(Product);
+            const product = await repository.findOneOrFail({ where: { id: 1 }, loadEagerRelations: false });
+
+            (product.customFields as any).singleId = 3;
+            await repository.save(product, { reload: false });
+
+            const result = await repository.findOne({
+                where: { id: 1 },
+                loadEagerRelations: false,
+                relations: { customFields: { single: true } } as any,
+            });
+            expect((result?.customFields as any).singleId).toBe(3);
+            expect((result?.customFields as any).single?.id).toBe(3);
+        });
+    });
+
     it('null values', async () => {
         const { updateCustomerAddress } = await adminClient.query(gql`
             mutation {

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -21,6 +21,7 @@ import { registerCustomEntityFields } from './entity/register-custom-entity-fiel
 import { runEntityMetadataModifiers } from './entity/run-entity-metadata-modifiers';
 import { setEntityIdStrategy } from './entity/set-entity-id-strategy';
 import { setMoneyStrategy } from './entity/set-money-strategy';
+import { patchTypeOrmEmbeddedRelationColumns } from './entity/typeorm-embedded-relation-fix';
 import { validateCustomFieldsConfig } from './entity/validate-custom-fields-config';
 import { EventBus } from './event-bus';
 import { BootstrappedEvent } from './event-bus/events/bootstrapped-event';
@@ -311,6 +312,8 @@ export async function preBootstrapConfig(
     Logger.useLogger(config.logger);
     config = await runPluginConfigurations(config);
     const entityIdStrategy = config.entityOptions.entityIdStrategy ?? config.entityIdStrategy;
+    patchTypeOrmEmbeddedRelationColumns();
+    registerCustomEntityFields(config);
     setEntityIdStrategy(entityIdStrategy, entities);
     const moneyStrategy = config.entityOptions.moneyStrategy;
     setMoneyStrategy(moneyStrategy, entities);
@@ -319,7 +322,6 @@ export async function preBootstrapConfig(
         process.exitCode = 1;
         throw new Error('CustomFields config error:\n- ' + customFieldValidationResult.errors.join('\n- '));
     }
-    registerCustomEntityFields(config);
     await runEntityMetadataModifiers(config);
     setExposedHeaders(config);
     return config;

--- a/packages/core/src/entity/entity-id.decorator.ts
+++ b/packages/core/src/entity/entity-id.decorator.ts
@@ -53,12 +53,15 @@ export function EntityId(options?: IdColumnOptions) {
 /**
  * Returns any columns on the entity which have been decorated with the {@link EntityId}
  * decorator.
+ *
+ * Multiple registry entries can exist for a single entity type, since dynamically-registered
+ * columns (e.g. custom field relation id columns) are decorated on separate instances
+ * rather than on the class prototype.
  */
 export function getIdColumnsFor(entityType: Type<any>): IdColumnConfig[] {
-    const match = Array.from(idColumnRegistry.entries()).find(
-        ([entity, columns]) => entity.constructor === entityType,
-    );
-    return match ? match[1] : [];
+    return Array.from(idColumnRegistry.entries())
+        .filter(([entity]) => entity.constructor === entityType)
+        .flatMap(([, columns]) => columns);
 }
 
 /**

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -20,6 +20,8 @@ import { CustomFieldConfig, CustomFields } from '../config/custom-field/custom-f
 import { Logger } from '../config/logger/vendure-logger';
 import { VendureConfig } from '../config/vendure-config';
 
+import { EntityId } from './entity-id.decorator';
+
 /**
  * The maximum length of the "length" argument of a MySQL varchar column.
  */
@@ -53,6 +55,9 @@ function registerCustomFieldsForEntity(
                             eager: customField.eager,
                         })(instance, name);
                         JoinColumn()(instance, name);
+                        // Expose the foreign key as an id property (e.g. "ownerId"), which maps
+                        // to the same database column as the relation's join column.
+                        EntityId({ nullable: true })(instance, `${name}Id`);
                     }
                 } else {
                     const options: ColumnOptions = {

--- a/packages/core/src/entity/set-entity-id-strategy.ts
+++ b/packages/core/src/entity/set-entity-id-strategy.ts
@@ -1,5 +1,5 @@
 import { Type } from '@vendure/common/lib/shared-types';
-import { Column, PrimaryColumn, PrimaryGeneratedColumn } from 'typeorm';
+import { Column, getMetadataArgsStorage, PrimaryColumn, PrimaryGeneratedColumn } from 'typeorm';
 
 import { EntityIdStrategy } from '../config/entity/entity-id-strategy';
 
@@ -7,7 +7,32 @@ import { getIdColumnsFor, getPrimaryGeneratedIdColumn } from './entity-id.decora
 
 export function setEntityIdStrategy(entityIdStrategy: EntityIdStrategy<any>, entities: Array<Type<any>>) {
     setBaseEntityIdType(entityIdStrategy);
-    setEntityIdColumnTypes(entityIdStrategy, entities);
+    const customFieldClasses = getCustomFieldsClasses(entities);
+    setEntityIdColumnTypes(entityIdStrategy, [...entities, ...customFieldClasses]);
+}
+
+/**
+ * Custom field relation id columns are registered on the embedded CustomFields classes
+ * (e.g. CustomProductFields) rather than on the entities themselves, so those classes
+ * also need to be included when resolving the id column data types.
+ */
+function getCustomFieldsClasses(entities: Array<Type<any>>): Array<Type<any>> {
+    const metadataArgsStorage = getMetadataArgsStorage();
+    const customFieldClasses: Array<Type<any>> = [];
+    for (const EntityCtor of entities) {
+        const embeddedMetadata = metadataArgsStorage.embeddeds.find(item => {
+            if (item.propertyName !== 'customFields') {
+                return false;
+            }
+            const targetName = typeof item.target === 'string' ? item.target : item.target.name;
+            return targetName === EntityCtor.name;
+        });
+        const customFieldsClass = embeddedMetadata?.type();
+        if (customFieldsClass && typeof customFieldsClass !== 'string') {
+            customFieldClasses.push(customFieldsClass as Type<any>);
+        }
+    }
+    return customFieldClasses;
 }
 
 function setEntityIdColumnTypes(entityIdStrategy: EntityIdStrategy<any>, entities: Array<Type<any>>) {

--- a/packages/core/src/entity/typeorm-embedded-relation-fix.ts
+++ b/packages/core/src/entity/typeorm-embedded-relation-fix.ts
@@ -18,9 +18,9 @@ let patchApplied = false;
  * `entity.customFields.owner` is ignored when TypeORM computes the value of the join column,
  * and the assignment is silently not persisted.
  *
- * See https://github.com/typeorm/typeorm/blob/master/src/metadata/ColumnMetadata.ts
- * (`getEntityValue`, the `if (this.relationMetadata && this.referencedColumn)` branch inside
- * the embedded case).
+ * Reported upstream as https://github.com/typeorm/typeorm/issues/12725, with a fix submitted
+ * in https://github.com/typeorm/typeorm/pull/12726. This workaround can be removed once the
+ * minimum supported TypeORM version contains that fix.
  *
  * The override below only takes effect for columns which are both embedded and merged with a
  * relation join column. All other columns are handled by the original implementation.

--- a/packages/core/src/entity/typeorm-embedded-relation-fix.ts
+++ b/packages/core/src/entity/typeorm-embedded-relation-fix.ts
@@ -1,0 +1,70 @@
+import { FindOperator } from 'typeorm';
+import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata';
+import { ApplyValueTransformers } from 'typeorm/util/ApplyValueTransformers';
+
+let patchApplied = false;
+
+/**
+ * Works around a TypeORM bug which breaks columns that are simultaneously a regular column
+ * and the join column of a relation ("relation id columns"), when they are defined inside an
+ * embedded entity. This is the case for the id columns of relation custom fields, e.g.
+ * `customFields.ownerId` alongside the `customFields.owner` relation.
+ *
+ * In `ColumnMetadata.getEntityValue()`, the embedded-column branch calls
+ * `this.relationMetadata.getEntityValue(embeddedObject)`, passing the already-extracted
+ * embedded object. However, `RelationMetadata.getEntityValue()` expects the full entity and
+ * performs the embedded-path traversal itself, so the relation value always resolves to
+ * `undefined`. The consequence is that a relation object assigned to e.g.
+ * `entity.customFields.owner` is ignored when TypeORM computes the value of the join column,
+ * and the assignment is silently not persisted.
+ *
+ * See https://github.com/typeorm/typeorm/blob/master/src/metadata/ColumnMetadata.ts
+ * (`getEntityValue`, the `if (this.relationMetadata && this.referencedColumn)` branch inside
+ * the embedded case).
+ *
+ * The override below only takes effect for columns which are both embedded and merged with a
+ * relation join column. All other columns are handled by the original implementation.
+ */
+export function patchTypeOrmEmbeddedRelationColumns() {
+    if (patchApplied) {
+        return;
+    }
+    patchApplied = true;
+
+    // eslint-disable-next-line @typescript-eslint/unbound-method
+    const originalGetEntityValue = ColumnMetadata.prototype.getEntityValue;
+    ColumnMetadata.prototype.getEntityValue = function (
+        this: ColumnMetadata,
+        entity: any,
+        transform = false,
+    ) {
+        if (entity != null && this.embeddedMetadata && this.relationMetadata && this.referencedColumn) {
+            const relatedEntity = this.relationMetadata.getEntityValue(entity);
+            if (relatedEntity !== undefined && !isSpecialObject(relatedEntity)) {
+                let value: any;
+                if (relatedEntity !== null && typeof relatedEntity === 'object') {
+                    value = this.referencedColumn.getEntityValue(relatedEntity);
+                } else {
+                    // `null` (which clears the relation) or a directly-assigned id value
+                    value = relatedEntity;
+                }
+                if (transform && this.transformer) {
+                    value = ApplyValueTransformers.transformTo(this.transformer, value);
+                }
+                return value;
+            }
+            // If the relation property is not set on the entity, fall through to the original
+            // implementation, which will use the value of the id column property itself.
+        }
+        return originalGetEntityValue.call(this, entity, transform);
+    };
+}
+
+function isSpecialObject(value: any): boolean {
+    return (
+        value instanceof FindOperator ||
+        typeof value === 'function' ||
+        Buffer.isBuffer(value) ||
+        value instanceof Date
+    );
+}

--- a/packages/core/src/entity/validate-custom-fields-config.spec.ts
+++ b/packages/core/src/entity/validate-custom-fields-config.spec.ts
@@ -128,6 +128,36 @@ describe('validateCustomFieldsConfig()', () => {
         expect(result.errors).toEqual(['Product entity already has a field named "name"']);
     });
 
+    it('name conflict with relation id property', () => {
+        const config: CustomFields = {
+            Product: [
+                { name: 'owner', type: 'relation', entity: coreEntitiesMap.User, list: false },
+                { name: 'ownerId', type: 'string' },
+            ],
+        };
+        const result = validateCustomFieldsConfig(config, allEntities);
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual([
+            'Product entity has a custom field "ownerId" which conflicts with the id property of the relation custom field "owner"',
+        ]);
+    });
+
+    it('name conflict with list relation id property', () => {
+        const config: CustomFields = {
+            Product: [
+                { name: 'owner', type: 'relation', entity: coreEntitiesMap.User, list: true },
+                { name: 'ownerIds', type: 'string' },
+            ],
+        };
+        const result = validateCustomFieldsConfig(config, allEntities);
+
+        expect(result.valid).toBe(false);
+        expect(result.errors).toEqual([
+            'Product entity has a custom field "ownerIds" which conflicts with the id property of the relation custom field "owner"',
+        ]);
+    });
+
     it('non-nullable must have defaultValue', () => {
         const config: CustomFields = {
             Product: [{ name: 'foo', type: 'string', nullable: false }],

--- a/packages/core/src/entity/validate-custom-fields-config.ts
+++ b/packages/core/src/entity/validate-custom-fields-config.ts
@@ -1,4 +1,5 @@
 import { Type } from '@vendure/common/lib/shared-types';
+import { getGraphQlInputName } from '@vendure/common/lib/shared-utils';
 import { getMetadataArgsStorage } from 'typeorm';
 
 import { CustomFieldConfig, CustomFields } from '../config/custom-field/custom-field-types';
@@ -13,6 +14,7 @@ function validateCustomFieldsForEntity(
         ...assertValidFieldNames(entity.name, customFields),
         ...assertNoNameConflictsWithEntity(entity, customFields),
         ...assertNoDuplicatedCustomFieldNames(entity.name, customFields),
+        ...assertNoRelationIdNameConflicts(entity.name, customFields),
         ...assetNonNullablesHaveDefaults(entity.name, customFields),
         ...(isTranslatable(entity) ? [] : assertNoLocaleStringFields(entity.name, customFields)),
     ];
@@ -66,6 +68,27 @@ function assertNoDuplicatedCustomFieldNames(entityName: string, customFields: Cu
     return Object.entries(nameCounts)
         .filter(([name, count]) => 1 < count)
         .map(([name, count]) => `${entityName} entity has duplicated custom field name: "${name}"`);
+}
+
+/**
+ * Relation custom fields are represented by an id property (`ownerId`/`ownerIds`) in GraphQL
+ * input types and, for non-list relations, as an id column on the entity. Assert that no other
+ * custom field is named in a way that would collide with those properties.
+ */
+function assertNoRelationIdNameConflicts(entityName: string, customFields: CustomFieldConfig[]): string[] {
+    const errors: string[] = [];
+    for (const field of customFields) {
+        if (field.type === 'relation') {
+            const idPropertyName = getGraphQlInputName(field);
+            if (customFields.some(f => f !== field && f.name === idPropertyName)) {
+                errors.push(
+                    `${entityName} entity has a custom field "${idPropertyName}" which conflicts with the ` +
+                        `id property of the relation custom field "${field.name}"`,
+                );
+            }
+        }
+    }
+    return errors;
 }
 
 /**

--- a/packages/core/src/service/helpers/custom-field-relation/custom-field-relation.service.ts
+++ b/packages/core/src/service/helpers/custom-field-relation/custom-field-relation.service.ts
@@ -64,6 +64,15 @@ export class CustomFieldRelationService {
                             ...entity.customFields,
                             ...entityWithCustomFields?.customFields,
                             [field.name]: relations,
+                            // The relation id column must always be kept in sync with the relation
+                            // itself, otherwise a stale id value would conflict with the relation
+                            // when persisting, since both map to the same database column.
+                            ...(field.list
+                                ? {}
+                                : {
+                                      [`${field.name}Id`]:
+                                          relations && !Array.isArray(relations) ? relations.id : null,
+                                  }),
                         };
                         await this.connection
                             .getRepository(ctx, entityType)

--- a/packages/core/src/service/services/order.service.ts
+++ b/packages/core/src/service/services/order.service.ts
@@ -852,12 +852,6 @@ export class OrderService {
                 }
 
                 orderLine.customFields = mergedCustomFields;
-                await this.customFieldRelationService.updateRelations(
-                    ctx,
-                    OrderLine,
-                    { customFields: mergedCustomFields },
-                    orderLine,
-                );
             }
             const existingQuantityInOtherLines = summate(
                 order.lines.filter(
@@ -881,6 +875,16 @@ export class OrderService {
                 await this.eventBus.publish(new OrderLineEvent(ctx, order, deletedOrderLine, 'deleted'));
             } else {
                 await this.orderModifier.updateOrderLineQuantity(ctx, orderLine, correctedQuantity, order);
+                if (customFields != null) {
+                    // This must run after the OrderLine has been saved with the merged custom field
+                    // values, since it re-loads the entity from the database to resolve the relations.
+                    await this.customFieldRelationService.updateRelations(
+                        ctx,
+                        OrderLine,
+                        { customFields },
+                        orderLine,
+                    );
+                }
                 updatedOrderLines.push(orderLine);
             }
             const quantityWasAdjustedDown = correctedQuantity < quantity;


### PR DESCRIPTION
## Description

Adds an id property for every non-list relation custom field, named `<fieldName>Id`. Given a relation custom field `owner` on Product, the related entity's id can now be read directly from the loaded entity without joining the relation:

```ts
const product = await this.connection.getRepository(ctx, Product).findOne({ where: { id } });
if (product.customFields.ownerId === ctx.activeUserId) {
    // ...
}
```

The id property can also be used to set the relation when saving.

Fixes #2031

## Implementation notes

**No migration required.** The id property maps to the same database column that TypeORM already creates for the relation's join column (e.g. `customFieldsOwnerid`). An e2e test asserts that exactly one column exists per relation and that it is the join column itself, so the schema is unchanged for existing projects.

**Always on.** There is no config option to enable this; every non-list relation custom field gets the id property. List relations are not covered, since their ids live in a join table rather than a column.

**TypeORM workaround.** The main reason the earlier attempt at this feature (see the issue comments) failed is a TypeORM bug: in `ColumnMetadata.getEntityValue()`, the embedded-column branch passes the already-extracted embedded object to `RelationMetadata.getEntityValue()`, which expects the full entity and traverses the embedded path itself. Once the join column is merged with an explicit id property, this causes relation object assignments (e.g. `entity.customFields.owner = user`) to be silently dropped on save. `typeorm-embedded-relation-fix.ts` contains a targeted runtime override which only affects embedded relation id columns and delegates everything else to the original implementation. Reported upstream as https://github.com/typeorm/typeorm/issues/12725 with a fix submitted in https://github.com/typeorm/typeorm/pull/12726; the runtime workaround can be removed once a TypeORM release containing the fix is the minimum supported version.

**Write precedence** matches the existing top-level pattern (`featuredAsset`/`featuredAssetId`): if the relation property is set (to an entity object or `null`), it wins over the id property when persisting. `CustomFieldRelationService` keeps the id property in sync with the relation, including setting it to `null` when the relation is removed, so the two cannot conflict in core flows.

**Fixed along the way:**
- `getIdColumnsFor()` only returned the first registry entry per entity type, so with multiple relation custom fields on one entity, only one id column would have been registered.
- `adjustOrderLines()` passed its merged custom field object to `CustomFieldRelationService.updateRelations()` as if it were user input. With the id columns present on loaded entities, this caused stale database values to overwrite in-memory scalar updates. It now passes the raw input, and runs after the OrderLine has been saved.
- New validation rejects a custom field named e.g. `ownerId` alongside a relation custom field `owner`, which would previously have collided silently in the GraphQL input types.

## Scope

Entity-level (TypeScript) access only. GraphQL output exposure (`customFields { ownerId }`) plus filter/sort support in list queries is planned as a follow-up PR, since the generated id fields need permission handling (`requiresPermission`, `public`, `internal`) inherited from their relation fields.

## Testing

- `custom-field-relations` e2e suite extended: id column/join column metadata assertions, read without join, write via id, clearing via null, and direct plugin-style writes (relation object assignment, null assignment with a stale id, id assignment)
- Unit tests for the new validation
- Full core e2e suite green on sqlite; the six most relevant suites (`custom-field-relations`, `order-line-custom-fields`, `shop-order`, `import`, `custom-fields`) also green on Postgres and MariaDB

## Breaking changes

None. Existing schemas are unchanged and relation write behaviour is preserved, including direct relation object assignment in plugin code.

