### PR TITLE
feat(core): Expose relation custom field ids in GraphQL APIs

### DIFF
--- a/docs/docs/guides/developer-guide/custom-fields/index.mdx
+++ b/docs/docs/guides/developer-guide/custom-fields/index.mdx
@@ -276,6 +276,47 @@ it takes precedence over the id property when saving. To avoid surprises, do not
 to conflicting values on the same entity.
 :::
 
+The id is also exposed in the GraphQL APIs. Alongside the relation field itself, the generated
+`customFields` type contains a `'<field name>Id'` field, which can be selected without the cost of
+loading the full relation:
+
+```graphql
+query {
+    activeCustomer {
+        customFields {
+            avatar {
+                id
+                preview
+            }
+            # or, when only the id is needed:
+            avatarId
+        }
+    }
+}
+```
+
+The id field respects the same `public`, `internal` and `requiresPermission` settings as the
+relation field it belongs to.
+
+In list queries, the id field can also be used to filter and sort:
+
+```graphql
+query {
+    products(options: {
+        filter: {
+            ownerId: { eq: "42" }
+        }
+        sort: {
+            ownerId: ASC
+        }
+    }) {
+        items {
+            id
+        }
+    }
+}
+```
+
 ## Custom field config properties
 
 ### Common properties

--- a/docs/docs/reference/typescript-api/assets/asset-options.mdx
+++ b/docs/docs/reference/typescript-api/assets/asset-options.mdx
@@ -2,7 +2,7 @@
 title: "AssetOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="738" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="752" packageName="@vendure/core" />
 
 The AssetOptions define how assets (images and other files) are named and stored, and how preview images are generated.
 

--- a/docs/docs/reference/typescript-api/auth/auth-options.mdx
+++ b/docs/docs/reference/typescript-api/auth/auth-options.mdx
@@ -2,7 +2,7 @@
 title: "AuthOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="365" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="366" packageName="@vendure/core" />
 
 The AuthOptions define how authentication and authorization is managed.
 

--- a/docs/docs/reference/typescript-api/auth/cookie-options.mdx
+++ b/docs/docs/reference/typescript-api/auth/cookie-options.mdx
@@ -2,7 +2,7 @@
 title: "CookieOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="260" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="261" packageName="@vendure/core" />
 
 Options for the handling of the cookies used to track sessions (only applicable if
 `authOptions.tokenMethod` is set to `'cookie'`). These options are passed directly

--- a/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
+++ b/docs/docs/reference/typescript-api/auth/superadmin-credentials.mdx
@@ -2,7 +2,7 @@
 title: "SuperadminCredentials"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="914" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="928" packageName="@vendure/core" />
 
 These credentials will be used to create the Superadmin user & administrator
 when Vendure first bootstraps.

--- a/docs/docs/reference/typescript-api/configuration/api-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/api-options.mdx
@@ -2,7 +2,7 @@
 title: "ApiOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="81" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="82" packageName="@vendure/core" />
 
 The ApiOptions define how the Vendure GraphQL APIs are exposed, as well as allowing the API layer
 to be extended with middleware.

--- a/docs/docs/reference/typescript-api/configuration/default-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/default-config.mdx
@@ -2,7 +2,7 @@
 title: "DefaultConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/default-config.ts" sourceLine="74" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/default-config.ts" sourceLine="75" packageName="@vendure/core" />
 
 The default configuration settings which are used if not explicitly overridden in the bootstrap() call.
 

--- a/docs/docs/reference/typescript-api/configuration/entity-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/entity-options.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## EntityOptions
 
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1112" packageName="@vendure/core" since="1.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1126" packageName="@vendure/core" since="1.3.0" />
 
 Options relating to the internal handling of entities.
 

--- a/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/runtime-vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "RuntimeVendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1398" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1412" packageName="@vendure/core" />
 
 This interface represents the VendureConfig object available at run-time, i.e. the user-supplied
 config values have been merged with the [defaultConfig](/reference/typescript-api/configuration/default-config#defaultconfig) values.

--- a/docs/docs/reference/typescript-api/configuration/system-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/system-options.mdx
@@ -2,7 +2,7 @@
 title: "SystemOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1210" packageName="@vendure/core" since="1.6.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1224" packageName="@vendure/core" since="1.6.0" />
 
 Options relating to system functions.
 

--- a/docs/docs/reference/typescript-api/configuration/trust-proxy-options.mdx
+++ b/docs/docs/reference/typescript-api/configuration/trust-proxy-options.mdx
@@ -2,7 +2,7 @@
 title: "TrustProxyOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="250" packageName="@vendure/core" since="3.4.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="251" packageName="@vendure/core" since="3.4.0" />
 
 Configures Express trust proxy settings when running behind a reverse proxy (usually the case with most hosting services).
 Setting `trustProxy` allows you to retrieve the original IP address from the `X-Forwarded-For` header.

--- a/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
+++ b/docs/docs/reference/typescript-api/configuration/vendure-config.mdx
@@ -2,7 +2,7 @@
 title: "VendureConfig"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1251" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1265" packageName="@vendure/core" />
 
 All possible configuration options are defined by the
 [`VendureConfig`](https://github.com/vendurehq/vendure/blob/master/packages/core/src/config/vendure-config.ts) interface.

--- a/docs/docs/reference/typescript-api/entities/order.mdx
+++ b/docs/docs/reference/typescript-api/entities/order.mdx
@@ -32,6 +32,8 @@ class Order extends VendureEntity implements ChannelAware, HasCustomFields {
     @Column({ nullable: true })
     @Index()
     orderPlacedAt?: Date;
+    @Column({ nullable: true, precision: 6 })
+    pricingUpdatedAt?: Date;
     @Index()
     @ManyToOne(type => Customer, customer => customer.orders)
     customer?: Customer;
@@ -137,6 +139,13 @@ This is governed by the [OrderPlacedStrategy](/reference/typescript-api/orders/o
 The date & time that the Order was placed, i.e. the Customer
 completed the checkout and the Order is no longer "active".
 This is governed by the [OrderPlacedStrategy](/reference/typescript-api/orders/order-placed-strategy#orderplacedstrategy).
+### pricingUpdatedAt
+
+<MemberInfo kind="property" type={`Date`}  since="3.8.0"  />
+
+The date & time that the Order's prices, promotions and taxes were last recalculated via
+`OrderService.applyPriceAdjustments`. Used by the configured [OrderRecalculationStrategy](/reference/typescript-api/orders/order-recalculation-strategy#orderrecalculationstrategy)to determine whether an active Order is stale and should be recalculated on read.
+Shipping method eligibility and rates are NOT included in read-time recalculation.
 ### customer
 
 <MemberInfo kind="property" type={`<a href='/reference/typescript-api/entities/customer#customer'>Customer</a>`}   />

--- a/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
+++ b/docs/docs/reference/typescript-api/import-export/import-export-options.mdx
@@ -2,7 +2,7 @@
 title: "ImportExportOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1012" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1026" packageName="@vendure/core" />
 
 Options related to importing & exporting data.
 

--- a/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
+++ b/docs/docs/reference/typescript-api/job-queue/job-queue-options.mdx
@@ -2,7 +2,7 @@
 title: "JobQueueOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1036" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1050" packageName="@vendure/core" />
 
 Options related to the built-in job queue.
 

--- a/docs/docs/reference/typescript-api/orders/order-options.mdx
+++ b/docs/docs/reference/typescript-api/orders/order-options.mdx
@@ -2,7 +2,7 @@
 title: "OrderOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="574" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="575" packageName="@vendure/core" />
 
 
 
@@ -24,6 +24,7 @@ interface OrderOptions {
     orderSellerStrategy?: OrderSellerStrategy;
     guestCheckoutStrategy?: GuestCheckoutStrategy;
     orderInterceptors?: OrderInterceptor[];
+    orderRecalculationStrategy?: OrderRecalculationStrategy;
 }
 ```
 
@@ -143,6 +144,16 @@ Defines how we deal with guest checkouts.
 <MemberInfo kind="property" type={`<a href='/reference/typescript-api/orders/order-interceptor#orderinterceptor'>OrderInterceptor</a>[]`} default={`[]`}  since="3.1.0"  />
 
 An array of [OrderInterceptor](/reference/typescript-api/orders/order-interceptor#orderinterceptor)s which can be used to modify the behavior of the Order process.
+### orderRecalculationStrategy
+
+<MemberInfo kind="property" type={`<a href='/reference/typescript-api/orders/order-recalculation-strategy#orderrecalculationstrategy'>OrderRecalculationStrategy</a>`} default={`<a href='/reference/typescript-api/orders/order-recalculation-strategy#noorderrecalculationstrategy'>NoOrderRecalculationStrategy</a>`}  since="3.8.0"  />
+
+Defines whether and when an active Order's prices, promotions and taxes are re-calculated
+when the Order is read (e.g. via the `activeOrder` query). By default no read-time
+recalculation occurs (prices only change on write mutations). Use
+[TtlOrderRecalculationStrategy](/reference/typescript-api/orders/order-recalculation-strategy#ttlorderrecalculationstrategy) to keep long-lived carts in sync with changing prices
+and promotions. Shipping method eligibility and rates are NOT re-evaluated on read; they are
+re-evaluated when the order transitions to `ArrangingPayment`.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/orders/order-process.mdx
+++ b/docs/docs/reference/typescript-api/orders/order-process.mdx
@@ -59,7 +59,7 @@ interface OrderProcess<State extends keyof CustomOrderStates | string> extends I
 </div>
 ## DefaultOrderProcessOptions
 
-<GenerationInfo sourceFile="packages/core/src/config/order/default-order-process.ts" sourceLine="50" packageName="@vendure/core" since="2.0.0" />
+<GenerationInfo sourceFile="packages/core/src/config/order/default-order-process.ts" sourceLine="51" packageName="@vendure/core" since="2.0.0" />
 
 Options which can be passed to the [configureDefaultOrderProcess](/reference/typescript-api/orders/order-process#configuredefaultorderprocess) function
 to configure an instance of the default [OrderProcess](/reference/typescript-api/orders/order-process#orderprocess). By default, all
@@ -148,7 +148,7 @@ the Order are part of a Fulfillment which itself is in the `Shipped` state.
 </div>
 ## configureDefaultOrderProcess
 
-<GenerationInfo sourceFile="packages/core/src/config/order/default-order-process.ts" sourceLine="163" packageName="@vendure/core" since="2.0.0" />
+<GenerationInfo sourceFile="packages/core/src/config/order/default-order-process.ts" sourceLine="164" packageName="@vendure/core" since="2.0.0" />
 
 Used to configure a customized instance of the default [OrderProcess](/reference/typescript-api/orders/order-process#orderprocess) that ships with Vendure.
 Using this function allows you to turn off certain checks and constraints that are enabled by default.
@@ -183,7 +183,7 @@ Parameters
 
 ## defaultOrderProcess
 
-<GenerationInfo sourceFile="packages/core/src/config/order/default-order-process.ts" sourceLine="475" packageName="@vendure/core" since="2.0.0" />
+<GenerationInfo sourceFile="packages/core/src/config/order/default-order-process.ts" sourceLine="508" packageName="@vendure/core" since="2.0.0" />
 
 This is the built-in [OrderProcess](/reference/typescript-api/orders/order-process#orderprocess) that ships with Vendure. A customized version of this process
 can be created using the [configureDefaultOrderProcess](/reference/typescript-api/orders/order-process#configuredefaultorderprocess) function, which allows you to pass in an object

--- a/docs/docs/reference/typescript-api/orders/order-recalculation-strategy.mdx
+++ b/docs/docs/reference/typescript-api/orders/order-recalculation-strategy.mdx
@@ -1,0 +1,155 @@
+---
+title: "OrderRecalculationStrategy"
+generated: true
+---
+## NoOrderRecalculationStrategy
+
+<GenerationInfo sourceFile="packages/core/src/config/order/no-order-recalculation-strategy.ts" sourceLine="13" packageName="@vendure/core" since="3.8.0" />
+
+The default [OrderRecalculationStrategy](/reference/typescript-api/orders/order-recalculation-strategy#orderrecalculationstrategy) which never triggers a read-time recalculation.
+This preserves the behaviour of Vendure prior to v3.8.0, where an active Order's prices are only
+re-calculated on write mutations.
+
+```ts title="Signature"
+class NoOrderRecalculationStrategy implements OrderRecalculationStrategy {
+    shouldRecalculate() => boolean;
+}
+```
+* Implements: [`OrderRecalculationStrategy`](/reference/typescript-api/orders/order-recalculation-strategy#orderrecalculationstrategy)
+
+
+
+<div className="members-wrapper">
+
+### shouldRecalculate
+
+<MemberInfo kind="method" type={`() => boolean`}   />
+
+
+
+
+</div>
+## OrderRecalculationStrategy
+
+<GenerationInfo sourceFile="packages/core/src/config/order/order-recalculation-strategy.ts" sourceLine="31" packageName="@vendure/core" since="3.8.0" />
+
+This strategy determines whether an active Order's prices, promotions, taxes and shipping
+promotions should be re-calculated when the Order is read (e.g. via the `activeOrder` query).
+Recalculation is only ever attempted for Orders in the `AddingItems` state.
+
+**Note:** the shipping *method* and *rate* are NOT re-evaluated on read, so a read never silently
+swaps the customer's chosen method — those are re-evaluated when the Order transitions to
+`ArrangingPayment` (checkout). Shipping *promotions* are re-tested, so a now-inactive shipping
+promotion's discount is cleared rather than surviving on the Order.
+
+The default [NoOrderRecalculationStrategy](/reference/typescript-api/orders/order-recalculation-strategy#noorderrecalculationstrategy) never triggers a recalculation, preserving the
+historical behaviour whereby an active Order's prices are only updated on write mutations. Use
+[TtlOrderRecalculationStrategy](/reference/typescript-api/orders/order-recalculation-strategy#ttlorderrecalculationstrategy) (or a custom implementation) to keep long-lived carts in
+sync with changing product prices and promotions.
+
+:::info
+
+This is configured via the `orderOptions.orderRecalculationStrategy` property of your VendureConfig.
+
+:::
+
+```ts title="Signature"
+interface OrderRecalculationStrategy extends InjectableStrategy {
+    shouldRecalculate(ctx: RequestContext, order: Order): boolean | Promise<boolean>;
+}
+```
+* Extends: [`InjectableStrategy`](/reference/typescript-api/common/injectable-strategy#injectablestrategy)
+
+
+
+<div className="members-wrapper">
+
+### shouldRecalculate
+
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, order: <a href='/reference/typescript-api/entities/order#order'>Order</a>) => boolean | Promise<boolean>`}   />
+
+Return `true` to trigger a recalculation of the Order's prices, promotions and taxes before
+it is returned from the active-order read path.
+
+**Note:** Implementations should rely only on fields that are always present on the Order
+(e.g. `pricingUpdatedAt`, `state`, `active`). Deep relations (lines, promotions, etc.) may
+not be loaded on the Order passed to this method.
+
+
+</div>
+## TtlOrderRecalculationStrategy
+
+<GenerationInfo sourceFile="packages/core/src/config/order/ttl-order-recalculation-strategy.ts" sourceLine="29" packageName="@vendure/core" since="3.8.0" />
+
+An [OrderRecalculationStrategy](/reference/typescript-api/orders/order-recalculation-strategy#orderrecalculationstrategy) which recalculates an active Order when the time since its
+last recalculation exceeds the configured `ttlMs`. This mirrors the "price freeze period" model
+used by other e-commerce platforms: quoted prices remain stable for a period, then refresh on the
+next access.
+
+*Example*
+
+```ts
+import { TtlOrderRecalculationStrategy, VendureConfig } from '@vendure/core';
+
+export const config: VendureConfig = {
+  // ...
+  orderOptions: {
+    orderRecalculationStrategy: new TtlOrderRecalculationStrategy({ ttlMs: 5 * 60 * 1000 }),
+  },
+};
+```
+
+```ts title="Signature"
+class TtlOrderRecalculationStrategy implements OrderRecalculationStrategy {
+    constructor(options: { ttlMs: number })
+    shouldRecalculate(ctx: RequestContext, order: Order) => boolean;
+}
+```
+* Implements: [`OrderRecalculationStrategy`](/reference/typescript-api/orders/order-recalculation-strategy#orderrecalculationstrategy)
+
+
+
+<div className="members-wrapper">
+
+### shouldRecalculate
+
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, order: <a href='/reference/typescript-api/entities/order#order'>Order</a>) => boolean`}   />
+
+
+
+
+</div>
+## ApplyPriceAdjustmentsOptions
+
+<GenerationInfo sourceFile="packages/core/src/service/helpers/order-calculator/order-calculator.ts" sourceLine="32" packageName="@vendure/core" since="3.8.0" />
+
+Options passed to `OrderService.applyPriceAdjustments` and `OrderCalculator.applyPriceAdjustments`.
+
+```ts title="Signature"
+interface ApplyPriceAdjustmentsOptions {
+    recalculateShipping?: boolean;
+    recalculateShippingPromotions?: boolean;
+}
+```
+
+<div className="members-wrapper">
+
+### recalculateShipping
+
+<MemberInfo kind="property" type={`boolean`}   />
+
+Whether the shipping method & rate should be re-evaluated — which may swap the Order's
+shipping method to a different eligible one. Defaults to `true`.
+### recalculateShippingPromotions
+
+<MemberInfo kind="property" type={`boolean`}   />
+
+When `recalculateShipping` is `false` (the chosen shipping method & rate are left
+untouched), this controls whether shipping *promotions* are still re-tested and their
+adjustments cleared/re-applied. Defaults to the value of `recalculateShipping`, so
+callers that freeze shipping entirely (e.g. order modification) are unaffected, while
+read-time recalculation can drop a now-inactive shipping promotion's discount without
+re-selecting the method.
+
+
+</div>

--- a/docs/docs/reference/typescript-api/payment/payment-options.mdx
+++ b/docs/docs/reference/typescript-api/payment/payment-options.mdx
@@ -2,7 +2,7 @@
 title: "PaymentOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="936" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="950" packageName="@vendure/core" />
 
 Defines payment-related options in the [VendureConfig](/reference/typescript-api/configuration/vendure-config#vendureconfig).
 

--- a/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
+++ b/docs/docs/reference/typescript-api/products-stock/catalog-options.mdx
@@ -2,7 +2,7 @@
 title: "CatalogOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="785" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="799" packageName="@vendure/core" />
 
 Options related to products and collections.
 

--- a/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
+++ b/docs/docs/reference/typescript-api/promotions/promotion-options.mdx
@@ -2,7 +2,7 @@
 title: "PromotionOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="847" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="861" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
+++ b/docs/docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx
@@ -2,7 +2,7 @@
 title: "SchedulerOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1075" packageName="@vendure/core" since="3.3.0" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="1089" packageName="@vendure/core" since="3.3.0" />
 
 Options related to scheduled tasks..
 

--- a/docs/docs/reference/typescript-api/service-helpers/order-calculator.mdx
+++ b/docs/docs/reference/typescript-api/service-helpers/order-calculator.mdx
@@ -2,7 +2,7 @@
 title: "OrderCalculator"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/helpers/order-calculator/order-calculator.ts" sourceLine="35" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/helpers/order-calculator/order-calculator.ts" sourceLine="62" packageName="@vendure/core" />
 
 This helper is used when making changes to an Order, to apply all applicable price adjustments to that Order,
 including:
@@ -14,7 +14,7 @@ including:
 ```ts title="Signature"
 class OrderCalculator {
     constructor(configService: ConfigService, zoneService: ZoneService, taxRateService: TaxRateService, shippingMethodService: ShippingMethodService, shippingCalculator: ShippingCalculator, requestContextCache: RequestContextCacheService)
-    applyPriceAdjustments(ctx: RequestContext, order: Order, promotions: Promotion[], updatedOrderLines: OrderLine[] = [], options?: { recalculateShipping?: boolean }) => Promise<Order>;
+    applyPriceAdjustments(ctx: RequestContext, order: Order, promotions: Promotion[], updatedOrderLines: OrderLine[] = [], options?: ApplyPriceAdjustmentsOptions) => Promise<Order>;
     calculateOrderTotals(order: Order) => ;
 }
 ```
@@ -23,7 +23,7 @@ class OrderCalculator {
 
 ### applyPriceAdjustments
 
-<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, order: <a href='/reference/typescript-api/entities/order#order'>Order</a>, promotions: <a href='/reference/typescript-api/entities/promotion#promotion'>Promotion</a>[], updatedOrderLines: <a href='/reference/typescript-api/entities/order-line#orderline'>OrderLine</a>[] = [], options?: { recalculateShipping?: boolean }) => Promise<<a href='/reference/typescript-api/entities/order#order'>Order</a>>`}   />
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, order: <a href='/reference/typescript-api/entities/order#order'>Order</a>, promotions: <a href='/reference/typescript-api/entities/promotion#promotion'>Promotion</a>[], updatedOrderLines: <a href='/reference/typescript-api/entities/order-line#orderline'>OrderLine</a>[] = [], options?: <a href='/reference/typescript-api/orders/order-recalculation-strategy#applypriceadjustmentsoptions'>ApplyPriceAdjustmentsOptions</a>) => Promise<<a href='/reference/typescript-api/entities/order#order'>Order</a>>`}   />
 
 Applies taxes and promotions to an Order. Mutates the order object.
 Returns an array of any OrderItems which had new adjustments

--- a/docs/docs/reference/typescript-api/services/order-service.mdx
+++ b/docs/docs/reference/typescript-api/services/order-service.mdx
@@ -72,7 +72,8 @@ class OrderService {
     deleteOrderNote(ctx: RequestContext, id: ID) => Promise<DeletionResponse>;
     deleteOrder(ctx: RequestContext, orderOrId: ID | Order) => ;
     mergeOrders(ctx: RequestContext, user: User, guestOrder?: Order, existingOrder?: Order) => Promise<Order | undefined>;
-    applyPriceAdjustments(ctx: RequestContext, order: Order, updatedOrderLines?: OrderLine[], relations?: RelationPaths<Order>) => Promise<Order>;
+    applyPriceAdjustments(ctx: RequestContext, order: Order, updatedOrderLines?: OrderLine[], relations?: RelationPaths<Order>, options?: ApplyPriceAdjustmentsOptions) => Promise<Order>;
+    applyPriceAdjustmentsIfStale(ctx: RequestContext, order: Order) => Promise<Order>;
 }
 ```
 
@@ -428,10 +429,20 @@ we need to reconcile the contents of the two orders.
 The logic used to do the merging is specified in the [OrderOptions](/reference/typescript-api/orders/order-options#orderoptions) `mergeStrategy` config setting.
 ### applyPriceAdjustments
 
-<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, order: <a href='/reference/typescript-api/entities/order#order'>Order</a>, updatedOrderLines?: <a href='/reference/typescript-api/entities/order-line#orderline'>OrderLine</a>[], relations?: RelationPaths<<a href='/reference/typescript-api/entities/order#order'>Order</a>>) => Promise<<a href='/reference/typescript-api/entities/order#order'>Order</a>>`}   />
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, order: <a href='/reference/typescript-api/entities/order#order'>Order</a>, updatedOrderLines?: <a href='/reference/typescript-api/entities/order-line#orderline'>OrderLine</a>[], relations?: RelationPaths<<a href='/reference/typescript-api/entities/order#order'>Order</a>>, options?: <a href='/reference/typescript-api/orders/order-recalculation-strategy#applypriceadjustmentsoptions'>ApplyPriceAdjustmentsOptions</a>) => Promise<<a href='/reference/typescript-api/entities/order#order'>Order</a>>`}   />
 
 Applies promotions, taxes and shipping to the Order. If the `updatedOrderLines` argument is passed in,
 then all of those OrderLines will have their prices re-calculated using the configured [OrderItemPriceCalculationStrategy](/reference/typescript-api/orders/order-item-price-calculation-strategy#orderitempricecalculationstrategy).
+### applyPriceAdjustmentsIfStale
+
+<MemberInfo kind="method" type={`(ctx: <a href='/reference/typescript-api/request/request-context#requestcontext'>RequestContext</a>, order: <a href='/reference/typescript-api/entities/order#order'>Order</a>) => Promise<<a href='/reference/typescript-api/entities/order#order'>Order</a>>`}  since="3.8.0"  />
+
+Recalculates the given active Order's prices, promotions, taxes and shipping promotions if the
+configured [OrderRecalculationStrategy](/reference/typescript-api/orders/order-recalculation-strategy#orderrecalculationstrategy) reports it as stale. The shipping *method* and
+*rate* are deliberately NOT re-evaluated on this read path — the customer's chosen method is
+never silently swapped; those are re-evaluated when the Order transitions to `ArrangingPayment`.
+Only Orders in the `AddingItems` state are eligible; no-ops (returning the Order unchanged)
+otherwise. Invoked on the active-order read path.
 
 
 </div>

--- a/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
+++ b/docs/docs/reference/typescript-api/shipping/shipping-options.mdx
@@ -2,7 +2,7 @@
 title: "ShippingOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="863" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="877" packageName="@vendure/core" />
 
 
 

--- a/docs/docs/reference/typescript-api/tax/tax-options.mdx
+++ b/docs/docs/reference/typescript-api/tax/tax-options.mdx
@@ -2,7 +2,7 @@
 title: "TaxOptions"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="976" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/config/vendure-config.ts" sourceLine="990" packageName="@vendure/core" />
 
 
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -964,7 +964,7 @@
                   "title": "AssetOptions",
                   "slug": "asset-options",
                   "file": "docs/reference/typescript-api/assets/asset-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "AssetPreviewStrategy",
@@ -1008,7 +1008,7 @@
                   "title": "AuthOptions",
                   "slug": "auth-options",
                   "file": "docs/reference/typescript-api/auth/auth-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "BcryptPasswordHashingStrategy",
@@ -1020,7 +1020,7 @@
                   "title": "CookieOptions",
                   "slug": "cookie-options",
                   "file": "docs/reference/typescript-api/auth/cookie-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "CustomerChannelAssignmentStrategy",
@@ -1104,7 +1104,7 @@
                   "title": "SuperadminCredentials",
                   "slug": "superadmin-credentials",
                   "file": "docs/reference/typescript-api/auth/superadmin-credentials.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "VerificationTokenStrategy",
@@ -1366,7 +1366,7 @@
                   "title": "ApiOptions",
                   "slug": "api-options",
                   "file": "docs/reference/typescript-api/configuration/api-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "CollectionFilter",
@@ -1378,7 +1378,7 @@
                   "title": "DefaultConfig",
                   "slug": "default-config",
                   "file": "docs/reference/typescript-api/configuration/default-config.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "DefaultSlugStrategy",
@@ -1408,7 +1408,7 @@
                   "title": "EntityOptions",
                   "slug": "entity-options",
                   "file": "docs/reference/typescript-api/configuration/entity-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "MergeConfig",
@@ -1432,7 +1432,7 @@
                   "title": "RuntimeVendureConfig",
                   "slug": "runtime-vendure-config",
                   "file": "docs/reference/typescript-api/configuration/runtime-vendure-config.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "SettingsStoreFields",
@@ -1450,19 +1450,19 @@
                   "title": "SystemOptions",
                   "slug": "system-options",
                   "file": "docs/reference/typescript-api/configuration/system-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "TrustProxyOptions",
                   "slug": "trust-proxy-options",
                   "file": "docs/reference/typescript-api/configuration/trust-proxy-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "VendureConfig",
                   "slug": "vendure-config",
                   "file": "docs/reference/typescript-api/configuration/vendure-config.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -1716,7 +1716,7 @@
                   "title": "Order",
                   "slug": "order",
                   "file": "docs/reference/typescript-api/entities/order.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "OrderableAsset",
@@ -2134,7 +2134,7 @@
                   "title": "ImportExportOptions",
                   "slug": "import-export-options",
                   "file": "docs/reference/typescript-api/import-export/import-export-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "ImportParser",
@@ -2214,7 +2214,7 @@
                   "title": "JobQueueOptions",
                   "slug": "job-queue-options",
                   "file": "docs/reference/typescript-api/job-queue/job-queue-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "JobQueueService",
@@ -2474,7 +2474,7 @@
                   "title": "OrderOptions",
                   "slug": "order-options",
                   "file": "docs/reference/typescript-api/orders/order-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "OrderPlacedStrategy",
@@ -2486,7 +2486,13 @@
                   "title": "OrderProcess",
                   "slug": "order-process",
                   "file": "docs/reference/typescript-api/orders/order-process.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
+                },
+                {
+                  "title": "OrderRecalculationStrategy",
+                  "slug": "order-recalculation-strategy",
+                  "file": "docs/reference/typescript-api/orders/order-recalculation-strategy.mdx",
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "OrderSellerStrategy",
@@ -2554,7 +2560,7 @@
                   "title": "PaymentOptions",
                   "slug": "payment-options",
                   "file": "docs/reference/typescript-api/payment/payment-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "PaymentProcess",
@@ -2648,7 +2654,7 @@
                   "title": "CatalogOptions",
                   "slug": "catalog-options",
                   "file": "docs/reference/typescript-api/products-stock/catalog-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "DefaultProductVariantPriceCalculationStrategy",
@@ -2722,7 +2728,7 @@
                   "title": "PromotionOptions",
                   "slug": "promotion-options",
                   "file": "docs/reference/typescript-api/promotions/promotion-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"
@@ -2816,7 +2822,7 @@
                   "title": "SchedulerOptions",
                   "slug": "scheduler-options",
                   "file": "docs/reference/typescript-api/scheduled-tasks/scheduler-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "SchedulerService",
@@ -2848,7 +2854,7 @@
                   "title": "OrderCalculator",
                   "slug": "order-calculator",
                   "file": "docs/reference/typescript-api/service-helpers/order-calculator.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "OrderModifier",
@@ -2988,7 +2994,7 @@
                   "title": "OrderService",
                   "slug": "order-service",
                   "file": "docs/reference/typescript-api/services/order-service.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "OrderTestingService",
@@ -3238,7 +3244,7 @@
                   "title": "ShippingOptions",
                   "slug": "shipping-options",
                   "file": "docs/reference/typescript-api/shipping/shipping-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "ShouldRunCheckFn",
@@ -3314,7 +3320,7 @@
                   "title": "TaxOptions",
                   "slug": "tax-options",
                   "file": "docs/reference/typescript-api/tax/tax-options.mdx",
-                  "lastModified": "2026-06-30T07:18:09+02:00"
+                  "lastModified": "2026-07-22T07:40:36Z"
                 },
                 {
                   "title": "TaxZoneStrategy",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -236,7 +236,7 @@
           "title": "Custom Fields",
           "slug": "custom-fields",
           "file": "docs/guides/developer-guide/custom-fields/index.mdx",
-          "lastModified": "2026-07-22T09:15:24+02:00"
+          "lastModified": "2026-07-22T09:37:32+02:00"
         },
         {
           "title": "Error Handling",

--- a/packages/core/e2e/custom-field-permissions.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-permissions.e2e-spec.ts
@@ -277,6 +277,13 @@ describe('Custom field permissions', () => {
             const { product } = await adminClient.query(productWithRestrictedRelationIdQuery);
             expect(product.customFields.restrictedRelationId).toBeNull();
         });
+
+        it('non-public relation id field is not present in the Shop API schema', async () => {
+            await shopClient.asAnonymousUser();
+            await expect(shopClient.query(productWithRestrictedRelationIdQuery)).rejects.toThrowError(
+                /restrictedRelationId/,
+            );
+        });
     });
 });
 

--- a/packages/core/e2e/custom-field-permissions.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-permissions.e2e-spec.ts
@@ -1,7 +1,8 @@
 import { Permission } from '@vendure/common/lib/generated-types';
-import { mergeConfig } from '@vendure/core';
+import { Asset, mergeConfig } from '@vendure/core';
 import { createTestEnvironment, SimpleGraphQLClient } from '@vendure/testing';
 import { fail } from 'assert';
+import gql from 'graphql-tag';
 import path from 'path';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 
@@ -53,6 +54,13 @@ describe('Custom field permissions', () => {
                         name: 'superadminField',
                         type: 'string',
                         defaultValue: 'superadminField Value',
+                        public: false,
+                        requiresPermission: Permission.SuperAdmin,
+                    },
+                    {
+                        name: 'restrictedRelation',
+                        type: 'relation',
+                        entity: Asset,
                         public: false,
                         requiresPermission: Permission.SuperAdmin,
                     },
@@ -233,6 +241,41 @@ describe('Custom field permissions', () => {
                 authenticatedField: 'new authenticatedField Value',
                 updateProductField: 'new updateProductField Value 2',
             });
+        });
+    });
+
+    // https://github.com/vendurehq/vendure/issues/2031
+    describe('relation id fields', () => {
+        const productWithRestrictedRelationIdQuery = gql`
+            query {
+                product(id: "T_1") {
+                    customFields {
+                        restrictedRelationId
+                    }
+                }
+            }
+        `;
+
+        beforeAll(async () => {
+            await adminClient.asSuperAdmin();
+            await adminClient.query(gql`
+                mutation {
+                    updateProduct(input: { id: "T_1", customFields: { restrictedRelationId: "T_1" } }) {
+                        id
+                    }
+                }
+            `);
+        });
+
+        it('relation id field is readable with the required permission', async () => {
+            const { product } = await adminClient.query(productWithRestrictedRelationIdQuery);
+            expect(product.customFields.restrictedRelationId).toBe('T_1');
+        });
+
+        it('relation id field is masked without the required permission', async () => {
+            await adminClient.asUserWithCredentials(readProductUpdateProductAdmin.emailAddress, 'test');
+            const { product } = await adminClient.query(productWithRestrictedRelationIdQuery);
+            expect(product.customFields.restrictedRelationId).toBeNull();
         });
     });
 });

--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -1616,6 +1616,121 @@ describe('Custom field relations', () => {
             expect((result?.customFields as any).singleId).toBe(3);
             expect((result?.customFields as any).single?.id).toBe(3);
         });
+
+        it('sorting by a relation custom field sorts by the id column', async () => {
+            const { products } = await adminClient.query(gql`
+                query {
+                    products(options: { sort: { single: ASC }, take: 5 }) {
+                        items {
+                            id
+                        }
+                    }
+                }
+            `);
+            expect(products.items.length).toBeGreaterThan(0);
+        });
+    });
+
+    // https://github.com/vendurehq/vendure/issues/2031
+    describe('relation id fields in the GraphQL APIs', () => {
+        beforeAll(async () => {
+            await adminClient.query(gql`
+                mutation {
+                    updateProduct(input: { id: "T_1", customFields: { singleId: "T_2" } }) {
+                        id
+                    }
+                }
+            `);
+        });
+
+        it('exposes the relation id in the Admin API', async () => {
+            const { product } = await adminClient.query(gql`
+                query {
+                    product(id: "T_1") {
+                        customFields {
+                            singleId
+                            single {
+                                id
+                            }
+                        }
+                    }
+                }
+            `);
+            expect(product.customFields.singleId).toBe('T_2');
+            expect(product.customFields.single.id).toBe('T_2');
+        });
+
+        it('exposes the relation id in the Shop API', async () => {
+            const { product } = await shopClient.query(gql`
+                query {
+                    product(id: "T_1") {
+                        customFields {
+                            singleId
+                        }
+                    }
+                }
+            `);
+            expect(product.customFields.singleId).toBe('T_2');
+        });
+
+        it('does not expose the id of internal relation custom fields', async () => {
+            await expect(
+                adminClient.query(gql`
+                    query {
+                        product(id: "T_1") {
+                            customFields {
+                                cfInternalAssetId
+                            }
+                        }
+                    }
+                `),
+            ).rejects.toThrowError(/cfInternalAssetId/);
+        });
+
+        it('filters by relation id', async () => {
+            const { products } = await adminClient.query(gql`
+                query {
+                    products(options: { filter: { singleId: { eq: "T_2" } } }) {
+                        items {
+                            id
+                            customFields {
+                                singleId
+                            }
+                        }
+                    }
+                }
+            `);
+            expect(products.items.map((i: { id: string }) => i.id)).toContain('T_1');
+            for (const item of products.items) {
+                expect(item.customFields.singleId).toBe('T_2');
+            }
+        });
+
+        it('filters by relation id isNull', async () => {
+            const { products } = await adminClient.query(gql`
+                query {
+                    products(options: { filter: { singleId: { isNull: true } } }) {
+                        items {
+                            id
+                        }
+                    }
+                }
+            `);
+            expect(products.items.map((i: { id: string }) => i.id)).not.toContain('T_1');
+        });
+
+        it('sorts by relation id', async () => {
+            const { products } = await adminClient.query(gql`
+                query {
+                    products(options: { sort: { singleId: DESC }, take: 3 }) {
+                        items {
+                            id
+                        }
+                    }
+                }
+            `);
+            expect(products.items.length).toBe(3);
+        });
     });
 
     it('null values', async () => {

--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -1716,21 +1716,53 @@ describe('Custom field relations', () => {
                     }
                 }
             `);
+            expect(products.items.length).toBeGreaterThan(0);
             expect(products.items.map((i: { id: string }) => i.id)).not.toContain('T_1');
         });
 
         it('sorts by relation id', async () => {
+            // Give a second product a distinct relation id so that the ordering
+            // of non-null values can be asserted.
+            await adminClient.query(gql`
+                mutation {
+                    updateProduct(input: { id: "T_2", customFields: { singleId: "T_3" } }) {
+                        id
+                    }
+                }
+            `);
+
+            const values = await getProductsSortedBySingle('singleId');
+            const nonNullValues = values.filter((id): id is string => id != null);
+            expect(nonNullValues.length).toBeGreaterThanOrEqual(2);
+            // The database may sort nulls first or last, but the non-null values
+            // must form a single contiguous block, in ascending order.
+            expect(nonNullValues).toEqual([...nonNullValues].sort());
+            const firstNonNull = values.findIndex(v => v != null);
+            expect(values.slice(firstNonNull, firstNonNull + nonNullValues.length)).toEqual(nonNullValues);
+        });
+
+        it('sorting by the relation field name is equivalent to sorting by its id', async () => {
+            const sortedByName = await getProductsSortedBySingle('single');
+            const sortedById = await getProductsSortedBySingle('singleId');
+            expect(sortedByName).toEqual(sortedById);
+        });
+
+        async function getProductsSortedBySingle(sortField: 'single' | 'singleId') {
             const { products } = await adminClient.query(gql`
                 query {
-                    products(options: { sort: { singleId: DESC }, take: 3 }) {
+                    products(options: { sort: { ${sortField}: ASC }, take: 100 }) {
                         items {
-                            id
+                            customFields {
+                                singleId
+                            }
                         }
                     }
                 }
             `);
-            expect(products.items.length).toBe(3);
-        });
+            return products.items.map(
+                (i: { customFields: { singleId: string | null } }) => i.customFields.singleId,
+            ) as Array<string | null>;
+        }
     });
 
     it('null values', async () => {

--- a/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
+++ b/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
@@ -1,5 +1,46 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`addGraphQLCustomFields() > adds relation id fields for non-list relation custom fields 1`] = `
+"type Product {
+  id: ID
+  customFields: ProductCustomFields
+}
+
+type Asset {
+  id: ID
+}
+
+input ProductSortParameter {
+  id: SortOrder
+  owner: SortOrder
+  ownerId: SortOrder
+}
+
+input ProductFilterParameter {
+  id: IDOperators
+  ownerId: IDOperators
+}
+
+enum SortOrder {
+  ASC
+  DESC
+}
+
+input IDOperators {
+  eq: String
+}
+
+scalar JSON
+
+scalar DateTime
+
+type ProductCustomFields {
+  owner: Asset
+  featured: [Asset!]
+  ownerId: ID
+}"
+`;
+
 exports[`addGraphQLCustomFields() > extends OrderAddress if Address custom fields defined 1`] = `
 "type Address {
   id: ID

--- a/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
+++ b/packages/core/src/api/config/__snapshots__/graphql-custom-fields.spec.ts.snap
@@ -13,12 +13,15 @@ type Asset {
 input ProductSortParameter {
   id: SortOrder
   owner: SortOrder
+  legacyOwner: SortOrder @deprecated(reason: "use owner instead")
   ownerId: SortOrder
+  legacyOwnerId: SortOrder @deprecated(reason: "use owner instead")
 }
 
 input ProductFilterParameter {
   id: IDOperators
   ownerId: IDOperators
+  legacyOwnerId: IDOperators @deprecated(reason: "use owner instead")
 }
 
 enum SortOrder {
@@ -37,7 +40,9 @@ scalar DateTime
 type ProductCustomFields {
   owner: Asset
   featured: [Asset!]
+  legacyOwner: Asset @deprecated(reason: "use owner instead")
   ownerId: ID
+  legacyOwnerId: ID @deprecated(reason: "use owner instead")
 }"
 `;
 

--- a/packages/core/src/api/config/generate-resolvers.ts
+++ b/packages/core/src/api/config/generate-resolvers.ts
@@ -326,6 +326,28 @@ function generateCustomFieldResolvers(
                     [fieldDef.name]: resolver,
                 } as any;
             }
+
+            if (isRelationalType(fieldDef) && fieldDef.list !== true) {
+                // Non-list relation custom fields also expose a `<name>Id` field, which is
+                // subject to the same permissions as the relation field itself.
+                const idResolver: IFieldResolver<any, any> = (source: any, args: any, context: any) => {
+                    const ctx = internal_getRequestContext(context.req);
+                    if (!userHasPermissionsOnCustomField(ctx, fieldDef)) {
+                        return null;
+                    }
+                    return source[`${fieldDef.name}Id`];
+                };
+                adminResolvers[customFieldTypeName] = {
+                    ...adminResolvers[customFieldTypeName],
+                    [`${fieldDef.name}Id`]: idResolver,
+                } as any;
+                if (fieldDef.public !== false && !excludeFromShopApi) {
+                    shopResolvers[customFieldTypeName] = {
+                        ...shopResolvers[customFieldTypeName],
+                        [`${fieldDef.name}Id`]: idResolver,
+                    } as any;
+                }
+            }
         }
         const allCustomFieldsAreNonPublic =
             customFields.length && customFields.every(f => f.public === false || f.internal === true);

--- a/packages/core/src/api/config/graphql-custom-fields.spec.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.spec.ts
@@ -251,6 +251,13 @@ describe('addGraphQLCustomFields()', () => {
                     graphQLType: 'Asset',
                     list: true,
                 },
+                {
+                    name: 'legacyOwner',
+                    type: 'relation',
+                    entity: class {} as any,
+                    graphQLType: 'Asset',
+                    deprecated: 'use owner instead',
+                },
             ],
         };
         const result = addGraphQLCustomFields(input, customFieldConfig, false);

--- a/packages/core/src/api/config/graphql-custom-fields.spec.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.spec.ts
@@ -213,6 +213,50 @@ describe('addGraphQLCustomFields()', () => {
         expect(printSchema(result)).toMatchSnapshot();
     });
 
+    // https://github.com/vendurehq/vendure/issues/2031
+    it('adds relation id fields for non-list relation custom fields', () => {
+        const input = `
+                    type Product {
+                        id: ID
+                    }
+
+                    type Asset {
+                        id: ID
+                    }
+
+                    input ProductSortParameter {
+                        id: SortOrder
+                    }
+
+                    input ProductFilterParameter {
+                        id: IDOperators
+                    }
+
+                    enum SortOrder {
+                        ASC
+                        DESC
+                    }
+
+                    input IDOperators {
+                        eq: String
+                    }
+                `;
+        const customFieldConfig: CustomFields = {
+            Product: [
+                { name: 'owner', type: 'relation', entity: class {} as any, graphQLType: 'Asset' },
+                {
+                    name: 'featured',
+                    type: 'relation',
+                    entity: class {} as any,
+                    graphQLType: 'Asset',
+                    list: true,
+                },
+            ],
+        };
+        const result = addGraphQLCustomFields(input, customFieldConfig, false);
+        expect(printSchema(result)).toMatchSnapshot();
+    });
+
     it('publicOnly = true', () => {
         const input = `
                  type Product {

--- a/packages/core/src/api/config/graphql-custom-fields.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.ts
@@ -115,6 +115,7 @@ export function addGraphQLCustomFields(
                 customFieldTypeDefs += `
                     type ${entityName}CustomFields {
                         ${mapToFields(customEntityFields, wrapListType(getGraphQlType(entityName)))}
+                        ${mapToRelationIdFields(customEntityFields, 'ID')}
                     }
 
                     extend type ${entityName} {
@@ -239,14 +240,22 @@ export function addGraphQLCustomFields(
             customFieldTypeDefs += `
                     extend input ${entityName}SortParameter {
                          ${mapToFields(sortableFields, () => 'SortOrder')}
+                         ${mapToRelationIdFields(sortableFields, 'SortOrder')}
                     }
                 `;
         }
 
-        if (filterableFields.length && schema.getType(`${entityName}FilterParameter`)) {
+        const relationIdFilterFields = customEntityFields.filter(
+            field => field.type === 'relation' && field.list !== true,
+        );
+        if (
+            (filterableFields.length || relationIdFilterFields.length) &&
+            schema.getType(`${entityName}FilterParameter`)
+        ) {
             customFieldTypeDefs += `
                     extend input ${entityName}FilterParameter {
                          ${mapToFields(filterableFields, getFilterOperator)}
+                         ${mapToRelationIdFields(relationIdFilterFields, 'IDOperators')}
                     }
                 `;
         }
@@ -295,6 +304,7 @@ export function addGraphQLCustomFields(
                 customFieldTypeDefs += `
                     type ${publicEntityName}CustomFields {
                         ${mapToFields(customEntityFields, wrapListType(getGraphQlType(entityName)))}
+                        ${mapToRelationIdFields(customEntityFields, 'ID')}
                     }
 
                     extend type ${publicEntityName} {
@@ -652,6 +662,18 @@ function mapToFields(
         })
         .filter(x => x != null);
     return res.join('\n');
+}
+
+/**
+ * Non-list relation custom fields also expose the id of the related entity as a `<name>Id`
+ * field, mirroring the id column on the entity itself. Maps such fields to a string of
+ * SDL fields of the given type.
+ */
+function mapToRelationIdFields(fieldDefs: CustomFieldConfig[], graphQlType: string): string {
+    return fieldDefs
+        .filter(field => field.type === 'relation' && field.list !== true)
+        .map(field => `${field.name}Id: ${graphQlType} ${getDeprecationDirective(field)}`)
+        .join('\n');
 }
 
 /**

--- a/packages/core/src/api/config/graphql-custom-fields.ts
+++ b/packages/core/src/api/config/graphql-custom-fields.ts
@@ -13,6 +13,7 @@ import {
     BaseTypedCustomFieldConfig,
     CustomFieldConfig,
     CustomFields,
+    isNonListRelationCustomField,
     StructCustomFieldConfig,
     StructFieldConfig,
 } from '../../config/custom-field/custom-field-types';
@@ -245,9 +246,7 @@ export function addGraphQLCustomFields(
                 `;
         }
 
-        const relationIdFilterFields = customEntityFields.filter(
-            field => field.type === 'relation' && field.list !== true,
-        );
+        const relationIdFilterFields = customEntityFields.filter(isNonListRelationCustomField);
         if (
             (filterableFields.length || relationIdFilterFields.length) &&
             schema.getType(`${entityName}FilterParameter`)
@@ -671,7 +670,7 @@ function mapToFields(
  */
 function mapToRelationIdFields(fieldDefs: CustomFieldConfig[], graphQlType: string): string {
     return fieldDefs
-        .filter(field => field.type === 'relation' && field.list !== true)
+        .filter(isNonListRelationCustomField)
         .map(field => `${field.name}Id: ${graphQlType} ${getDeprecationDirective(field)}`)
         .join('\n');
 }

--- a/packages/core/src/config/custom-field/custom-field-types.ts
+++ b/packages/core/src/config/custom-field/custom-field-types.ts
@@ -333,3 +333,13 @@ export type CustomFields = {
 export interface HasCustomFields {
     customFields: CustomFieldsObject;
 }
+
+/**
+ * Returns true for non-list relation custom fields, i.e. those which also expose a
+ * `<name>Id` property on the entity and in the GraphQL APIs.
+ */
+export function isNonListRelationCustomField(
+    config: CustomFieldConfig,
+): config is RelationCustomFieldConfig {
+    return config.type === 'relation' && config.list !== true;
+}

--- a/packages/core/src/service/helpers/list-query-builder/parse-sort-params.ts
+++ b/packages/core/src/service/helpers/list-query-builder/parse-sort-params.ts
@@ -60,6 +60,9 @@ export function parseSortParams<T extends VendureEntity>(
             }
         } else if (customPropertyMap?.[key]) {
             output[customPropertyMap[key]] = order as any;
+        } else if (isNonListRelationCustomField(customFields, key)) {
+            // Non-list relation custom fields are sorted by their id column
+            output[`${alias}.customFields.${key}Id`] = order as any;
         } else {
             throw new UserInputError('error.invalid-sort-field', {
                 fieldName: key,
@@ -75,4 +78,11 @@ export function parseSortParams<T extends VendureEntity>(
 
 function getValidSortFields(columns: ColumnMetadata[]): string[] {
     return unique(columns.map(c => c.propertyName));
+}
+
+function isNonListRelationCustomField(
+    customFields: CustomFieldConfig[] | undefined,
+    fieldName: string,
+): boolean {
+    return !!customFields?.find(f => f.name === fieldName && f.type === 'relation' && f.list !== true);
 }

--- a/packages/core/src/service/helpers/list-query-builder/parse-sort-params.ts
+++ b/packages/core/src/service/helpers/list-query-builder/parse-sort-params.ts
@@ -6,7 +6,10 @@ import { ColumnMetadata } from 'typeorm/metadata/ColumnMetadata';
 
 import { UserInputError } from '../../../common/error/errors';
 import { NullOptionals, SortParameter } from '../../../common/types/common-types';
-import { CustomFieldConfig } from '../../../config/custom-field/custom-field-types';
+import {
+    CustomFieldConfig,
+    isNonListRelationCustomField,
+} from '../../../config/custom-field/custom-field-types';
 import { VendureEntity } from '../../../entity/base/base.entity';
 
 import { escapeCalculatedColumnExpression, getColumnMetadata } from './connection-utils';
@@ -60,7 +63,7 @@ export function parseSortParams<T extends VendureEntity>(
             }
         } else if (customPropertyMap?.[key]) {
             output[customPropertyMap[key]] = order as any;
-        } else if (isNonListRelationCustomField(customFields, key)) {
+        } else if (customFields?.some(f => f.name === key && isNonListRelationCustomField(f))) {
             // Non-list relation custom fields are sorted by their id column
             output[`${alias}.customFields.${key}Id`] = order as any;
         } else {
@@ -78,11 +81,4 @@ export function parseSortParams<T extends VendureEntity>(
 
 function getValidSortFields(columns: ColumnMetadata[]): string[] {
     return unique(columns.map(c => c.propertyName));
-}
-
-function isNonListRelationCustomField(
-    customFields: CustomFieldConfig[] | undefined,
-    fieldName: string,
-): boolean {
-    return !!customFields?.find(f => f.name === fieldName && f.type === 'relation' && f.list !== true);
 }


### PR DESCRIPTION
## Description

Follow-up to the entity-level relation id properties added in the PR for issue 2031. This exposes the id of non-list relation custom fields in the GraphQL APIs, completing the feature.

Given a relation custom field `owner`, the generated `customFields` output types now contain an `ownerId: ID` field alongside `owner`:

```graphql
query {
    product(id: "T_1") {
        customFields {
            ownerId  # resolved from the entity's id column — no extra DB query
        }
    }
}
```

The id field can also be used to filter (`ownerId: IDOperators`) and sort (`ownerId: SortOrder`) in list queries. Since the id is a real column on the entity, filtering and sorting require no joins.

Relates to #2031

## Implementation notes

- **Zero extra queries.** Selecting `owner { id }` triggers the relation resolver, which loads the related entity from the database (per entity, per field, in lists). Selecting `ownerId` reads the already-loaded column.
- **Access control is inherited from the relation field.** The id fields are generated from the same filtered field list as the relation fields, so `internal: true` (absent from all APIs) and `public: false` (absent from the Shop API) apply identically at the schema level. At runtime, the generated id-field resolver applies the same `requiresPermission` check as the relation field, returning `null` when the user lacks the permission.
- **ID encoding/decoding is automatic.** Output encoding is schema-driven (any `ID`-typed field), and the `IdInterceptor` already decodes `IDOperators` filter inputs.
- **List relations are not covered**, since their ids live in a join table rather than a column on the entity. Their input fields (`<name>Ids`) are unchanged.

## Fixes a regression in sorting by relation custom field name

The generated `<Entity>SortParameter` inputs have always included non-list relation custom fields (e.g. `owner: SortOrder`). This worked by riding on TypeORM's implicit join column, whose `propertyName` used to equal the relation property name. Since the entity id columns were introduced, the join column's property name is `ownerId`, so sorting by `owner` began throwing `error.invalid-sort-field`. `parseSortParams` now maps a non-list relation custom field name to its id column, restoring the previous behaviour (and giving it well-defined semantics: sort by the foreign key). Since both changes landed within the same minor release cycle, no released version is affected.

## Testing

- Unit test with schema snapshot covering output, sort and filter type generation for relation fields (list and non-list)
- e2e (`custom-field-relations`): Admin & Shop API reads with id encoding, `internal` field absence from the schema, filtering by id (`eq`, `isNull`), sorting by id and by relation field name
- e2e (`custom-field-permissions`): `requiresPermission` inheritance — id field readable with the permission, masked (null) without it
- Full core e2e suite: 1995 passed, 0 failed
- Core unit tests: 1115 passed

## Breaking changes

None. The new fields are additive; existing queries are unaffected.

## Documentation

The "Relation ids" section of the custom fields guide has been extended with the GraphQL usage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5013"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787297884&installation_model_id=20193&pr_number=5013&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5013&signature=ec00bc684d436e7aa821874b0a238177701b9df3ca513b7ed312b4a4e5aeca48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->