### PR TITLE
docs: direct security reports to GitHub advisories

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Report a Security Vulnerability
+    url: https://github.com/vendurehq/vendure/security/advisories/new
+    about: Privately report a suspected security vulnerability to the Vendure maintainers
   - name: Feature Request
     url: https://github.com/vendurehq/vendure/discussions/new?category=feature-requests
     about: Suggest an idea or new feature for Vendure Core

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ Contributions are welcome: bugs, features, or docs. Our **[Contribution Guide](.
 
 Pick up a [labelled issue](https://github.com/vendurehq/vendure/issues?q=is%3Aissue%20state%3Aopen%20label%3A%22%F0%9F%91%8B%20contributions%20welcome%22) as a good first contribution.
 
+## Security
+
+To report a suspected security vulnerability, use
+[GitHub's private vulnerability reporting](https://github.com/vendurehq/vendure/security/advisories/new).
+Do not disclose security vulnerabilities through public GitHub issues or email. See our
+[security policy](./SECURITY.md) for details.
+
 ## Releases
 
 Patch releases ship regularly. Check our [release notes](https://github.com/vendurehq/vendure/releases) to keep up to date.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,4 +11,9 @@
 
 ## Reporting a Vulnerability
 
-To report a security vulnerability, email [contact@vendure.io](mailto:contact@vendure.io).
+Report suspected security vulnerabilities through
+[GitHub's private vulnerability reporting](https://github.com/vendurehq/vendure/security/advisories/new).
+This allows the Vendure maintainers to discuss and resolve the report securely before
+any details are made public.
+
+Please do not report security vulnerabilities through public GitHub issues or email.


### PR DESCRIPTION
# Description

Direct suspected vulnerability reports to GitHub's private security advisory system instead of email. The security policy, README, and GitHub issue chooser now consistently point developers to private vulnerability reporting and warn against public disclosure.

# Breaking changes

No.

# Screenshots

Not applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5020"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787386409&installation_model_id=20193&pr_number=5020&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5020&signature=e969add03d89217ab84d1aae4ddb0948c3e92050976b3822927a89b9c04d9479"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->