### PR TITLE
docs: Add missing path import to importing-data test-data example

### DIFF
--- a/docs/docs/guides/developer-guide/importing-data/index.mdx
+++ b/docs/docs/guides/developer-guide/importing-data/index.mdx
@@ -246,6 +246,7 @@ This guide illustrates how to populate that test data again on an existing Vendu
 ```ts title="src/populate-test-data.ts"
 import { populate } from '@vendure/core/cli';
 import { bootstrap, VendureConfig } from '@vendure/core';
+import path from 'path';
 import { config } from './vendure-config';
 
 populate(


### PR DESCRIPTION
The **Populating test data** example in the importing-data guide calls `path.join(...)` but its import block omits `import path from 'path'` (the earlier *Populating The Server* example has it). Added the missing import so the snippet is copy-paste runnable.

Relates to OSS-336

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5021"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787410349&installation_model_id=20193&pr_number=5021&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5021&signature=58840626b83169a7a220972ce7fcfcdd219130a648ec8e3d83881ccc96689bad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->