### PR TITLE
feat(dashboard): Add badge support to nav menu items

### DIFF
--- a/packages/dashboard/src/lib/components/layout/nav-main.tsx
+++ b/packages/dashboard/src/lib/components/layout/nav-main.tsx
@@ -92,6 +92,7 @@ function CollapsedSectionMenu({
                             )}
                         >
                             {i18n.t(subItem.title)}
+                            {subItem.badge && <subItem.badge />}
                         </Link>
                     </NavItemWrapper>
                 ))}
@@ -364,6 +365,7 @@ export function NavMain({ items }: Readonly<{ items: Array<NavMenuSection | NavM
                         >
                             {item.icon && <item.icon />}
                             <span>{i18n.t(item.title)}</span>
+                            {item.badge && <item.badge />}
                             {navigationChordActive ? <ShortcutBadge shortcut={item.shortcut} /> : null}
                         </SidebarMenuButton>
                     </SidebarMenuItem>
@@ -409,6 +411,7 @@ export function NavMain({ items }: Readonly<{ items: Array<NavMenuSection | NavM
                                                 isActive={isPathActive(subItem.url)}
                                             >
                                                 <span>{i18n.t(subItem.title)}</span>
+                                                {subItem.badge && <subItem.badge />}
                                                 {navigationChordActive ? (
                                                     <ShortcutBadge shortcut={subItem.shortcut} />
                                                 ) : null}

--- a/packages/dashboard/src/lib/framework/extension-api/logic/navigation.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/logic/navigation.ts
@@ -50,6 +50,7 @@ function registerRoutes(routes?: DashboardRouteDefinition[]) {
                 icon: route.navMenuItem.icon,
                 placement: route.navMenuItem.placement,
                 shortcut: route.navMenuItem.shortcut,
+                badge: route.navMenuItem.badge,
             };
             addNavMenuItem(item, route.navMenuItem.sectionId);
         }

--- a/packages/dashboard/src/lib/framework/nav-menu/nav-menu-extensions.ts
+++ b/packages/dashboard/src/lib/framework/nav-menu/nav-menu-extensions.ts
@@ -1,4 +1,5 @@
 import type { LucideIcon } from 'lucide-react';
+import type { ComponentType } from 'react';
 
 import { globalRegistry } from '../registry/global-registry.js';
 
@@ -117,6 +118,15 @@ export interface NavMenuItem {
      * Optional second key for the global `G` navigation chord.
      */
     shortcut?: NavigationShortcut;
+    /**
+     * @description
+     * An optional component rendered after the item's title, for example a
+     * count badge. It is rendered in every nav state: as a top-level item, as
+     * an expanded sub-item, and in the collapsed section's hover card.
+     *
+     * @since 3.8.0
+     */
+    badge?: ComponentType;
 }
 
 export interface NavMenuSection extends Omit<NavMenuItem, 'url' | 'shortcut'> {


### PR DESCRIPTION
## Description

Adds an optional `badge` component to `NavMenuItem` so a Dashboard extension can render a count or status indicator next to a menu item.

Currently `NavMenuItem` exposes `{ id, title, url, icon, order, placement, requiresPermission, shortcut }` — there is no way to attach a small component (e.g. a pending-count badge) to a nav entry. This adds:

- `badge?: ComponentType` on the `NavMenuItem` interface (with a `@since 3.8.0` doc tag).
- Rendering of the badge in all three nav states in `nav-main.tsx`: the top-level item, the expanded sub-item, and the collapsed section's hover-card link.
- Forwarding of the field in `registerRoutes`, so a route-registered `navMenuItem.badge` is not dropped (that function builds the item field-by-field).

It is purely additive and optional — existing nav items and the `shortcut`/`ShortcutBadge` behaviour are untouched.

### Example

```tsx
defineDashboardExtension({
  routes: [
    {
      path: '/exports',
      navMenuItem: {
        sectionId: 'sales',
        id: 'exports',
        title: 'Exports',
        badge: PendingExportCount, // renders next to the title
      },
      component: () => <ExportsPage />,
    },
  ],
});
```

## Motivation

We maintain a Vendure 3.7 project whose admin brief requires a count badge next to a nav item. With no upstream field for it we currently carry a small `pnpm patch` of `@vendure/dashboard` making exactly this change; this PR is that patch offered upstream so we (and anyone else who needs it) can drop the patch.

## Breaking changes

None. The field is optional and additive.

## Notes

- Targeted at `minor` per the contribution guidelines (new feature).
- Happy to open a corresponding feature-request issue if the maintainers prefer the issue-first flow — let me know.
- The change was prepared with the assistance of Claude Code; it has been reviewed by me and I am the contributor signing the CLA.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787423266&installation_model_id=20193&pr_number=5024&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5024&signature=89df3708e26ce3a088f9ed8a7da7241f9bfe1f91732fc9f28402271687a23a7b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->