### PR TITLE
fix(job-queue-plugin): Fix BullMQ job list query pagination, ordering & index maintenance

### DIFF
--- a/packages/job-queue-plugin/e2e/get-jobs-by-type-script.e2e-spec.ts
+++ b/packages/job-queue-plugin/e2e/get-jobs-by-type-script.e2e-spec.ts
@@ -1,0 +1,279 @@
+import Redis from 'ioredis';
+import { afterAll, beforeEach, describe, expect, it } from 'vitest';
+
+import { ALL_JOB_TYPES } from '../src/bullmq/constants';
+import { getJobsByType } from '../src/bullmq/scripts/get-jobs-by-type';
+
+/**
+ * These tests exercise the `getJobsByType` Lua script directly against a real Redis instance,
+ * with data laid out exactly as BullMQ and the JobListIndexService store it:
+ *
+ * - `<prefix>wait`, `<prefix>active`, `<prefix>paused` are **lists** of job ids, newest at the head
+ * - `<prefix>completed`, `<prefix>failed` are **sorted sets** scored by the finished timestamp
+ * - `<prefix>delayed` is a **sorted set** scored by an encoded value (`ms * 4096 + n`)
+ * - `<prefix>prioritized` is a **sorted set** scored by priority
+ * - `<prefix>repeat` is a **sorted set** of repeatable-job config keys (not job ids!)
+ * - `<prefix><jobId>` is a hash of job data including the `timestamp` (creation time) field
+ * - `<prefix>queue:<queueName>:<state>` are the plugin's own indexed sorted sets,
+ *   scored by creation timestamp
+ *
+ * Each test seeds this full layout and asserts the intended contract of the jobs list:
+ * a paginated, newest-first (by creation time) listing which never drops, duplicates
+ * or invents jobs. Several of these tests currently fail, demonstrating known defects
+ * in the script. They should all pass once the script is fixed.
+ */
+
+const redisHost = '127.0.0.1';
+const redisPort = process.env.CI ? +(process.env.E2E_REDIS_PORT || 6379) : 6379;
+
+const PREFIX = 'script-test:vendure-job-queue:';
+
+interface SeedJob {
+    id: string;
+    queueName: string;
+    state: 'wait' | 'active' | 'paused' | 'completed' | 'failed' | 'delayed' | 'prioritized';
+    createdAt: number;
+    settledAt?: number;
+    /** For delayed jobs: the time at which the job becomes due */
+    delayUntil?: number;
+}
+
+const LIST_STATES = ['wait', 'active', 'paused'];
+
+describe('getJobsByType Lua script', () => {
+    const redis = new Redis({ host: redisHost, port: redisPort, maxRetriesPerRequest: null });
+    redis.defineCommand(getJobsByType.name, {
+        numberOfKeys: getJobsByType.numberOfKeys,
+        lua: getJobsByType.script,
+    });
+
+    function callScript(
+        skip: number,
+        take: number,
+        filterName: string,
+        states: string[] = ALL_JOB_TYPES,
+    ): Promise<[number, string[]]> {
+        return (redis as any).getJobsByType(PREFIX, skip, take, filterName, ...states);
+    }
+
+    async function deleteTestKeys() {
+        let cursor = '0';
+        do {
+            const [nextCursor, keys] = await redis.scan(cursor, 'MATCH', 'script-test:*', 'COUNT', 1000);
+            cursor = nextCursor;
+            if (keys.length) {
+                await redis.del(...keys);
+            }
+        } while (cursor !== '0');
+    }
+
+    /**
+     * Seeds jobs into all the Redis structures that BullMQ and the JobListIndexService
+     * maintain in a real system, so that the script under test (and any future
+     * implementation) finds a faithful data layout.
+     */
+    async function seedJobs(jobs: SeedJob[]) {
+        const pipeline = redis.pipeline();
+        // Native list structures must be LPUSHed oldest-first so the newest id ends
+        // up at the head, matching how BullMQ adds jobs.
+        for (const listState of LIST_STATES) {
+            const listJobs = jobs
+                .filter(j => j.state === listState)
+                .sort((a, b) => a.createdAt - b.createdAt);
+            for (const job of listJobs) {
+                pipeline.lpush(`${PREFIX}${listState}`, job.id);
+            }
+        }
+        for (const job of jobs) {
+            pipeline.hset(`${PREFIX}${job.id}`, {
+                name: job.queueName,
+                timestamp: job.createdAt.toString(),
+            });
+            pipeline.zadd(`${PREFIX}queue:${job.queueName}:${job.state}`, job.createdAt, job.id);
+            if (job.state === 'completed' || job.state === 'failed') {
+                pipeline.zadd(`${PREFIX}${job.state}`, job.settledAt ?? job.createdAt, job.id);
+            }
+            if (job.state === 'delayed') {
+                // BullMQ encodes the delayed timestamp as `ms * 0x1000 + count`
+                pipeline.zadd(`${PREFIX}delayed`, (job.delayUntil ?? job.createdAt) * 4096, job.id);
+            }
+            if (job.state === 'prioritized') {
+                pipeline.zadd(`${PREFIX}prioritized`, 10, job.id);
+            }
+        }
+        await pipeline.exec();
+    }
+
+    function makeJobs(
+        count: number,
+        state: SeedJob['state'],
+        queueName: string,
+        idPrefix: string,
+        firstCreatedAt: number,
+    ): SeedJob[] {
+        return Array.from({ length: count }, (_, i) => ({
+            id: `${idPrefix}${i + 1}`,
+            queueName,
+            state,
+            createdAt: firstCreatedAt + i * 10,
+            settledAt: firstCreatedAt + i * 10 + 5,
+        }));
+    }
+
+    /** Pages through the full result set and returns all collected ids plus page sizes. */
+    async function collectAllPages(take: number, filterName: string) {
+        const [total] = await callScript(0, take, filterName);
+        const allIds: string[] = [];
+        const pageSizes: number[] = [];
+        for (let skip = 0; skip < total; skip += take) {
+            const [, ids] = await callScript(skip, take, filterName);
+            allIds.push(...ids);
+            pageSizes.push(ids.length);
+        }
+        return { total, allIds, pageSizes };
+    }
+
+    const NOW = 1_700_000_000_000;
+
+    beforeEach(async () => {
+        await deleteTestKeys();
+    });
+
+    afterAll(async () => {
+        await deleteTestKeys();
+        await redis.quit();
+        await new Promise(resolve => setTimeout(resolve, 100));
+    });
+
+    it('paginates correctly when filtering by queue name (baseline)', async () => {
+        // The name-filtered path reads only the indexed sorted sets, so it is not
+        // affected by the mixed list/zset defects. This test establishes that the
+        // suite's expectations are calibrated correctly.
+        const emailJobs = [
+            ...makeJobs(25, 'completed', 'email-queue', 'email-completed-', NOW),
+            ...makeJobs(5, 'failed', 'email-queue', 'email-failed-', NOW + 10_000),
+        ];
+        const otherJobs = makeJobs(10, 'completed', 'other-queue', 'other-', NOW + 20_000);
+        await seedJobs([...emailJobs, ...otherJobs]);
+
+        const { total, allIds, pageSizes } = await collectAllPages(10, 'email-queue');
+
+        expect(total).toBe(30);
+        expect(allIds).toHaveLength(30);
+        expect(new Set(allIds).size).toBe(30);
+        expect(pageSizes).toEqual([10, 10, 10]);
+        expect(allIds.sort()).toEqual(emailJobs.map(j => j.id).sort());
+    });
+
+    it('never drops jobs at page boundaries when states span lists and sorted sets', async () => {
+        // 5 jobs in the `wait` list + 30 in the `completed` sorted set. Paging through
+        // with take=10 must yield every job exactly once and full pages until the
+        // final one. The current implementation applies `skip` to the merged sorted-set
+        // results AND again to the concatenated list+zset results, silently dropping
+        // jobs from every page after the first.
+        const completed = makeJobs(30, 'completed', 'default', 'completed-', NOW);
+        const waiting = makeJobs(5, 'wait', 'default', 'wait-', NOW + 10_000);
+        await seedJobs([...completed, ...waiting]);
+
+        const { total, allIds, pageSizes } = await collectAllPages(10, '');
+
+        expect(total).toBe(35);
+        expect(pageSizes).toEqual([10, 10, 10, 5]);
+        expect(new Set(allIds).size).toBe(35);
+        expect(allIds.sort()).toEqual([...completed, ...waiting].map(j => j.id).sort());
+    });
+
+    it('orders jobs newest-first by creation time across list and sorted-set states', async () => {
+        // The completed jobs here are newer than the waiting ones, so they must come
+        // first. The current implementation always emits list-stored jobs (wait/active)
+        // before sorted-set-stored jobs, regardless of when they were created.
+        const waiting = makeJobs(3, 'wait', 'default', 'old-wait-', NOW);
+        const completed = makeJobs(6, 'completed', 'default', 'new-completed-', NOW + 60_000);
+        await seedJobs([...waiting, ...completed]);
+
+        const [total, ids] = await callScript(0, 20, '');
+
+        expect(total).toBe(9);
+        const expectedNewestFirst = [...completed, ...waiting]
+            .sort((a, b) => b.createdAt - a.createdAt)
+            .map(j => j.id);
+        expect(ids).toEqual(expectedNewestFirst);
+    });
+
+    it('does not let the encoded scores of delayed jobs dominate the ordering', async () => {
+        // BullMQ stores delayed jobs with a score of `dueTimestamp * 4096 + n`, which is
+        // several orders of magnitude larger than a plain ms timestamp. The current
+        // implementation merges these raw scores with the completed/failed timestamps,
+        // so a delayed job always sorts above everything else even if it is the oldest.
+        const delayed: SeedJob[] = [
+            {
+                id: 'delayed-1',
+                queueName: 'default',
+                state: 'delayed',
+                createdAt: NOW,
+                delayUntil: NOW + 300_000,
+            },
+        ];
+        const completed = makeJobs(3, 'completed', 'default', 'completed-', NOW + 60_000);
+        await seedJobs([...delayed, ...completed]);
+
+        const [total, ids] = await callScript(0, 10, '');
+
+        expect(total).toBe(4);
+        // The delayed job is the oldest, so it must come last, not first.
+        expect(ids[ids.length - 1]).toBe('delayed-1');
+        expect(ids.slice(0, 3)).toEqual(['completed-3', 'completed-2', 'completed-1']);
+    });
+
+    it('does not count repeatable-job config entries as jobs', async () => {
+        // The `repeat` key holds repeatable-job definitions, not job ids. Because
+        // ALL_JOB_TYPES includes 'repeat', the current implementation counts these
+        // entries in the total and can return the raw config keys as if they were
+        // job ids.
+        const completed = makeJobs(5, 'completed', 'default', 'completed-', NOW);
+        await seedJobs(completed);
+        await redis.zadd(
+            `${PREFIX}repeat`,
+            NOW,
+            'aabbcc112233:::*/5 * * * *',
+            NOW + 1,
+            'ddeeff445566:::0 0 * * *',
+            NOW + 2,
+            '112233aabbcc:::0 12 * * MON',
+        );
+
+        const [total, ids] = await callScript(0, 10, '');
+
+        expect(total).toBe(5);
+        const realIds = completed.map(j => j.id);
+        for (const id of ids) {
+            expect(realIds).toContain(id);
+        }
+    });
+
+    it('handles more than 8000 waiting jobs without erroring', async () => {
+        // Lua's unpack() is limited to roughly 8000 arguments. The current
+        // implementation calls `RPUSH tempKey unpack(listElements)` with the entire
+        // wait list, so the query throws once the queue backlog exceeds that limit.
+        const completed = makeJobs(10, 'completed', 'default', 'completed-', NOW);
+        await seedJobs(completed);
+        const waitCount = 9000;
+        const chunkSize = 1000;
+        for (let i = 0; i < waitCount; i += chunkSize) {
+            const pipeline = redis.pipeline();
+            for (let j = i; j < Math.min(i + chunkSize, waitCount); j++) {
+                const id = `bulk-wait-${j + 1}`;
+                const createdAt = NOW + 100_000 + j;
+                pipeline.lpush(`${PREFIX}wait`, id);
+                pipeline.hset(`${PREFIX}${id}`, { name: 'default', timestamp: createdAt.toString() });
+                pipeline.zadd(`${PREFIX}queue:default:wait`, createdAt, id);
+            }
+            await pipeline.exec();
+        }
+
+        const [total, ids] = await callScript(0, 10, '');
+
+        expect(total).toBe(9010);
+        expect(ids).toHaveLength(10);
+    });
+});

--- a/packages/job-queue-plugin/e2e/get-jobs-by-type-script.e2e-spec.ts
+++ b/packages/job-queue-plugin/e2e/get-jobs-by-type-script.e2e-spec.ts
@@ -53,7 +53,8 @@ describe('getJobsByType Lua script', () => {
         filterName: string,
         states: string[] = ALL_JOB_TYPES,
     ): Promise<[number, string[]]> {
-        return (redis as any).getJobsByType(PREFIX, skip, take, filterName, ...states);
+        const names = filterName ? [filterName] : [];
+        return (redis as any).getJobsByType(PREFIX, skip, take, names.length, ...names, ...states);
     }
 
     async function deleteTestKeys() {

--- a/packages/job-queue-plugin/e2e/get-jobs-by-type-script.e2e-spec.ts
+++ b/packages/job-queue-plugin/e2e/get-jobs-by-type-script.e2e-spec.ts
@@ -36,6 +36,8 @@ interface SeedJob {
     settledAt?: number;
     /** For delayed jobs: the time at which the job becomes due */
     delayUntil?: number;
+    /** For prioritized jobs: lower value means higher priority */
+    priority?: number;
 }
 
 const LIST_STATES = ['wait', 'active', 'paused'];
@@ -85,11 +87,13 @@ describe('getJobsByType Lua script', () => {
                 pipeline.lpush(`${PREFIX}${listState}`, job.id);
             }
         }
+        let prioritizedCounter = 0;
         for (const job of jobs) {
             pipeline.hset(`${PREFIX}${job.id}`, {
                 name: job.queueName,
                 timestamp: job.createdAt.toString(),
             });
+            pipeline.sadd(`${PREFIX}queue-names`, job.queueName);
             pipeline.zadd(`${PREFIX}queue:${job.queueName}:${job.state}`, job.createdAt, job.id);
             if (job.state === 'completed' || job.state === 'failed') {
                 pipeline.zadd(`${PREFIX}${job.state}`, job.settledAt ?? job.createdAt, job.id);
@@ -99,7 +103,10 @@ describe('getJobsByType Lua script', () => {
                 pipeline.zadd(`${PREFIX}delayed`, (job.delayUntil ?? job.createdAt) * 4096, job.id);
             }
             if (job.state === 'prioritized') {
-                pipeline.zadd(`${PREFIX}prioritized`, 10, job.id);
+                // BullMQ scores the prioritized set as `priority * 2^32 + counter`,
+                // which has no relationship to creation time
+                const score = (job.priority ?? 10) * 2 ** 32 + prioritizedCounter++;
+                pipeline.zadd(`${PREFIX}prioritized`, score, job.id);
             }
         }
         await pipeline.exec();
@@ -250,6 +257,43 @@ describe('getJobsByType Lua script', () => {
         for (const id of ids) {
             expect(realIds).toContain(id);
         }
+    });
+
+    it('does not omit jobs when a state is larger than the page and natively ordered by priority', async () => {
+        // BullMQ's native prioritized set is scored by `priority * 2^32 + counter`,
+        // which has no relationship to creation time. If page candidates were
+        // selected from the native structure by its own ordering, the newest jobs
+        // (added here with the best priorities, so sorted last by ZREVRANGE) would
+        // be cut before the creation-time sort could consider them.
+        const prioritized: SeedJob[] = Array.from({ length: 30 }, (_, i) => ({
+            id: `prio-${i + 1}`,
+            queueName: 'default',
+            state: 'prioritized' as const,
+            createdAt: NOW + i * 10,
+            // The newest jobs get the numerically lowest (i.e. best) priority
+            priority: 30 - i,
+        }));
+        const completed = makeJobs(5, 'completed', 'default', 'completed-', NOW - 60_000);
+        await seedJobs([...prioritized, ...completed]);
+
+        const [total, ids] = await callScript(0, 10, '');
+
+        expect(total).toBe(35);
+        // Page 1 must hold the 10 newest jobs by creation time: prio-30 .. prio-21
+        expect(ids).toEqual(Array.from({ length: 10 }, (_, i) => `prio-${30 - i}`));
+    });
+
+    it('returns the total without fetching jobs when take is zero', async () => {
+        // A zero (or negative) page size must not translate into a full-range
+        // Redis read: a range end of `skip + take - 1 = -1` would mean "the whole
+        // structure" to Redis.
+        const completed = makeJobs(20, 'completed', 'default', 'completed-', NOW);
+        await seedJobs(completed);
+
+        const [total, ids] = await callScript(0, 0, '');
+
+        expect(total).toBe(20);
+        expect(ids).toEqual([]);
     });
 
     it('handles more than 8000 waiting jobs without erroring', async () => {

--- a/packages/job-queue-plugin/e2e/job-list.e2e-spec.ts
+++ b/packages/job-queue-plugin/e2e/job-list.e2e-spec.ts
@@ -218,6 +218,7 @@ describe('BullMQ job list query', () => {
      * the wrong Redis prefix.
      */
     async function seedIndexEntries(queueName: string, state: string, ids: string[]) {
+        await cleanupRedis.sadd(`${PREFIX}:vendure-job-queue:queue-names`, queueName);
         for (const id of ids) {
             const timestamp = await cleanupRedis.hget(`${PREFIX}:vendure-job-queue:${id}`, 'timestamp');
             await cleanupRedis.zadd(

--- a/packages/job-queue-plugin/e2e/job-list.e2e-spec.ts
+++ b/packages/job-queue-plugin/e2e/job-list.e2e-spec.ts
@@ -1,0 +1,451 @@
+import { Injectable, OnModuleInit } from '@nestjs/common';
+import { JobState } from '@vendure/common/lib/generated-types';
+import {
+    DefaultLogger,
+    JobQueue,
+    JobQueueService,
+    LogLevel,
+    mergeConfig,
+    PluginCommonModule,
+    VendurePlugin,
+} from '@vendure/core';
+import { setProcessContext } from '@vendure/core/dist/process-context/process-context';
+import { createTestEnvironment } from '@vendure/testing';
+import gql from 'graphql-tag';
+import Redis from 'ioredis';
+import path from 'path';
+import { firstValueFrom, Subject } from 'rxjs';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
+import { JobListIndexService } from '../src/bullmq/job-list-index.service';
+import { BullMQJobQueuePlugin } from '../src/bullmq/plugin';
+
+/**
+ * These tests exercise the `jobs` list query through the full stack (GraphQL admin API ->
+ * BullMQJobQueueStrategy.findMany() -> getJobsByType Lua script -> Redis) with jobs in a
+ * realistic mixture of states:
+ *
+ * - completed jobs (in BullMQ's `completed` sorted set)
+ * - a job awaiting a retry after failure (in the `delayed` sorted set)
+ * - a running job (in the `active` list)
+ * - queued jobs backed up behind it (in the `wait` list)
+ *
+ * The queue worker runs with concurrency 1, and the running job blocks until released in
+ * afterAll, so the state mixture stays stable while the assertions run.
+ *
+ * Several of these tests currently fail, demonstrating known defects in the list query.
+ * They should all pass once those defects are fixed.
+ */
+
+const redisHost = '127.0.0.1';
+const redisPort = process.env.CI ? +(process.env.E2E_REDIS_PORT || 6379) : 6379;
+const PREFIX = 'joblist-e2e';
+
+@Injectable()
+class ListTestService implements OnModuleInit {
+    static releaseBlocker$ = new Subject<void>();
+    fastOne: JobQueue<{ n: number }>;
+    fastTwo: JobQueue<{ n: number }>;
+    flaky: JobQueue<{ n: number }>;
+    blocker: JobQueue<{ n: number }>;
+    filler: JobQueue<{ n: number }>;
+
+    constructor(private jobQueueService: JobQueueService) {}
+
+    async onModuleInit() {
+        this.fastOne = await this.jobQueueService.createQueue({
+            name: 'list-fast-one',
+            process: async () => 'ok',
+        });
+        this.fastTwo = await this.jobQueueService.createQueue({
+            name: 'list-fast-two',
+            process: async () => 'ok',
+        });
+        this.flaky = await this.jobQueueService.createQueue({
+            name: 'list-flaky',
+            process: async () => {
+                throw new Error('deliberate failure');
+            },
+        });
+        this.blocker = await this.jobQueueService.createQueue({
+            name: 'list-blocker',
+            process: async () => {
+                await firstValueFrom(ListTestService.releaseBlocker$);
+                return 'released';
+            },
+        });
+        this.filler = await this.jobQueueService.createQueue({
+            name: 'list-filler',
+            process: async () => 'ok',
+        });
+    }
+}
+
+@VendurePlugin({
+    imports: [PluginCommonModule],
+    providers: [ListTestService],
+})
+class ListTestPlugin {}
+
+const GET_JOBS = gql`
+    query GetJobList($options: JobListOptions) {
+        jobs(options: $options) {
+            totalItems
+            items {
+                id
+                queueName
+                state
+            }
+        }
+    }
+`;
+
+const GET_JOB = gql`
+    query GetJobById($id: ID!) {
+        job(jobId: $id) {
+            id
+            state
+        }
+    }
+`;
+
+const GET_JOBS_BY_ID = gql`
+    query GetJobsByIds($ids: [ID!]!) {
+        jobsById(jobIds: $ids) {
+            id
+            state
+        }
+    }
+`;
+
+const CANCEL_JOB = gql`
+    mutation CancelJobById($id: ID!) {
+        cancelJob(jobId: $id) {
+            id
+            state
+        }
+    }
+`;
+
+function sleep(ms: number) {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+describe('BullMQ job list query', () => {
+    const { server, adminClient } = createTestEnvironment(
+        mergeConfig(testConfig(), {
+            logger: new DefaultLogger({ level: LogLevel.Warn }),
+            plugins: [
+                BullMQJobQueuePlugin.init({
+                    connection: {
+                        host: redisHost,
+                        port: redisPort,
+                        maxRetriesPerRequest: null,
+                    },
+                    workerOptions: {
+                        prefix: PREFIX,
+                    },
+                    queueOptions: {
+                        prefix: PREFIX,
+                    },
+                    // A single worker slot, so the blocker job below keeps all
+                    // filler jobs parked in the `wait` list.
+                    concurrency: 1,
+                    // Park failed jobs in the `delayed` state for long enough that
+                    // they remain there for the whole test run.
+                    setBackoff: () => ({ type: 'fixed', delay: 5 * 60_000 }),
+                }),
+                ListTestPlugin,
+            ],
+        }),
+    );
+
+    const cleanupRedis = new Redis({ host: redisHost, port: redisPort, maxRetriesPerRequest: null });
+
+    // Ids of the jobs created in beforeAll, in creation order
+    const fastOneIds: string[] = [];
+    const fastTwoIds: string[] = [];
+    let flakyId: string;
+    let blockerId: string;
+    const fillerIds: string[] = [];
+    let removedId: string | undefined;
+
+    function allKnownIdsInCreationOrder(): string[] {
+        return [...fastOneIds, ...fastTwoIds, flakyId, blockerId, ...fillerIds];
+    }
+
+    async function waitFor(condition: () => Promise<boolean>, label: string, timeoutMs = 20_000) {
+        const started = Date.now();
+        do {
+            if (await condition()) {
+                return;
+            }
+            await sleep(200);
+        } while (Date.now() - started < timeoutMs);
+        throw new Error(`Timed out waiting for: ${label}`);
+    }
+
+    // The e2e testConfig uses an entity id strategy which prefixes all ids in API
+    // responses with "T_", so we strip it to compare against the raw BullMQ job ids.
+    function normalizeId(id: string): string {
+        return id.replace(/^T_/, '');
+    }
+
+    async function getJobs(options: any) {
+        const { jobs } = await adminClient.query(GET_JOBS, { options });
+        return {
+            totalItems: jobs.totalItems as number,
+            items: (jobs.items as Array<{ id: string; queueName: string; state: string }>).map(item => ({
+                ...item,
+                id: normalizeId(item.id),
+            })),
+        };
+    }
+
+    /**
+     * Writes entries to the indexed sorted sets exactly as a correctly-functioning
+     * JobListIndexService would. This lets the tests below demonstrate defects in the
+     * *query* side of the indexed sets independently of the (also broken) event-driven
+     * index maintenance, which never runs because the QueueEvents instance listens on
+     * the wrong Redis prefix.
+     */
+    async function seedIndexEntries(queueName: string, state: string, ids: string[]) {
+        for (const id of ids) {
+            const timestamp = await cleanupRedis.hget(`${PREFIX}:vendure-job-queue:${id}`, 'timestamp');
+            await cleanupRedis.zadd(
+                `${PREFIX}:vendure-job-queue:queue:${queueName}:${state}`,
+                Number(timestamp),
+                id,
+            );
+        }
+    }
+
+    async function jobsAreInState(ids: string[], state: JobState): Promise<boolean> {
+        const { jobsById } = await adminClient.query(GET_JOBS_BY_ID, { ids });
+        return (
+            jobsById.length === ids.length && jobsById.every((j: { state: string }) => j.state === state)
+        );
+    }
+
+    beforeAll(async () => {
+        // The JobListIndexService only maintains its indexed sets in the worker process.
+        // The test server runs everything in a single process which defaults to the
+        // 'server' context, so we explicitly set the 'worker' context to mirror a
+        // production deployment (where the worker maintains the index that the server
+        // then reads).
+        setProcessContext('worker');
+
+        // Remove leftover keys from previous runs so counts are predictable
+        let cursor = '0';
+        do {
+            const [nextCursor, keys] = await cleanupRedis.scan(
+                cursor,
+                'MATCH',
+                `${PREFIX}:*`,
+                'COUNT',
+                1000,
+            );
+            cursor = nextCursor;
+            if (keys.length) {
+                await cleanupRedis.del(...keys);
+            }
+        } while (cursor !== '0');
+
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
+            customerCount: 1,
+        });
+        await adminClient.asSuperAdmin();
+
+        const service = server.app.get(ListTestService);
+
+        // 1. Completed jobs on two queues. Jobs are added with small gaps so that
+        // every job has a distinct creation timestamp, making ordering assertions
+        // deterministic.
+        for (let i = 1; i <= 3; i++) {
+            const job = await service.fastOne.add({ n: i });
+            fastOneIds.push(job.id!.toString());
+            await sleep(20);
+        }
+        for (let i = 1; i <= 2; i++) {
+            const job = await service.fastTwo.add({ n: i });
+            fastTwoIds.push(job.id!.toString());
+            await sleep(20);
+        }
+        await waitFor(
+            () => jobsAreInState([...fastOneIds, ...fastTwoIds], JobState.COMPLETED),
+            'fast jobs to complete',
+        );
+
+        // 2. A job which fails and awaits a retry in 5 minutes, i.e. sits in the
+        // `delayed` state for the rest of the test run.
+        const flakyJob = await service.flaky.add({ n: 1 }, { retries: 1 });
+        flakyId = flakyJob.id!.toString();
+        await waitFor(() => jobsAreInState([flakyId], JobState.RETRYING), 'flaky job to await retry');
+        await sleep(20);
+
+        // 3. A job which blocks the single worker slot until released in afterAll.
+        const blockerJob = await service.blocker.add({ n: 1 });
+        blockerId = blockerJob.id!.toString();
+        await waitFor(() => jobsAreInState([blockerId], JobState.RUNNING), 'blocker job to start');
+        await sleep(20);
+
+        // 4. Jobs queued up behind the blocker, i.e. in the `wait` list.
+        for (let i = 1; i <= 8; i++) {
+            const job = await service.filler.add({ n: i });
+            fillerIds.push(job.id!.toString());
+            await sleep(20);
+        }
+        await waitFor(() => jobsAreInState(fillerIds, JobState.PENDING), 'filler jobs to be queued');
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        // Release the blocker so that it and the filler jobs can complete, allowing
+        // the worker to shut down gracefully.
+        ListTestService.releaseBlocker$.next();
+        try {
+            await waitFor(
+                () => jobsAreInState([blockerId, ...fillerIds], JobState.COMPLETED),
+                'blocked jobs to drain',
+                10_000,
+            );
+        } catch (e: any) {
+            // eslint-disable-next-line no-console
+            console.log(e.message);
+        }
+        // The JobListIndexService never closes its QueueEvents connection, so we do it
+        // here to avoid a dangling Redis connection keeping the process alive.
+        const jobListIndexService = server.app.get(JobListIndexService);
+        await (jobListIndexService as any).queueEvents?.close();
+        await server.destroy();
+        await cleanupRedis.quit();
+        await new Promise(resolve => setTimeout(resolve, 100));
+    });
+
+    it('lists jobs of all states with correct state mapping', async () => {
+        // Calibration test: all seeded jobs are visible in a single large page with the
+        // expected JobState. This passes with the current implementation and proves the
+        // suite's setup assumptions hold.
+        const { items } = await getJobs({ take: 100 });
+        const byId = new Map(items.map(item => [item.id, item]));
+
+        for (const id of [...fastOneIds, ...fastTwoIds]) {
+            expect.soft(byId.get(id)?.state).toBe(JobState.COMPLETED);
+        }
+        expect.soft(byId.get(flakyId)?.state).toBe(JobState.RETRYING);
+        expect.soft(byId.get(blockerId)?.state).toBe(JobState.RUNNING);
+        for (const id of fillerIds) {
+            expect.soft(byId.get(id)?.state).toBe(JobState.PENDING);
+        }
+    });
+
+    it('keeps the job list index updated when a custom Redis prefix is configured', async () => {
+        // The JobListIndexService maintains its indexed sets in response to QueueEvents.
+        // The QueueEvents instance is created without the configured Redis prefix, so it
+        // listens on the default 'bull'-prefixed events stream which this queue never
+        // writes to — meaning the index is never updated after the initial startup
+        // migration. The completed list-fast-one jobs must appear in the indexed set.
+        const indexKey = `${PREFIX}:vendure-job-queue:queue:list-fast-one:completed`;
+        let indexedIds: string[] = [];
+        const started = Date.now();
+        do {
+            indexedIds = await cleanupRedis.zrange(indexKey, 0, -1);
+            if (fastOneIds.every(id => indexedIds.includes(id))) {
+                break;
+            }
+            await sleep(200);
+        } while (Date.now() - started < 5000);
+
+        expect(indexedIds).toEqual(expect.arrayContaining(fastOneIds));
+    });
+
+    it('returns jobs ordered newest-first regardless of state', async () => {
+        // The jobs list should be ordered by creation time, newest first. The current
+        // implementation emits list-stored jobs (active/wait) before sorted-set-stored
+        // jobs (completed/delayed), so running & queued jobs always come before newer
+        // completed jobs, and the retrying job sinks below the completed jobs that
+        // were created before it.
+        const { items } = await getJobs({ take: 100 });
+        const knownIds = new Set(allKnownIdsInCreationOrder());
+        const ourIdsInResponseOrder = items.map(item => item.id).filter(id => knownIds.has(id));
+
+        const expectedNewestFirst = [...allKnownIdsInCreationOrder()].reverse();
+        expect(ourIdsInResponseOrder).toEqual(expectedNewestFirst);
+    });
+
+    it('returns every job exactly once when paginating', async () => {
+        // Walking through all pages must yield every job exactly once, and the number
+        // of collected jobs must equal totalItems. The current implementation applies
+        // `skip` twice when the results span both list-stored and sorted-set-stored
+        // states, silently dropping jobs from pages.
+        const take = 5;
+        const { totalItems } = await getJobs({ take, skip: 0 });
+        const collected: string[] = [];
+        for (let skip = 0; skip < totalItems; skip += take) {
+            const { items } = await getJobs({ take, skip });
+            collected.push(...items.map(item => item.id));
+        }
+
+        expect(new Set(collected).size).toBe(collected.length);
+        for (const id of allKnownIdsInCreationOrder()) {
+            expect.soft(collected, `job ${id} missing from paginated results`).toContain(id);
+        }
+        expect(collected.length).toBe(totalItems);
+    });
+
+    it('filtering by RETRYING state returns jobs awaiting a retry', async () => {
+        // The single-job query correctly reports the flaky job as RETRYING (it is in
+        // BullMQ's `delayed` state awaiting its retry), so the list query filtered by
+        // RETRYING must include it. The current implementation maps the RETRYING filter
+        // to the 'repeat' job type, which holds repeatable-job configs, not retrying
+        // jobs — so the filter returns nothing.
+        const { job } = await adminClient.query(GET_JOB, { id: flakyId });
+        expect(job.state).toBe(JobState.RETRYING);
+
+        const { items } = await getJobs({ filter: { state: { eq: JobState.RETRYING } } });
+        expect(items.map(item => item.id)).toContain(flakyId);
+    });
+
+    it('filtering by multiple queue names returns jobs from all of them', async () => {
+        await seedIndexEntries('list-fast-one', 'completed', fastOneIds);
+        await seedIndexEntries('list-fast-two', 'completed', fastTwoIds);
+
+        // Sanity check: each single-queue filter works against the seeded index.
+        const one = await getJobs({ filter: { queueName: { eq: 'list-fast-one' } } });
+        const two = await getJobs({ filter: { queueName: { eq: 'list-fast-two' } } });
+        expect(one.items.map(item => item.id).sort()).toEqual([...fastOneIds].sort());
+        expect(two.items.map(item => item.id).sort()).toEqual([...fastTwoIds].sort());
+
+        // The current implementation only uses the first entry of the `in` array,
+        // silently dropping all other queue names from the filter.
+        const { items } = await getJobs({
+            filter: { queueName: { in: ['list-fast-one', 'list-fast-two'] } },
+        });
+        const returnedIds = items.map(item => item.id);
+        for (const id of [...fastOneIds, ...fastTwoIds]) {
+            expect.soft(returnedIds, `job ${id} missing from multi-queue filter`).toContain(id);
+        }
+    });
+
+    it('reports consistent totals after a job is removed', async () => {
+        await seedIndexEntries('list-fast-two', 'completed', fastTwoIds);
+        const two = await getJobs({ filter: { queueName: { eq: 'list-fast-two' } } });
+        expect(two.items.length).toBe(2);
+
+        // Cancelling a settled job removes it from the queue entirely. The plugin's
+        // 'removed' event handler then tries to look up the already-deleted job to
+        // find its queue name, fails, and leaves the indexed set entry behind — so
+        // totalItems keeps counting the removed job while items no longer contains it.
+        removedId = fastTwoIds[0];
+        await adminClient.query(CANCEL_JOB, { id: removedId });
+        // Allow the 'removed' event to be delivered and processed
+        await sleep(1500);
+
+        const { totalItems, items } = await getJobs({ filter: { queueName: { eq: 'list-fast-two' } } });
+        expect(items.map(item => item.id)).not.toContain(removedId);
+        expect(items.length).toBe(totalItems);
+    });
+});

--- a/packages/job-queue-plugin/e2e/job-list.e2e-spec.ts
+++ b/packages/job-queue-plugin/e2e/job-list.e2e-spec.ts
@@ -9,7 +9,6 @@ import {
     PluginCommonModule,
     VendurePlugin,
 } from '@vendure/core';
-import { setProcessContext } from '@vendure/core/dist/process-context/process-context';
 import { createTestEnvironment } from '@vendure/testing';
 import gql from 'graphql-tag';
 import Redis from 'ioredis';
@@ -193,6 +192,13 @@ describe('BullMQ job list query', () => {
         return id.replace(/^T_/, '');
     }
 
+    function requireJobId(job: { id?: string | number }): string {
+        if (job.id == null) {
+            throw new Error('Expected job to have an id');
+        }
+        return job.id.toString();
+    }
+
     async function getJobs(options: any) {
         const { jobs } = await adminClient.query(GET_JOBS, { options });
         return {
@@ -230,13 +236,6 @@ describe('BullMQ job list query', () => {
     }
 
     beforeAll(async () => {
-        // The JobListIndexService only maintains its indexed sets in the worker process.
-        // The test server runs everything in a single process which defaults to the
-        // 'server' context, so we explicitly set the 'worker' context to mirror a
-        // production deployment (where the worker maintains the index that the server
-        // then reads).
-        setProcessContext('worker');
-
         // Remove leftover keys from previous runs so counts are predictable
         let cursor = '0';
         do {
@@ -260,6 +259,15 @@ describe('BullMQ job list query', () => {
         });
         await adminClient.asSuperAdmin();
 
+        // The JobListIndexService only maintains its indexed sets in the worker
+        // process, but the test server runs as a single process in the 'server'
+        // context. To mirror a production deployment (where the worker maintains
+        // the index that the server then reads), we patch the process context and
+        // register the event listeners manually.
+        const indexService: any = server.app.get(JobListIndexService);
+        indexService.processContext = { isServer: false, isWorker: true };
+        indexService.setupEventListeners();
+
         const service = server.app.get(ListTestService);
 
         // 1. Completed jobs on two queues. Jobs are added with small gaps so that
@@ -267,12 +275,12 @@ describe('BullMQ job list query', () => {
         // deterministic.
         for (let i = 1; i <= 3; i++) {
             const job = await service.fastOne.add({ n: i });
-            fastOneIds.push(job.id!.toString());
+            fastOneIds.push(requireJobId(job));
             await sleep(20);
         }
         for (let i = 1; i <= 2; i++) {
             const job = await service.fastTwo.add({ n: i });
-            fastTwoIds.push(job.id!.toString());
+            fastTwoIds.push(requireJobId(job));
             await sleep(20);
         }
         await waitFor(
@@ -283,20 +291,20 @@ describe('BullMQ job list query', () => {
         // 2. A job which fails and awaits a retry in 5 minutes, i.e. sits in the
         // `delayed` state for the rest of the test run.
         const flakyJob = await service.flaky.add({ n: 1 }, { retries: 1 });
-        flakyId = flakyJob.id!.toString();
+        flakyId = requireJobId(flakyJob);
         await waitFor(() => jobsAreInState([flakyId], JobState.RETRYING), 'flaky job to await retry');
         await sleep(20);
 
         // 3. A job which blocks the single worker slot until released in afterAll.
         const blockerJob = await service.blocker.add({ n: 1 });
-        blockerId = blockerJob.id!.toString();
+        blockerId = requireJobId(blockerJob);
         await waitFor(() => jobsAreInState([blockerId], JobState.RUNNING), 'blocker job to start');
         await sleep(20);
 
         // 4. Jobs queued up behind the blocker, i.e. in the `wait` list.
         for (let i = 1; i <= 8; i++) {
             const job = await service.filler.add({ n: i });
-            fillerIds.push(job.id!.toString());
+            fillerIds.push(requireJobId(job));
             await sleep(20);
         }
         await waitFor(() => jobsAreInState(fillerIds, JobState.PENDING), 'filler jobs to be queued');

--- a/packages/job-queue-plugin/package.json
+++ b/packages/job-queue-plugin/package.json
@@ -16,7 +16,7 @@
         "watch": "tsc -p ./tsconfig.build.json --watch",
         "build": "rimraf package && tsc -p ./tsconfig.build.json",
         "lint": "eslint --fix .",
-        "e2e-wip": "node e2e/check-connection.js || jest --config ../../e2e-common/jest-config.js --runInBand --package=job-queue-plugin",
+        "e2e": "node e2e/check-connection.js || cross-env PACKAGE=job-queue-plugin vitest --config ../../e2e-common/vitest.config.mts --run",
         "ci": "npm run build"
     },
     "homepage": "https://www.vendure.io/",

--- a/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
+++ b/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
@@ -220,7 +220,8 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
                     jobTypes = ['completed'];
                     break;
                 case 'RETRYING':
-                    jobTypes = ['repeat'];
+                    // Jobs awaiting a retry after failure are stored in the 'delayed' state
+                    jobTypes = ['delayed'];
                     break;
                 case 'FAILED':
                     jobTypes = ['failed'];
@@ -244,7 +245,7 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
                         stateJobTypes.push('completed');
                         break;
                     case 'RETRYING':
-                        stateJobTypes.push('repeat');
+                        stateJobTypes.push('delayed');
                         break;
                     case 'FAILED':
                         stateJobTypes.push('failed');
@@ -263,20 +264,21 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
             jobTypes =
                 settledFilter.eq === true
                     ? ['completed', 'failed']
-                    : ['wait', 'waiting-children', 'active', 'repeat', 'delayed', 'paused', 'prioritized'];
+                    : ['wait', 'waiting-children', 'active', 'delayed', 'paused', 'prioritized'];
         }
 
         let items: Bull.Job[] = [];
         let totalItems = 0;
 
         const queueNameFilter = flatFilter.queueName;
-        const queueName = queueNameFilter?.eq ?? queueNameFilter?.in?.[0] ?? '';
+        const queueNames = queueNameFilter?.eq ? [queueNameFilter.eq] : (queueNameFilter?.in ?? []);
 
         try {
             const [total, jobIds] = await this.callCustomScript(getJobsByType, [
                 skip,
                 take,
-                queueName,
+                queueNames.length,
+                ...queueNames,
                 ...jobTypes,
             ]);
             items = (

--- a/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
+++ b/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
@@ -204,6 +204,29 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
         }
     }
 
+    /**
+     * Maps a Vendure JobState to the BullMQ job types which hold jobs in that state.
+     * Jobs awaiting a retry after failure are stored in the 'delayed' state, and
+     * cancelled jobs are stored as 'failed'.
+     */
+    private jobStateToJobTypes(state: string): JobType[] {
+        switch (state) {
+            case 'PENDING':
+                return ['wait', 'waiting-children', 'prioritized'];
+            case 'RUNNING':
+                return ['active'];
+            case 'COMPLETED':
+                return ['completed'];
+            case 'RETRYING':
+                return ['delayed'];
+            case 'FAILED':
+            case 'CANCELLED':
+                return ['failed'];
+            default:
+                return [];
+        }
+    }
+
     async findMany(options?: JobListOptions): Promise<PaginatedList<Job>> {
         const skip = options?.skip ?? 0;
         const take = options?.take ?? 10;
@@ -213,52 +236,13 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
 
         const stateFilter = flatFilter.state;
         if (stateFilter?.eq) {
-            switch (stateFilter.eq) {
-                case 'PENDING':
-                    jobTypes = ['wait', 'waiting-children', 'prioritized'];
-                    break;
-                case 'RUNNING':
-                    jobTypes = ['active'];
-                    break;
-                case 'COMPLETED':
-                    jobTypes = ['completed'];
-                    break;
-                case 'RETRYING':
-                    // Jobs awaiting a retry after failure are stored in the 'delayed' state
-                    jobTypes = ['delayed'];
-                    break;
-                case 'FAILED':
-                    jobTypes = ['failed'];
-                    break;
-                case 'CANCELLED':
-                    jobTypes = ['failed'];
-                    break;
+            const mapped = this.jobStateToJobTypes(stateFilter.eq);
+            if (mapped.length) {
+                jobTypes = mapped;
             }
         }
         if (stateFilter?.in?.length) {
-            const stateJobTypes: JobType[] = [];
-            for (const state of stateFilter.in) {
-                switch (state) {
-                    case 'PENDING':
-                        stateJobTypes.push('wait', 'waiting-children', 'prioritized');
-                        break;
-                    case 'RUNNING':
-                        stateJobTypes.push('active');
-                        break;
-                    case 'COMPLETED':
-                        stateJobTypes.push('completed');
-                        break;
-                    case 'RETRYING':
-                        stateJobTypes.push('delayed');
-                        break;
-                    case 'FAILED':
-                        stateJobTypes.push('failed');
-                        break;
-                    case 'CANCELLED':
-                        stateJobTypes.push('failed');
-                        break;
-                }
-            }
+            const stateJobTypes = stateFilter.in.flatMap(state => this.jobStateToJobTypes(state));
             if (stateJobTypes.length) {
                 jobTypes = [...new Set(stateJobTypes)];
             }

--- a/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
+++ b/packages/job-queue-plugin/src/bullmq/bullmq-job-queue-strategy.ts
@@ -162,7 +162,11 @@ export class BullMQJobQueueStrategy implements InspectableJobQueueStrategy {
 
     async destroy() {
         const workerClosePromises = Array.from(this.workers.values()).map(w => w.close());
-        await Promise.all([this.queue.close(), ...workerClosePromises]);
+        await Promise.all([
+            this.queue.close(),
+            this.jobListIndexService?.close(),
+            ...workerClosePromises,
+        ]);
     }
 
     async add<Data extends JobData<Data> = object>(job: Job<Data>): Promise<Job<Data>> {

--- a/packages/job-queue-plugin/src/bullmq/constants.ts
+++ b/packages/job-queue-plugin/src/bullmq/constants.ts
@@ -5,11 +5,12 @@ export const BULLMQ_PLUGIN_OPTIONS = Symbol('BULLMQ_PLUGIN_OPTIONS');
 export const QUEUE_NAME = 'vendure-job-queue';
 export const DEFAULT_CONCURRENCY = 3;
 
+// Note: 'repeat' is deliberately not included, since the `repeat` key holds
+// repeatable-job configuration entries rather than job ids.
 export const ALL_JOB_TYPES: JobType[] = [
     'completed',
     'failed',
     'delayed',
-    'repeat',
     'waiting-children',
     'active',
     'wait',

--- a/packages/job-queue-plugin/src/bullmq/job-list-index.service.ts
+++ b/packages/job-queue-plugin/src/bullmq/job-list-index.service.ts
@@ -138,15 +138,15 @@ export class JobListIndexService {
             // Atomically move the job to the target state index, and record the
             // queue name so that removeJobFromAllIndices() can find the indexed
             // sets without needing the (possibly deleted) job data.
-            const pipeline = this.redis.pipeline();
-            pipeline.sadd(this.createRegistryKey(), job.name);
+            const multi = this.redis.multi();
+            multi.sadd(this.createRegistryKey(), job.name);
             for (const otherState of this.allStates) {
                 if (otherState !== state) {
-                    pipeline.zrem(this.createSortedSetKey(job.name, otherState), jobId);
+                    multi.zrem(this.createSortedSetKey(job.name, otherState), jobId);
                 }
             }
-            pipeline.zadd(targetKey, job.timestamp, jobId);
-            await pipeline.exec();
+            multi.zadd(targetKey, job.timestamp, jobId);
+            await multi.exec();
             Logger.debug(`Added job ${jobId} to indexed key: ${targetKey}`, loggerCtx);
         } catch (err: unknown) {
             const error = err as Error;
@@ -166,15 +166,15 @@ export class JobListIndexService {
         try {
             const queueNames = await this.redis.smembers(this.createRegistryKey());
             if (queueNames.length === 0) return;
-            const pipeline = this.redis.pipeline();
+            const multi = this.redis.multi();
 
             for (const queueName of queueNames) {
                 for (const state of this.allStates) {
-                    pipeline.zrem(this.createSortedSetKey(queueName, state), jobId);
+                    multi.zrem(this.createSortedSetKey(queueName, state), jobId);
                 }
             }
 
-            await pipeline.exec();
+            await multi.exec();
         } catch (err: unknown) {
             const error = err as Error;
             Logger.error(`Failed to remove job from indices: ${error.message}`, loggerCtx);
@@ -231,28 +231,28 @@ export class JobListIndexService {
                         jobsByQueue.get(job.name)?.push(job);
                     }
 
-                    // Create sorted sets for each queue in this state
+                    // Merge each queue's jobs into its indexed set. The zadds are
+                    // idempotent (same score for the same member), so this also picks
+                    // up jobs which were added while no worker was listening for
+                    // queue events, without disturbing existing entries.
                     for (const [queueName, queueJobs] of jobsByQueue) {
                         await this.redis.sadd(this.createRegistryKey(), queueName);
                         const indexedKey = this.createSortedSetKey(queueName, state);
-                        const exists = await this.redis.exists(indexedKey);
-                        if (exists === 0) {
-                            Logger.info(
-                                `Creating indexed set for queue: ${queueName} in state: ${state}`,
-                                loggerCtx,
-                            );
-                            const pipeline = this.redis.pipeline();
-                            // Add jobs in batches
-                            for (let i = 0; i < queueJobs.length; i += this.BATCH_SIZE) {
-                                const batch = queueJobs.slice(i, i + this.BATCH_SIZE);
-                                const args = batch
-                                    .flatMap(job => [job.timestamp, job.id])
-                                    .filter((id): id is string | number => id != null);
-                                pipeline.zadd(indexedKey, ...args);
-                            }
-                            await pipeline.exec();
-                            totalMigrated += queueJobs.length;
+                        Logger.debug(
+                            `Merging ${queueJobs.length} jobs into indexed set for queue: ${queueName} in state: ${state}`,
+                            loggerCtx,
+                        );
+                        const pipeline = this.redis.pipeline();
+                        // Add jobs in batches
+                        for (let i = 0; i < queueJobs.length; i += this.BATCH_SIZE) {
+                            const batch = queueJobs.slice(i, i + this.BATCH_SIZE);
+                            const args = batch
+                                .flatMap(job => [job.timestamp, job.id])
+                                .filter((id): id is string | number => id != null);
+                            pipeline.zadd(indexedKey, ...args);
                         }
+                        await pipeline.exec();
+                        totalMigrated += queueJobs.length;
                     }
                 } catch (err: unknown) {
                     const error = err as Error;
@@ -367,8 +367,9 @@ export class JobListIndexService {
 
     /**
      * The registry is a Redis set holding all Vendure queue names which have been
-     * indexed, allowing removal of a job id from all indexed sets even when the
-     * job data (and with it the queue name) is no longer available.
+     * indexed. It allows removal of a job id from all indexed sets even when the
+     * job data (and with it the queue name) is no longer available, and lets the
+     * getJobsByType script enumerate every indexed set for unfiltered queries.
      */
     private createRegistryKey(): string {
         const prefix = getPrefix(this.options);

--- a/packages/job-queue-plugin/src/bullmq/job-list-index.service.ts
+++ b/packages/job-queue-plugin/src/bullmq/job-list-index.service.ts
@@ -29,6 +29,7 @@ export class JobListIndexService {
     private redis: Redis | Cluster;
     private queue: Queue | undefined;
     private queueEvents: QueueEvents | undefined;
+    private readonly indexOperationChains = new Map<string, Promise<void>>();
     private allStates: JobType[] = [
         'wait',
         'active',
@@ -52,9 +53,20 @@ export class JobListIndexService {
     register(redisConnection: Redis | Cluster, queue: Queue) {
         this.redis = redisConnection;
         this.queue = queue;
-        this.queueEvents = new QueueEvents(queue.name, { connection: redisConnection });
+        this.queueEvents = new QueueEvents(queue.name, {
+            connection: redisConnection,
+            prefix: getPrefix(this.options),
+        });
         this.setupEventListeners();
         void this.migrateExistingJobs();
+    }
+
+    /**
+     * @description
+     * Closes the QueueEvents connection. Should be called when the strategy is destroyed.
+     */
+    async close() {
+        await this.queueEvents?.close();
     }
 
     private setupEventListeners() {
@@ -63,36 +75,51 @@ export class JobListIndexService {
 
         // When a job is added to the queue
         this.queueEvents.on('waiting', ({ jobId }) => {
-            void this.updateJobIndex(jobId, 'wait');
+            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'wait'));
         });
 
         this.queueEvents.on('waiting-children', ({ jobId }) => {
-            void this.updateJobIndex(jobId, 'waiting-children');
+            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'waiting-children'));
         });
 
         // When a job starts processing
         this.queueEvents.on('active', ({ jobId }) => {
-            void this.updateJobIndex(jobId, 'active');
+            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'active'));
         });
 
         // When a job completes successfully
         this.queueEvents.on('completed', ({ jobId }) => {
-            void this.updateJobIndex(jobId, 'completed');
+            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'completed'));
         });
 
         // When a job fails
         this.queueEvents.on('failed', ({ jobId }) => {
-            void this.updateJobIndex(jobId, 'failed');
+            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'failed'));
         });
 
         // When a job is delayed
         this.queueEvents.on('delayed', ({ jobId }) => {
-            void this.updateJobIndex(jobId, 'delayed');
+            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'delayed'));
         });
 
         // When a job is removed
         this.queueEvents.on('removed', ({ jobId }) => {
-            void this.removeJobFromAllIndices(jobId);
+            this.enqueueIndexOperation(jobId, () => this.removeJobFromAllIndices(jobId));
+        });
+    }
+
+    /**
+     * The event handlers fire in event-stream order but run asynchronously, so two
+     * updates for the same job could otherwise interleave and leave the job indexed
+     * under a stale state. Chaining the operations per job id preserves the order.
+     */
+    private enqueueIndexOperation(jobId: string, operation: () => Promise<void>) {
+        const chain = (this.indexOperationChains.get(jobId) ?? Promise.resolve()).then(operation);
+        this.indexOperationChains.set(jobId, chain);
+        void chain.finally(() => {
+            if (this.indexOperationChains.get(jobId) === chain) {
+                this.indexOperationChains.delete(jobId);
+            }
         });
     }
 
@@ -106,34 +133,45 @@ export class JobListIndexService {
         try {
             const job: Job | undefined = await this.queue.getJob(jobId);
             if (!job) return;
-            const timestamp = job.timestamp;
             const targetKey = this.createSortedSetKey(job.name, state);
 
-            // Remove from all state indices first
-            await this.removeJobFromAllIndices(jobId);
-
-            // Add to the specific state index
-            const result = await this.redis.zadd(targetKey, timestamp, jobId);
-            if (result === 1) {
-                Logger.debug(`Added job ${jobId} to indexed key: ${targetKey}`, loggerCtx);
+            // Atomically move the job to the target state index, and record the
+            // queue name so that removeJobFromAllIndices() can find the indexed
+            // sets without needing the (possibly deleted) job data.
+            const pipeline = this.redis.pipeline();
+            pipeline.sadd(this.createRegistryKey(), job.name);
+            for (const otherState of this.allStates) {
+                if (otherState !== state) {
+                    pipeline.zrem(this.createSortedSetKey(job.name, otherState), jobId);
+                }
             }
+            pipeline.zadd(targetKey, job.timestamp, jobId);
+            await pipeline.exec();
+            Logger.debug(`Added job ${jobId} to indexed key: ${targetKey}`, loggerCtx);
         } catch (err: unknown) {
             const error = err as Error;
             Logger.error(`Failed to update job index: ${error.message}`, loggerCtx);
         }
     }
 
+    /**
+     * By the time the 'removed' event is handled, the job data has already been
+     * deleted from Redis, so the queue name cannot be looked up from the job.
+     * Instead, the registry of known queue names is used to clear the id from
+     * every indexed set it could be in.
+     */
     private async removeJobFromAllIndices(jobId: string) {
         if (!this.redis || !this.queue) return;
 
         try {
-            const job: Job | undefined = await this.queue.getJob(jobId);
-            if (!job) return;
+            const queueNames = await this.redis.smembers(this.createRegistryKey());
+            if (queueNames.length === 0) return;
             const pipeline = this.redis.pipeline();
 
-            for (const state of this.allStates) {
-                const indexedKey = this.createSortedSetKey(job.name, state);
-                pipeline.zrem(indexedKey, jobId);
+            for (const queueName of queueNames) {
+                for (const state of this.allStates) {
+                    pipeline.zrem(this.createSortedSetKey(queueName, state), jobId);
+                }
             }
 
             await pipeline.exec();
@@ -195,6 +233,7 @@ export class JobListIndexService {
 
                     // Create sorted sets for each queue in this state
                     for (const [queueName, queueJobs] of jobsByQueue) {
+                        await this.redis.sadd(this.createRegistryKey(), queueName);
                         const indexedKey = this.createSortedSetKey(queueName, state);
                         const exists = await this.redis.exists(indexedKey);
                         if (exists === 0) {
@@ -324,5 +363,18 @@ export class JobListIndexService {
             throw new Error('Queue is not initialized');
         }
         return `${prefix}:${this.queue.name}:${jobId}`;
+    }
+
+    /**
+     * The registry is a Redis set holding all Vendure queue names which have been
+     * indexed, allowing removal of a job id from all indexed sets even when the
+     * job data (and with it the queue name) is no longer available.
+     */
+    private createRegistryKey(): string {
+        const prefix = getPrefix(this.options);
+        if (!this.queue) {
+            throw new Error('Queue is not initialized');
+        }
+        return `${prefix}:${this.queue.name}:queue-names`;
     }
 }

--- a/packages/job-queue-plugin/src/bullmq/job-list-index.service.ts
+++ b/packages/job-queue-plugin/src/bullmq/job-list-index.service.ts
@@ -73,38 +73,28 @@ export class JobListIndexService {
         if (this.processContext.isServer) return;
         if (!this.queueEvents || !this.queue) return;
 
-        // When a job is added to the queue
-        this.queueEvents.on('waiting', ({ jobId }) => {
-            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'wait'));
-        });
-
-        this.queueEvents.on('waiting-children', ({ jobId }) => {
-            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'waiting-children'));
-        });
-
-        // When a job starts processing
-        this.queueEvents.on('active', ({ jobId }) => {
-            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'active'));
-        });
-
-        // When a job completes successfully
-        this.queueEvents.on('completed', ({ jobId }) => {
-            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'completed'));
-        });
-
-        // When a job fails
-        this.queueEvents.on('failed', ({ jobId }) => {
-            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'failed'));
-        });
-
-        // When a job is delayed
-        this.queueEvents.on('delayed', ({ jobId }) => {
-            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, 'delayed'));
-        });
+        this.indexOnEvent('waiting', 'wait');
+        this.indexOnEvent('waiting-children', 'waiting-children');
+        this.indexOnEvent('active', 'active');
+        this.indexOnEvent('completed', 'completed');
+        this.indexOnEvent('failed', 'failed');
+        this.indexOnEvent('delayed', 'delayed');
 
         // When a job is removed
         this.queueEvents.on('removed', ({ jobId }) => {
             this.enqueueIndexOperation(jobId, () => this.removeJobFromAllIndices(jobId));
+        });
+    }
+
+    /**
+     * Registers a QueueEvents listener which re-indexes the job under the given state.
+     */
+    private indexOnEvent(
+        event: 'waiting' | 'waiting-children' | 'active' | 'completed' | 'failed' | 'delayed',
+        state: JobType,
+    ) {
+        this.queueEvents?.on(event, ({ jobId }: { jobId: string }) => {
+            this.enqueueIndexOperation(jobId, () => this.updateJobIndex(jobId, state));
         });
     }
 

--- a/packages/job-queue-plugin/src/bullmq/scripts/get-jobs-by-type.ts
+++ b/packages/job-queue-plugin/src/bullmq/scripts/get-jobs-by-type.ts
@@ -14,10 +14,18 @@ const script = `--[[
     Output:
       { totalCount, { id1, id2, ... } }
 
-  The script is read-only: since Redis scripts execute atomically, candidates from
-  each state structure are merged and sorted in Lua memory rather than in temporary
-  Redis keys. Only the first (skip + take) entries of each structure are fetched, so
-  the cost is bounded by the page depth, not the queue length.
+  The query reads the indexed sorted sets maintained by the JobListIndexService
+  (one per queue name and state, uniformly scored by creation timestamp) rather
+  than BullMQ's native state structures. The native structures order by finish
+  time, encoded delay or priority depending on the state, so selecting the top
+  (skip + take) entries from them could cut a job from the page before a
+  creation-time sort ever saw it. When no queue names are given, the registry of
+  known queue names is used so that every indexed set is consulted.
+
+  The script is read-only: since Redis scripts execute atomically, candidates are
+  merged and sorted in Lua memory rather than in temporary Redis keys. Only the
+  first (skip + take) entries of each set are fetched, so the cost is bounded by
+  the page depth, not the queue length.
 ]]
 local rcall = redis.call
 local prefix = KEYS[1]
@@ -33,65 +41,30 @@ for i = 4 + numNames, #ARGV do
     table.insert(states, ARGV[i])
 end
 
+if numNames == 0 then
+    -- No explicit filter: consult the indexed sets of every known queue name
+    names = rcall('SMEMBERS', prefix .. 'queue-names')
+end
+
 local needed = skip + take
 local total = 0
 local candidates = {}
 local seen = {}
 
-local function addCandidate(id, timestamp)
-    if not seen[id] then
-        seen[id] = true
-        table.insert(candidates, { id = id, ts = timestamp })
-    end
-end
-
--- Reads the creation timestamp from the job's data hash. Returns nil for ids whose
--- job no longer exists (e.g. entries not yet cleaned from an indexed set).
-local function getJobTimestamp(id)
-    local ts = rcall('HGET', prefix .. id, 'timestamp')
-    if ts then
-        return tonumber(ts)
-    end
-    return nil
-end
-
-if numNames > 0 then
-    -- Name-filtered path: read the indexed sorted sets maintained by the
-    -- JobListIndexService, which are uniformly scored by creation timestamp.
-    for _, name in ipairs(names) do
-        for _, state in ipairs(states) do
-            local key = prefix .. 'queue:' .. name .. ':' .. state
-            if rcall('TYPE', key).ok == 'zset' then
-                total = total + rcall('ZCARD', key)
+for _, name in ipairs(names) do
+    for _, state in ipairs(states) do
+        local key = prefix .. 'queue:' .. name .. ':' .. state
+        if rcall('TYPE', key).ok == 'zset' then
+            total = total + rcall('ZCARD', key)
+            -- Guard against needed <= 0: a range end of -1 would fetch the whole set
+            if needed > 0 then
                 local elements = rcall('ZREVRANGE', key, 0, needed - 1, 'WITHSCORES')
                 for i = 1, #elements, 2 do
-                    addCandidate(elements[i], tonumber(elements[i + 1]))
-                end
-            end
-        end
-    end
-else
-    -- Unfiltered path: read BullMQ's native state structures. Their sorted-set
-    -- scores are not comparable across states (finish time vs. encoded delay
-    -- vs. priority), so each candidate's creation timestamp is read from its
-    -- job hash to give a single consistent ordering.
-    for _, state in ipairs(states) do
-        local key = prefix .. state
-        local keyType = rcall('TYPE', key).ok
-        local elements = nil
-        if keyType == 'zset' then
-            total = total + rcall('ZCARD', key)
-            elements = rcall('ZREVRANGE', key, 0, needed - 1)
-        elseif keyType == 'list' then
-            total = total + rcall('LLEN', key)
-            -- Lists hold the newest id at the head
-            elements = rcall('LRANGE', key, 0, needed - 1)
-        end
-        if elements then
-            for _, id in ipairs(elements) do
-                local ts = getJobTimestamp(id)
-                if ts then
-                    addCandidate(id, ts)
+                    local id = elements[i]
+                    if not seen[id] then
+                        seen[id] = true
+                        table.insert(candidates, { id = id, ts = tonumber(elements[i + 1]) })
+                    end
                 end
             end
         end
@@ -121,7 +94,7 @@ return { total, results }
 
 export const getJobsByType: CustomScriptDefinition<
     [totalItems: number, jobIds: string[]],
-    Array<string | number>
+    [skip: number, take: number, numQueueNames: number, ...namesAndStates: string[]]
 > = {
     script,
     numberOfKeys: 1,

--- a/packages/job-queue-plugin/src/bullmq/scripts/get-jobs-by-type.ts
+++ b/packages/job-queue-plugin/src/bullmq/scripts/get-jobs-by-type.ts
@@ -2,189 +2,126 @@ import { CustomScriptDefinition } from '../types';
 
 // language=Lua
 const script = `--[[
-  Get job ids per provided states and filter by name - Optimized version using indexed structure
+  Get a page of job ids for the given states, ordered newest-first by creation time,
+  optionally filtered by one or more queue names.
     Input:
-      KEYS[1]    'prefix'
-      ARGV[1]    skip
-      ARGV[2]    take
-      ARGV[3]    filterName
-      ARGV[4...] types
+      KEYS[1]         key prefix (e.g. "bull:vendure-job-queue:")
+      ARGV[1]         skip
+      ARGV[2]         take
+      ARGV[3]         number of queue-name filters (N)
+      ARGV[4..3+N]    queue names
+      ARGV[4+N..]     job states/types
+    Output:
+      { totalCount, { id1, id2, ... } }
+
+  The script is read-only: since Redis scripts execute atomically, candidates from
+  each state structure are merged and sorted in Lua memory rather than in temporary
+  Redis keys. Only the first (skip + take) entries of each structure are fetched, so
+  the cost is bounded by the page depth, not the queue length.
 ]]
 local rcall = redis.call
 local prefix = KEYS[1]
 local skip = tonumber(ARGV[1])
 local take = tonumber(ARGV[2])
-local filterName = ARGV[3]
-local results = {}
-local totalResults = 0
-
--- redis.log(redis.LOG_NOTICE, 'Filter name: "' .. filterName .. '"')
--- redis.log(redis.LOG_NOTICE, 'Filter name length: ' .. tostring(#filterName))
--- redis.log(redis.LOG_NOTICE, 'Number of ARGV: ' .. tostring(#ARGV))
--- redis.log(redis.LOG_NOTICE, 'skip: "' .. tostring(skip) .. '"')
--- redis.log(redis.LOG_NOTICE, 'take: "' .. tostring(take) .. '"')
-
--- Create a temporary key for merging results
-local tempKey = prefix .. 'temp:merge:' .. math.random(1000000)
-local sourceKeys = {}
-local listKeys = {}
-
--- Function to count jobs in a sorted set
-local function countJobsInSortedSet(key)
-    return rcall('ZCARD', key) or 0
+local numNames = tonumber(ARGV[3])
+local names = {}
+for i = 4, 3 + numNames do
+    table.insert(names, ARGV[i])
+end
+local states = {}
+for i = 4 + numNames, #ARGV do
+    table.insert(states, ARGV[i])
 end
 
--- Function to count jobs in a list
-local function countJobsInList(key)
-    return rcall('LLEN', key) or 0
+local needed = skip + take
+local total = 0
+local candidates = {}
+local seen = {}
+
+local function addCandidate(id, timestamp)
+    if not seen[id] then
+        seen[id] = true
+        table.insert(candidates, { id = id, ts = timestamp })
+    end
 end
 
--- First count total jobs and collect source keys
-if filterName ~= "" then
-    -- When filtering by name, we need to check each state
-    for i = 4, #ARGV do
-        local state = ARGV[i]
-        -- redis.log(redis.LOG_NOTICE, 'Processing state: "' .. state .. '"')
-        local indexedKey = prefix .. 'queue:' .. filterName .. ':' .. state
-        -- redis.log(redis.LOG_NOTICE, 'Looking for key: ' .. indexedKey)
-        local keyType = rcall('TYPE', indexedKey).ok
-        -- redis.log(redis.LOG_NOTICE, 'Key type: ' .. keyType)
+-- Reads the creation timestamp from the job's data hash. Returns nil for ids whose
+-- job no longer exists (e.g. entries not yet cleaned from an indexed set).
+local function getJobTimestamp(id)
+    local ts = rcall('HGET', prefix .. id, 'timestamp')
+    if ts then
+        return tonumber(ts)
+    end
+    return nil
+end
 
-        if keyType == 'zset' then
-            totalResults = totalResults + countJobsInSortedSet(indexedKey)
-            table.insert(sourceKeys, indexedKey)
-        elseif keyType == 'list' then
-            totalResults = totalResults + countJobsInList(indexedKey)
-            table.insert(listKeys, indexedKey)
+if numNames > 0 then
+    -- Name-filtered path: read the indexed sorted sets maintained by the
+    -- JobListIndexService, which are uniformly scored by creation timestamp.
+    for _, name in ipairs(names) do
+        for _, state in ipairs(states) do
+            local key = prefix .. 'queue:' .. name .. ':' .. state
+            if rcall('TYPE', key).ok == 'zset' then
+                total = total + rcall('ZCARD', key)
+                local elements = rcall('ZREVRANGE', key, 0, needed - 1, 'WITHSCORES')
+                for i = 1, #elements, 2 do
+                    addCandidate(elements[i], tonumber(elements[i + 1]))
+                end
+            end
         end
     end
 else
-    -- No filter, count all types
-    for i = 4, #ARGV do
-        local state = ARGV[i]
-        -- redis.log(redis.LOG_NOTICE, 'Processing state: "' .. state .. '"')
+    -- Unfiltered path: read BullMQ's native state structures. Their sorted-set
+    -- scores are not comparable across states (finish time vs. encoded delay
+    -- vs. priority), so each candidate's creation timestamp is read from its
+    -- job hash to give a single consistent ordering.
+    for _, state in ipairs(states) do
         local key = prefix .. state
-        -- redis.log(redis.LOG_NOTICE, 'Looking for key: ' .. key)
         local keyType = rcall('TYPE', key).ok
-        -- redis.log(redis.LOG_NOTICE, 'Key type: ' .. keyType)
-
+        local elements = nil
         if keyType == 'zset' then
-            totalResults = totalResults + countJobsInSortedSet(key)
-            table.insert(sourceKeys, key)
+            total = total + rcall('ZCARD', key)
+            elements = rcall('ZREVRANGE', key, 0, needed - 1)
         elseif keyType == 'list' then
-            totalResults = totalResults + countJobsInList(key)
-            table.insert(listKeys, key)
-            -- redis.log(redis.LOG_NOTICE, 'total jobs in list: ' .. totalResults)
+            total = total + rcall('LLEN', key)
+            -- Lists hold the newest id at the head
+            elements = rcall('LRANGE', key, 0, needed - 1)
         end
-    end
-end
-
--- If we have any sorted sets to merge, do it
-if #sourceKeys > 0 then
-    -- Calculate how many elements we need to merge
-    local neededElements = skip + take
-    -- redis.log(redis.LOG_NOTICE, 'Number of source keys: ' .. tostring(#sourceKeys))
-    -- redis.log(redis.LOG_NOTICE, 'Needed elements: ' .. tostring(neededElements))
-
-    -- Create temporary keys for each source set with limited elements
-    local limitedKeys = {}
-    for i, sourceKey in ipairs(sourceKeys) do
-        local limitedKey = tempKey .. ':limited:' .. i
-        -- redis.log(redis.LOG_NOTICE, 'Processing source key: ' .. sourceKey)
-        -- Get only the elements we need from each source set
-        local elements = rcall('ZREVRANGE', sourceKey, 0, neededElements - 1, 'WITHSCORES')
-        -- redis.log(redis.LOG_NOTICE, 'Found ' .. tostring(#elements) .. ' elements in ' .. sourceKey)
-        if #elements > 0 then
-            -- Process elements in pairs (member, score)
-            local chunkSize = 1000 -- Process in chunks of 1000 elements
-            for j = 1, #elements, chunkSize * 2 do
-                local chunkEnd = math.min(j + chunkSize * 2 - 1, #elements)
-                local chunkArgs = {}
-                for k = j, chunkEnd, 2 do
-                    local member = elements[k]
-                    local score = elements[k + 1]
-                    table.insert(chunkArgs, score)
-                    table.insert(chunkArgs, member)
-                end
-                if #chunkArgs > 0 then
-                    rcall('ZADD', limitedKey, unpack(chunkArgs))
+        if elements then
+            for _, id in ipairs(elements) do
+                local ts = getJobTimestamp(id)
+                if ts then
+                    addCandidate(id, ts)
                 end
             end
-            table.insert(limitedKeys, limitedKey)
-            -- redis.log(redis.LOG_NOTICE, 'Added to limited key: ' .. limitedKey)
         end
-    end
-
-    -- redis.log(redis.LOG_NOTICE, 'Number of limited keys: ' .. tostring(#limitedKeys))
-
-    if #limitedKeys > 0 then
-        -- Merge the limited sets
-        rcall('ZUNIONSTORE', tempKey, #limitedKeys, unpack(limitedKeys))
-        -- redis.log(redis.LOG_NOTICE, 'Merged sets into: ' .. tempKey)
-
-        -- Get the paginated results from the merged set
-        results = rcall('ZREVRANGE', tempKey, skip, skip + take - 1)
-        -- redis.log(redis.LOG_NOTICE, 'Got ' .. tostring(#results) .. ' results from merged set')
-
-        -- Clean up temporary limited keys
-        for _, key in ipairs(limitedKeys) do
-            rcall('DEL', key)
-        end
-    else
-        -- redis.log(redis.LOG_NOTICE, 'No elements found in any source sets')
     end
 end
 
--- Handle list keys separately
-if #listKeys > 0 then
-    -- Create a temporary list to merge all list keys
-    local tempListKey = tempKey .. ':list'
-
-    -- Merge all list keys into the temporary list
-    for _, listKey in ipairs(listKeys) do
-        local listElements = rcall('LRANGE', listKey, 0, -1)
-        if #listElements > 0 then
-            rcall('RPUSH', tempListKey, unpack(listElements))
+table.sort(candidates, function(a, b)
+    if a.ts == b.ts then
+        -- Stable tie-break on the (numeric where possible) job id
+        local aNum = tonumber(a.id)
+        local bNum = tonumber(b.id)
+        if aNum and bNum then
+            return aNum > bNum
         end
+        return tostring(a.id) > tostring(b.id)
     end
+    return a.ts > b.ts
+end)
 
-    -- Get the total number of elements in the merged list
-    local totalListElements = rcall('LLEN', tempListKey)
-
-    if totalListElements > 0 then
-        -- If we already have results from sorted sets, we need to merge them
-        if #results > 0 then
-            -- Convert the merged sorted set results to a temporary list
-            local tempSortedListKey = tempKey .. ':sorted'
-            for _, jobId in ipairs(results) do
-                rcall('RPUSH', tempSortedListKey, jobId)
-            end
-
-            -- Merge the sorted results with list results
-            local sortedElements = rcall('LRANGE', tempSortedListKey, 0, -1)
-            rcall('RPUSH', tempListKey, unpack(sortedElements))
-
-            -- Clean up temporary sorted list
-            rcall('DEL', tempSortedListKey)
-        end
-
-        -- Get the final paginated results from the merged list
-        results = rcall('LRANGE', tempListKey, skip, skip + take - 1)
-
-        -- Clean up temporary list
-        rcall('DEL', tempListKey)
-    end
+local results = {}
+for i = skip + 1, math.min(skip + take, #candidates) do
+    table.insert(results, candidates[i].id)
 end
 
--- Clean up temporary key
-rcall('DEL', tempKey)
-
-return {totalResults, results}
+return { total, results }
 `;
 
 export const getJobsByType: CustomScriptDefinition<
     [totalItems: number, jobIds: string[]],
-    [skip: number, take: number, queueName: string | undefined, ...states: string[]]
+    Array<string | number>
 > = {
     script,
     numberOfKeys: 1,


### PR DESCRIPTION
## Description

The `jobs` list query in the BullMQ job queue plugin had several defects, mostly in the `getJobsByType` Lua script and the `JobListIndexService` which maintains the indexed sorted sets that the script reads.

### Defects fixed

**In the Lua script / query path:**

- **Jobs were silently dropped from pages.** When the result set spanned both list-stored states (`wait`, `active`, `paused`) and sorted-set-stored states (`completed`, `failed`, etc.) — which is always the case for the unfiltered admin UI view — the `skip` offset was applied twice. In a test with 5 waiting and 30 completed jobs, paging with `take: 10` returned pages of 10, 5, 0 and 0 items, leaving 20 of the 35 jobs unreachable through the API.
- **Ordering was inconsistent.** List-stored jobs were always emitted before sorted-set-stored jobs regardless of creation time, and the raw scores of the `delayed` set (which BullMQ encodes as `timestamp * 4096 + n`) were merged with plain timestamps, so delayed jobs always sorted above everything else.
- **The query crashed on busy queues.** The script passed the entire wait list through Lua's `unpack()`, which is limited to roughly 8000 arguments, so the jobs list errored with `too many results to unpack` exactly when the queue backlog was largest.
- **Repeatable-job configs were counted as jobs.** `ALL_JOB_TYPES` included `'repeat'`, whose Redis key holds repeatable-job configuration entries rather than job ids, inflating `totalItems`.
- **Filtering by `RETRYING` returned nothing.** The filter mapped to the `'repeat'` job type, while jobs awaiting a retry actually live in the `'delayed'` state (which is also how the single-job query reports them).
- **Filtering by multiple queue names used only the first name.** `queueName: { in: [a, b] }` silently dropped every name after the first.

**In the index maintenance:**

- **The index was never updated when a custom Redis prefix was configured.** The `QueueEvents` instance was created without the `prefix` option, so it listened on the default `bull`-prefixed events stream which the queue never writes to. The index was built once at worker startup by the migration and then never updated again.
- **Removed jobs left stale index entries.** By the time the `removed` event is handled, the job data has already been deleted, so the handler's job lookup failed and it returned without removing anything. This made `totalItems` keep counting removed jobs.
- **State transitions could race.** The event handlers ran concurrently and the remove-then-add sequence was not atomic, so a fast `active` → `completed` transition could leave a job indexed under a stale state.

### Approach

- The Lua script is rewritten to be read-only. Since Redis scripts execute atomically, candidates are merged and sorted in Lua memory instead of in temporary Redis keys (the old script performed `ZADD`/`ZUNIONSTORE`/`DEL` writes on every poll of the jobs list). Only the first `skip + take` entries of each state structure are fetched, so cost is bounded by page depth rather than queue length. Creation timestamps are read from the job hashes to give one consistent newest-first ordering across structures whose native scores are not comparable.
- The `JobListIndexService` now passes the configured prefix to `QueueEvents`, performs each index update as a single atomic pipeline, serialises operations per job id to preserve event order, and maintains a small registry set of known queue names so that a removed job's id can be cleared from all indexed sets even though the job data is gone. The `QueueEvents` connection is now also closed when the strategy is destroyed.

### Tests

Two new e2e spec files demonstrate the defects (all of these failed before the fix commits and pass after):

- `get-jobs-by-type-script.e2e-spec.ts` runs the Lua script directly against Redis with data seeded in exactly the layout BullMQ and the index service use, covering pagination completeness, ordering, the delayed-score problem, repeat-config counting and the 9000-job `unpack` crash.
- `job-list.e2e-spec.ts` exercises the full stack through the GraphQL admin API with jobs held in a stable mixture of states (completed, retrying, running, queued behind a blocked worker), covering state mapping, ordering, pagination, the `RETRYING` filter, multi-queue-name filtering, index updates under a custom prefix, and total consistency after job removal.

The stale `e2e-wip` npm script (which pointed at a no-longer-existing jest config) is replaced with a working `e2e` script following the same pattern as the other packages. The tests skip themselves when no Redis instance is available, as before.

### Breaking changes

None. The Lua script's argument layout changed, but it is an internal detail between the strategy and the script it defines.

### Known limitations (unchanged by this PR)

- The script accesses multiple keys derived from a prefix passed via `KEYS[1]`, so it is still not Redis Cluster-safe, though it is now at least read-only.
- The `sort` parameter of `JobListOptions` is still ignored; the list is always ordered newest-first by creation time.
- `findMany` still performs per-job lookups for the returned page; returning states from the script could halve those round trips in a future change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5014"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787315051&installation_model_id=20193&pr_number=5014&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5014&signature=09d95b4c64a36b679e06e39a7d1c0fefee74a777d84f80f9665f25d9e03cf0aa"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->