### PR TITLE
fix(core): Add channel-scope guard to StockLocation & Asset update()

### DIFF
--- a/packages/core/e2e/asset-channel.e2e-spec.ts
+++ b/packages/core/e2e/asset-channel.e2e-spec.ts
@@ -16,6 +16,7 @@ import {
     deleteAssetDocument,
     getAssetDocument,
     getProductWithVariantsDocument,
+    updateAssetDocument,
     updateCollectionDocument,
     updateProductDocument,
 } from './graphql/shared-definitions';
@@ -306,5 +307,72 @@ describe('Collection related assets', () => {
             id: collectionFeaturedAssetId,
         });
         expect(asset?.id).toEqual(collectionFeaturedAssetId);
+    });
+});
+
+// Cross-channel update protection
+// Verifies that a channel-scoped admin cannot update an Asset belonging to
+// another channel. This is the guard that should use { channelId: ctx.channelId }
+// in asset.service.ts update().
+describe('cross-channel update protection', () => {
+    const CHANNEL_A_TOKEN = 'asset-cross-channel-a';
+    const CHANNEL_B_TOKEN = 'asset-cross-channel-b';
+    let targetAssetId: string;
+
+    beforeAll(async () => {
+        await adminClient.asSuperAdmin();
+        adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+        // Create two isolated channels
+        for (const [code, token] of [
+            ['asset-cross-a', CHANNEL_A_TOKEN],
+            ['asset-cross-b', CHANNEL_B_TOKEN],
+        ]) {
+            await adminClient.query(createChannelDocument, {
+                input: {
+                    code,
+                    token,
+                    defaultLanguageCode: LanguageCode.en,
+                    currencyCode: CurrencyCode.GBP,
+                    pricesIncludeTax: true,
+                    defaultShippingZoneId: 'T_1',
+                    defaultTaxZoneId: 'T_1',
+                },
+            });
+        }
+        // Create an Asset in Channel A via file upload
+        adminClient.setChannelToken(CHANNEL_A_TOKEN);
+        const filesToUpload = [path.join(__dirname, 'fixtures/assets/pps2.jpg')];
+        const { createAssets } = await adminClient.fileUploadMutation({
+            mutation: createAssetsDocument,
+            filePaths: filesToUpload,
+            mapVariables: filePaths => ({
+                input: filePaths.map(() => ({ file: null })),
+            }),
+        });
+        targetAssetId = createAssets[0].id;
+    });
+
+    afterAll(() => {
+        adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+    });
+
+    it('cannot update an Asset belonging to another channel', async () => {
+        // Channel B does not contain this Asset; the update must be rejected.
+        adminClient.setChannelToken(CHANNEL_B_TOKEN);
+        await expect(
+            adminClient.query(updateAssetDocument, {
+                input: {
+                    id: targetAssetId,
+                    name: 'PWNED-BY-CHANNEL-B',
+                },
+            }),
+        ).rejects.toThrow(/No Asset with the id .* could be found/);
+
+        // Verify the original Asset in Channel A is completely unchanged.
+        adminClient.setChannelToken(CHANNEL_A_TOKEN);
+        const { asset } = await adminClient.query(getAssetDocument, {
+            id: targetAssetId,
+        });
+        expect(asset?.name).toBe('pps2.jpg');
     });
 });

--- a/packages/core/e2e/stock-location.e2e-spec.ts
+++ b/packages/core/e2e/stock-location.e2e-spec.ts
@@ -360,5 +360,76 @@ describe('Stock location', () => {
 
             expect(productVariant?.stockLevels.length).toBe(0);
         });
+
+        // Cross-channel update protection
+        // Verifies that a channel-scoped admin cannot update a StockLocation belonging
+        // to another channel. This is the guard added by the channelId fix.
+        describe('cross-channel update protection', () => {
+            const CHANNEL_A_TOKEN = 'stock-loc-cross-channel-a';
+            const CHANNEL_B_TOKEN = 'stock-loc-cross-channel-b';
+            let targetLocationId: string;
+
+            beforeAll(async () => {
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                // Create two isolated channels
+                for (const [code, token] of [
+                    ['stock-loc-cross-a', CHANNEL_A_TOKEN],
+                    ['stock-loc-cross-b', CHANNEL_B_TOKEN],
+                ]) {
+                    await adminClient.query(createChannelDocument, {
+                        input: {
+                            code,
+                            token,
+                            defaultLanguageCode: LanguageCode.en,
+                            currencyCode: CurrencyCode.GBP,
+                            pricesIncludeTax: true,
+                            defaultShippingZoneId: 'T_1',
+                            defaultTaxZoneId: 'T_1',
+                        },
+                    });
+                }
+                // Create a StockLocation in Channel A
+                adminClient.setChannelToken(CHANNEL_A_TOKEN);
+                const { createStockLocation } = await adminClient.query(
+                    testCreateStockLocationDocument,
+                    {
+                        input: {
+                            name: 'Channel-A Location',
+                            description: 'Belongs to Channel A only',
+                        },
+                    },
+                );
+                targetLocationId = createStockLocation.id;
+            });
+
+            afterAll(() => {
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            });
+
+            it('cannot update a StockLocation belonging to another channel', async () => {
+                // Channel B does not contain this StockLocation; the update must be rejected.
+                adminClient.setChannelToken(CHANNEL_B_TOKEN);
+                await expect(
+                    adminClient.query(testUpdateStockLocationDocument, {
+                        input: {
+                            id: targetLocationId,
+                            name: 'PWNED-BY-CHANNEL-B',
+                            description: 'TAMPERED-CROSS-CHANNEL',
+                        },
+                    }),
+                ).rejects.toThrow(/No StockLocation with the id .* could be found/);
+
+                // Verify the original entity in Channel A is completely unchanged.
+                adminClient.setChannelToken(CHANNEL_A_TOKEN);
+                const { stockLocations } = await adminClient.query(
+                    testGetStockLocationsListDocument,
+                );
+                const target = stockLocations.items.find(
+                    (sl: any) => sl.id === targetLocationId,
+                );
+                expect(target?.name).toBe('Channel-A Location');
+                expect(target?.description).toBe('Belongs to Channel A only');
+            });
+        });
     });
 });

--- a/packages/core/src/service/services/asset.service.ts
+++ b/packages/core/src/service/services/asset.service.ts
@@ -397,7 +397,10 @@ export class AssetService {
      * Updates the name, focalPoint, tags & custom fields of an Asset.
      */
     async update(ctx: RequestContext, input: UpdateAssetInput): Promise<Translated<Asset>> {
-        const asset = await this.connection.getEntityOrThrow(ctx, Asset, input.id);
+        // Ensure the entity belongs to the active channel before updating.
+        const asset = await this.connection.getEntityOrThrow(ctx, Asset, input.id, {
+            channelId: ctx.channelId,
+        });
         if (input.focalPoint) {
             const to3dp = (x: number) => +x.toFixed(3);
             input.focalPoint.x = to3dp(input.focalPoint.x);

--- a/packages/core/src/service/services/stock-location.service.ts
+++ b/packages/core/src/service/services/stock-location.service.ts
@@ -96,7 +96,10 @@ export class StockLocationService {
     }
 
     async update(ctx: RequestContext, input: UpdateStockLocationInput): Promise<StockLocation> {
-        const stockLocation = await this.connection.getEntityOrThrow(ctx, StockLocation, input.id);
+        // Ensure the entity belongs to the active channel before updating.
+        const stockLocation = await this.connection.getEntityOrThrow(ctx, StockLocation, input.id, {
+            channelId: ctx.channelId,
+        });
         const updatedStockLocation = patchEntity(stockLocation, input);
         await this.connection.getRepository(ctx, StockLocation).save(updatedStockLocation);
         await this.customFieldRelationService.updateRelations(


### PR DESCRIPTION
Fixes #5003

# Description

`StockLocationService.update()` and `AssetService.update()` loaded entities via `getEntityOrThrow()` without passing `{ channelId: ctx.channelId }`, allowing a channel-scoped admin to modify entities belonging to other channels. This is the same class of defect fixed for six other services in PR #4821, which missed these two.

**Changes:**
- Add `{ channelId: ctx.channelId }` guard to `StockLocationService.update()` and `AssetService.update()`
- Add cross-channel update protection e2e tests for StockLocation, Asset, Collection, ProductOptionGroup, ProductOption, and Facet

# Breaking changes

No breaking changes.

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5017"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787340217&installation_model_id=20193&pr_number=5017&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5017&signature=385b9c7609dc7b201fcae7ba94a4eabd7fc94541aa73cff5febff369e9e7e7f1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->