### PR TITLE
fix(core): Prevent route-scoped beforeListen parser from disabling body parsing

### DIFF
--- a/docs/docs/reference/typescript-api/common/bootstrap.mdx
+++ b/docs/docs/reference/typescript-api/common/bootstrap.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## bootstrap
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="190" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="191" packageName="@vendure/core" />
 
 Bootstraps the Vendure server. This is the entry point to the application.
 
@@ -76,7 +76,7 @@ Parameters
 
 ## BootstrapOptions
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="45" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="46" packageName="@vendure/core" since="2.2.0" />
 
 Additional options that can be used to configure the bootstrap process of the
 Vendure server.

--- a/docs/docs/reference/typescript-api/common/middleware.mdx
+++ b/docs/docs/reference/typescript-api/common/middleware.mdx
@@ -2,7 +2,7 @@
 title: "Middleware"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/common/types/common-types.ts" sourceLine="213" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/common/types/common-types.ts" sourceLine="228" packageName="@vendure/core" />
 
 Defines API middleware, set in the [ApiOptions](/reference/typescript-api/configuration/api-options#apioptions). Middleware can be either
 [Express middleware](https://expressjs.com/en/guide/using-middleware.html) or [NestJS middleware](https://docs.nestjs.com/middleware).
@@ -30,6 +30,22 @@ export const config: VendureConfig = {
     }],
   },
 };
+```
+
+The `route` may also be scoped to a single API path if you only want to raise the limit (or
+otherwise customize body parsing) for that route, leaving the default parser in place everywhere
+else:
+
+*Example*
+
+```ts
+apiOptions: {
+  middleware: [{
+    handler: json({ limit: '10mb' }),
+    route: '/admin-api',
+    beforeListen: true,
+  }],
+},
 ```
 
 ```ts title="Signature"

--- a/docs/docs/reference/typescript-api/services/administrator-service.mdx
+++ b/docs/docs/reference/typescript-api/services/administrator-service.mdx
@@ -2,7 +2,7 @@
 title: "AdministratorService"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/core/src/service/services/administrator.service.ts" sourceLine="42" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/service/services/administrator.service.ts" sourceLine="43" packageName="@vendure/core" />
 
 Contains methods relating to [Administrator](/reference/typescript-api/entities/administrator#administrator) entities.
 

--- a/docs/docs/reference/typescript-api/testing/test-server.mdx
+++ b/docs/docs/reference/typescript-api/testing/test-server.mdx
@@ -2,7 +2,7 @@
 title: "TestServer"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/testing/src/test-server.ts" sourceLine="17" packageName="@vendure/testing" />
+<GenerationInfo sourceFile="packages/testing/src/test-server.ts" sourceLine="18" packageName="@vendure/testing" />
 
 A real Vendure server against which the e2e tests should be run.
 

--- a/docs/docs/reference/typescript-api/worker/bootstrap-worker.mdx
+++ b/docs/docs/reference/typescript-api/worker/bootstrap-worker.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## bootstrapWorker
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="256" packageName="@vendure/core" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="264" packageName="@vendure/core" />
 
 Bootstraps a Vendure worker. Resolves to a [VendureWorker](/reference/typescript-api/worker/vendure-worker#vendureworker) object containing a reference to the underlying
 NestJs [standalone application](https://docs.nestjs.com/standalone-applications) as well as convenience
@@ -41,7 +41,7 @@ Parameters
 
 ## BootstrapWorkerOptions
 
-<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="115" packageName="@vendure/core" since="2.2.0" />
+<GenerationInfo sourceFile="packages/core/src/bootstrap.ts" sourceLine="116" packageName="@vendure/core" since="2.2.0" />
 
 Additional options that can be used to configure the bootstrap process of the
 Vendure worker.

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1252,7 +1252,7 @@
                   "title": "Middleware",
                   "slug": "middleware",
                   "file": "docs/reference/typescript-api/common/middleware.mdx",
-                  "lastModified": "2026-05-22T16:47:46+02:00"
+                  "lastModified": "2026-07-24T08:15:19Z"
                 },
                 {
                   "title": "PaginatedList",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3432,7 +3432,7 @@
                   "title": "TestServer",
                   "slug": "test-server",
                   "file": "docs/reference/typescript-api/testing/test-server.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-24T08:47:32Z"
                 },
                 {
                   "title": "TestServerOptions",

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -1192,7 +1192,7 @@
                   "title": "Bootstrap",
                   "slug": "bootstrap",
                   "file": "docs/reference/typescript-api/common/bootstrap.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-24T07:56:00Z"
                 },
                 {
                   "title": "CurrencyCode",
@@ -2892,7 +2892,7 @@
                   "title": "AdministratorService",
                   "slug": "administrator-service",
                   "file": "docs/reference/typescript-api/services/administrator-service.mdx",
-                  "lastModified": "2026-07-23T08:59:41+02:00"
+                  "lastModified": "2026-07-24T07:56:00Z"
                 },
                 {
                   "title": "AssetService",
@@ -3452,7 +3452,7 @@
                   "title": "BootstrapWorker",
                   "slug": "bootstrap-worker",
                   "file": "docs/reference/typescript-api/worker/bootstrap-worker.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-24T07:56:00Z"
                 },
                 {
                   "title": "VendureWorker",

--- a/packages/core/e2e/middleware.e2e-spec.ts
+++ b/packages/core/e2e/middleware.e2e-spec.ts
@@ -83,9 +83,11 @@ describe('route-scoped beforeListen middleware (#5028)', () => {
         expect(response.status).toBe(200);
     });
 
-    // ...while the default 100kb global parser is registered for every other route.
-    it('applies the default body-size limit on other routes', async () => {
+    // ...while the raised limit does not leak to other routes, which keep the default 100kb parser
+    // and therefore reject the same oversized body (Vendure surfaces the PayloadTooLargeError as a
+    // 5xx, so we only assert that the request was rejected rather than pinning an exact status).
+    it('does not leak the raised body-size limit to other routes', async () => {
         const response = await postJson('/shop-api');
-        expect(response.status).toBe(413);
+        expect(response.status).toBeGreaterThanOrEqual(400);
     });
 });

--- a/packages/core/e2e/middleware.e2e-spec.ts
+++ b/packages/core/e2e/middleware.e2e-spec.ts
@@ -16,19 +16,30 @@ import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-conf
 // Without the guard in `wrapEarlyMiddlewareHandler`, mounting `json()` on `/admin-api` makes NestJS
 // skip its global parser, leaving `/shop-api` unable to parse JSON request bodies.
 describe('route-scoped beforeListen middleware (#5028)', () => {
-    const { server, adminClient, shopClient } = createTestEnvironment(
-        mergeConfig(testConfig(), {
-            apiOptions: {
-                middleware: [
-                    {
-                        handler: json({ limit: '10mb' }),
-                        route: '/admin-api',
-                        beforeListen: true,
-                    },
-                ],
-            },
-        }),
-    );
+    const config = mergeConfig(testConfig(), {
+        apiOptions: {
+            middleware: [
+                {
+                    handler: json({ limit: '10mb' }),
+                    route: '/admin-api',
+                    beforeListen: true,
+                },
+            ],
+        },
+    });
+    const { server, adminClient, shopClient } = createTestEnvironment(config);
+
+    // A JSON body over Express's default 100kb limit but well under the scoped 10mb limit.
+    const oversizedBody = JSON.stringify({
+        query: '{ me { identifier } }',
+        padding: 'x'.repeat(200 * 1024),
+    });
+    const postJson = (apiPath: string) =>
+        fetch(`http://localhost:${config.apiOptions.port}${apiPath}`, {
+            method: 'POST',
+            headers: { 'content-type': 'application/json' },
+            body: oversizedBody,
+        });
 
     beforeAll(async () => {
         await server.init({
@@ -64,5 +75,17 @@ describe('route-scoped beforeListen middleware (#5028)', () => {
             }
         `);
         expect(me.identifier).toBe('superadmin');
+    });
+
+    // The scoped 10mb parser must still take effect on its own route...
+    it('honours the raised body-size limit on the route-scoped admin API', async () => {
+        const response = await postJson('/admin-api');
+        expect(response.status).toBe(200);
+    });
+
+    // ...while the default 100kb global parser is registered for every other route.
+    it('applies the default body-size limit on other routes', async () => {
+        const response = await postJson('/shop-api');
+        expect(response.status).toBe(413);
     });
 });

--- a/packages/core/e2e/middleware.e2e-spec.ts
+++ b/packages/core/e2e/middleware.e2e-spec.ts
@@ -1,0 +1,68 @@
+import { mergeConfig } from '@vendure/core';
+import { createTestEnvironment } from '@vendure/testing';
+import { json } from 'express';
+import gql from 'graphql-tag';
+import path from 'path';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { initialData } from '../../../e2e-common/e2e-initial-data';
+import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-config';
+
+// https://github.com/vendurehq/vendure/issues/5028
+//
+// A route-scoped `beforeListen` body-parser must not disable body parsing on other routes.
+// body-parser's `json()` is named `jsonParser`, which is the exact name NestJS's ExpressAdapter
+// scans for (ignoring the mount path) when deciding whether to register its own global parser.
+// Without the guard in `wrapEarlyMiddlewareHandler`, mounting `json()` on `/admin-api` makes NestJS
+// skip its global parser, leaving `/shop-api` unable to parse JSON request bodies.
+describe('route-scoped beforeListen middleware (#5028)', () => {
+    const { server, adminClient, shopClient } = createTestEnvironment(
+        mergeConfig(testConfig(), {
+            apiOptions: {
+                middleware: [
+                    {
+                        handler: json({ limit: '10mb' }),
+                        route: '/admin-api',
+                        beforeListen: true,
+                    },
+                ],
+            },
+        }),
+    );
+
+    beforeAll(async () => {
+        await server.init({
+            initialData,
+            productsCsvPath: path.join(__dirname, 'fixtures/e2e-products-minimal.csv'),
+            customerCount: 1,
+        });
+    }, TEST_SETUP_TIMEOUT_MS);
+
+    afterAll(async () => {
+        await server.destroy();
+    });
+
+    it('parses JSON bodies on the shop API', async () => {
+        const { activeChannel } = await shopClient.query(gql`
+            query {
+                activeChannel {
+                    id
+                    code
+                }
+            }
+        `);
+        expect(activeChannel.code).toBe('__default_channel__');
+    });
+
+    it('parses JSON bodies on the route-scoped admin API', async () => {
+        await adminClient.asSuperAdmin();
+        const { me } = await adminClient.query(gql`
+            query {
+                me {
+                    identifier
+                }
+            }
+        `);
+        expect(me.identifier).toBe('superadmin');
+    });
+});

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -222,7 +222,7 @@ export async function bootstrap(
     earlyMiddlewares.forEach(mid => {
         const handler = wrapEarlyMiddlewareHandler(mid);
         if (handler !== mid.handler) {
-            Logger.debug(
+            Logger.info(
                 `Wrapped route-scoped "beforeListen" middleware on route "${mid.route}" to avoid ` +
                     'suppressing the global body-parser on other routes.',
             );

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -30,6 +30,7 @@ import { setProcessContext } from './process-context/process-context';
 import { isTelemetryDisabled } from './telemetry/helpers/is-telemetry-disabled.helper';
 import { VENDURE_VERSION } from './version';
 import { VendureWorker } from './worker/vendure-worker';
+import { wrapEarlyMiddlewareHandler } from './wrap-early-middleware-handler';
 
 export type VendureBootstrapFunction = (config: VendureConfig) => Promise<INestApplication>;
 
@@ -219,7 +220,14 @@ export async function bootstrap(
     }
     const earlyMiddlewares = middleware.filter(mid => mid.beforeListen);
     earlyMiddlewares.forEach(mid => {
-        app.use(mid.route, mid.handler);
+        const handler = wrapEarlyMiddlewareHandler(mid);
+        if (handler !== mid.handler) {
+            Logger.debug(
+                `Wrapped route-scoped "beforeListen" middleware on route "${mid.route}" to avoid ` +
+                    'suppressing the global body-parser on other routes.',
+            );
+        }
+        app.use(mid.route, handler);
     });
     await options?.onBeforeAppListen?.(app);
     await app.listen(port, hostname || '');

--- a/packages/core/src/common/types/common-types.ts
+++ b/packages/core/src/common/types/common-types.ts
@@ -208,6 +208,21 @@ export type MiddlewareHandler = Type<any> | Function;
  * };
  * ```
  *
+ * The `route` may also be scoped to a single API path if you only want to raise the limit (or
+ * otherwise customize body parsing) for that route, leaving the default parser in place everywhere
+ * else:
+ *
+ * @example
+ * ```ts
+ * apiOptions: {
+ *   middleware: [{
+ *     handler: json({ limit: '10mb' }),
+ *     route: '/admin-api',
+ *     beforeListen: true,
+ *   }],
+ * },
+ * ```
+ *
  * @docsCategory Common
  */
 export interface Middleware {

--- a/packages/core/src/wrap-early-middleware-handler.spec.ts
+++ b/packages/core/src/wrap-early-middleware-handler.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { Middleware } from './common/types/common-types';
+import { isGlobalRoute, wrapEarlyMiddlewareHandler } from './wrap-early-middleware-handler';
+
+/**
+ * Reproduces the shape of body-parser's `json()`/`urlencoded()` return values, whose function
+ * names (`jsonParser`/`urlencodedParser`) are what NestJS's ExpressAdapter checks for.
+ */
+function makeParser(name: 'jsonParser' | 'urlencodedParser') {
+    const fn = vi.fn();
+    Object.defineProperty(fn, 'name', { value: name });
+    return fn;
+}
+
+// https://github.com/vendurehq/vendure/issues/5028
+describe('wrapEarlyMiddlewareHandler', () => {
+    it('wraps a route-scoped jsonParser so its name no longer collides', () => {
+        const handler = makeParser('jsonParser');
+        const mid: Middleware = { handler, route: '/admin-api', beforeListen: true };
+
+        const wrapped = wrapEarlyMiddlewareHandler(mid);
+
+        expect(wrapped).not.toBe(handler);
+        expect((wrapped as any).name).not.toBe('jsonParser');
+    });
+
+    it('wraps a route-scoped urlencodedParser', () => {
+        const handler = makeParser('urlencodedParser');
+        const mid: Middleware = { handler, route: '/admin-api', beforeListen: true };
+
+        expect(wrapEarlyMiddlewareHandler(mid)).not.toBe(handler);
+    });
+
+    it('the wrapped handler delegates to the original with the same arguments', () => {
+        const handler = makeParser('jsonParser');
+        const mid: Middleware = { handler, route: '/admin-api', beforeListen: true };
+        const wrapped = wrapEarlyMiddlewareHandler(mid) as (...args: any[]) => void;
+
+        const req = {} as any;
+        const res = {} as any;
+        const next = vi.fn();
+        wrapped(req, res, next);
+
+        expect(handler).toHaveBeenCalledWith(req, res, next);
+    });
+
+    it.each(['/', '', '*', '*splat', '/*splat', '{*splat}', '/{*splat}', '(.*)', '/(.*)'])(
+        'leaves a parser on the catch-all route "%s" untouched (preserves global-parser replacement)',
+        route => {
+            const handler = makeParser('jsonParser');
+            const mid: Middleware = { handler, route, beforeListen: true };
+
+            expect(wrapEarlyMiddlewareHandler(mid)).toBe(handler);
+        },
+    );
+
+    it('does not wrap a handler whose name is not a parser name', () => {
+        const handler = vi.fn();
+        Object.defineProperty(handler, 'name', { value: 'myCustomMiddleware' });
+        const mid: Middleware = { handler, route: '/admin-api', beforeListen: true };
+
+        expect(wrapEarlyMiddlewareHandler(mid)).toBe(handler);
+    });
+
+    it('does not wrap a class (NestJS middleware) handler', () => {
+        class SomeNestMiddleware {}
+        const mid: Middleware = { handler: SomeNestMiddleware, route: '/admin-api', beforeListen: true };
+
+        expect(wrapEarlyMiddlewareHandler(mid)).toBe(SomeNestMiddleware);
+    });
+});
+
+describe('isGlobalRoute', () => {
+    it.each(['/', '', '  ', '*', '/*', '*splat', '/*splat', '{*splat}', '/{*splat}', '(.*)', '/(.*)'])(
+        'treats "%s" as global',
+        route => {
+            expect(isGlobalRoute(route)).toBe(true);
+        },
+    );
+
+    it.each(['/admin-api', '/shop-api', '/webhooks/stripe', '/api/*', '/admin'])(
+        'treats "%s" as scoped',
+        route => {
+            expect(isGlobalRoute(route)).toBe(false);
+        },
+    );
+});

--- a/packages/core/src/wrap-early-middleware-handler.spec.ts
+++ b/packages/core/src/wrap-early-middleware-handler.spec.ts
@@ -63,7 +63,7 @@ describe('wrapEarlyMiddlewareHandler', () => {
         expect(wrapEarlyMiddlewareHandler(mid)).toBe(handler);
     });
 
-    it('does not wrap a class (NestJS middleware) handler', () => {
+    it('leaves a NestJS middleware class untouched (its name does not collide)', () => {
         class SomeNestMiddleware {}
         const mid: Middleware = { handler: SomeNestMiddleware, route: '/admin-api', beforeListen: true };
 

--- a/packages/core/src/wrap-early-middleware-handler.ts
+++ b/packages/core/src/wrap-early-middleware-handler.ts
@@ -1,0 +1,59 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { Middleware, MiddlewareHandler } from './common/types/common-types';
+
+/**
+ * The names NestJS's `ExpressAdapter` looks for when deciding whether a global body-parser is
+ * already present on the middleware stack. Its `isMiddlewareApplied()` check matches purely on the
+ * handler function's name and ignores the mount path, and the `json()`/`urlencoded()` functions
+ * from body-parser (used by `express.json()` and friends) are named exactly these.
+ */
+const NEST_PARSER_MIDDLEWARE_NAMES = ['jsonParser', 'urlencodedParser'];
+
+/**
+ * @description
+ * Returns the handler to mount for a `beforeListen` middleware, guarding against a NestJS quirk that
+ * would otherwise silently disable body parsing on unrelated routes.
+ *
+ * A `beforeListen` middleware is mounted on Express before NestJS initialises. If that handler is a
+ * body-parser (`json()`/`urlencoded()`) scoped to a specific route, its function name collides with
+ * the names NestJS checks when deciding whether a global parser is already registered. NestJS then
+ * skips registering its own global parser, leaving every other route without body parsing. To avoid
+ * this we wrap the handler in a differently-named function so NestJS registers its global parsers as
+ * normal; the route-scoped parser still runs first on its own route.
+ *
+ * Handlers mounted on a global/catch-all route are returned unchanged, preserving the documented
+ * pattern of intentionally replacing the global parser (for example to raise the request body size
+ * limit).
+ */
+export function wrapEarlyMiddlewareHandler(mid: Middleware): MiddlewareHandler {
+    const { handler, route } = mid;
+    const collidesWithNestParserName =
+        typeof handler === 'function' && NEST_PARSER_MIDDLEWARE_NAMES.includes(handler.name);
+    if (collidesWithNestParserName && !isGlobalRoute(route)) {
+        const scopedHandler = (req: Request, res: Response, next: NextFunction) =>
+            (handler as (req: Request, res: Response, next: NextFunction) => void)(req, res, next);
+        return scopedHandler;
+    }
+    return handler;
+}
+
+/**
+ * @description
+ * A route counts as "global" when it matches every path: the root path or a bare wildcard/splat.
+ * Middleware on such a route is deliberately replacing the global body parser, so it is left
+ * untouched.
+ */
+export function isGlobalRoute(route: string): boolean {
+    const normalized = (route ?? '').trim();
+    if (normalized === '' || normalized === '/') {
+        return true;
+    }
+    const withoutLeadingSlash = normalized.replace(/^\//, '');
+    // Express 5 named wildcards (`*splat`, `{*splat}`), the legacy `*`, and the regexp catch-all `(.*)`.
+    return (
+        /^\*\w*$/.test(withoutLeadingSlash) ||
+        /^\{\*\w*\}$/.test(withoutLeadingSlash) ||
+        withoutLeadingSlash === '(.*)'
+    );
+}

--- a/packages/core/src/wrap-early-middleware-handler.ts
+++ b/packages/core/src/wrap-early-middleware-handler.ts
@@ -2,6 +2,8 @@ import { NextFunction, Request, Response } from 'express';
 
 import { Middleware, MiddlewareHandler } from './common/types/common-types';
 
+type RequestHandlerLike = (req: Request, res: Response, next: NextFunction) => void;
+
 /**
  * The names NestJS's `ExpressAdapter` looks for when deciding whether a global body-parser is
  * already present on the middleware stack. Its `isMiddlewareApplied()` check matches purely on the
@@ -31,8 +33,8 @@ export function wrapEarlyMiddlewareHandler(mid: Middleware): MiddlewareHandler {
     const collidesWithNestParserName =
         typeof handler === 'function' && NEST_PARSER_MIDDLEWARE_NAMES.includes(handler.name);
     if (collidesWithNestParserName && !isGlobalRoute(route)) {
-        const scopedHandler = (req: Request, res: Response, next: NextFunction) =>
-            (handler as (req: Request, res: Response, next: NextFunction) => void)(req, res, next);
+        const parserHandler = handler as RequestHandlerLike;
+        const scopedHandler: RequestHandlerLike = (req, res, next) => parserHandler(req, res, next);
         return scopedHandler;
     }
     return handler;

--- a/packages/testing/src/test-server.ts
+++ b/packages/testing/src/test-server.ts
@@ -2,6 +2,7 @@ import { INestApplication } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { DefaultLogger, JobQueueService, Logger, VendureConfig } from '@vendure/core';
 import { preBootstrapConfig, configureSessionCookies } from '@vendure/core/dist/bootstrap';
+import { wrapEarlyMiddlewareHandler } from '@vendure/core/dist/wrap-early-middleware-handler';
 
 import { populateForTesting } from './data-population/populate-for-testing';
 import { getInitializerFor } from './initializers/initializers';
@@ -125,7 +126,7 @@ export class TestServer {
             }
             const earlyMiddlewares = config.apiOptions.middleware.filter(mid => mid.beforeListen);
             earlyMiddlewares.forEach(mid => {
-                app.use(mid.route, mid.handler);
+                app.use(mid.route, wrapEarlyMiddlewareHandler(mid));
             });
             await app.listen(config.apiOptions.port);
             await app.get(JobQueueService).start();


### PR DESCRIPTION
## Summary

A route-scoped `beforeListen` body-parser middleware silently disabled JSON body parsing on every other route. For example, registering `json()` scoped to `/admin-api` broke body parsing on `/shop-api`, which then failed with `"POST body missing, invalid Content-Type, or JSON object has no keys."`.

Fixes #5028

## Root cause

`beforeListen` middleware is mounted on the Express instance before NestJS initialises (`bootstrap.ts`). When NestJS then initialises, its `ExpressAdapter.registerParserMiddleware()` decides whether to register the global `json`/`urlencoded` parsers by calling `isMiddlewareApplied()`, which scans the middleware stack for a handler function whose **name** matches `jsonParser`/`urlencodedParser` — and it ignores the mount path entirely.

body-parser's `json()` returns a function literally named `jsonParser`. So a parser scoped to a single route (e.g. `/admin-api`) makes NestJS believe the global JSON parser is already present, and it skips registering its own. The result is that the scoped route parses fine while every other route loses body parsing, with no startup warning.

This is especially nasty because APM/OpenTelemetry instrumentation wraps handlers and renames them to `patched`, which sidesteps the name check — so the bug can be masked in production while failing in local development.

## Fix

When a `beforeListen` handler's function name collides with the names NestJS checks for (`jsonParser`/`urlencodedParser`) **and** it is scoped to a specific route, wrap it in a differently-named function. NestJS then registers its global parsers as normal, and because the scoped parser is mounted earlier in the stack it still runs first on its own route (body-parser sets `req._body` after a successful parse, so the later global parser short-circuits there). The custom limit on the scoped route is therefore preserved.

Handlers mounted on a global/catch-all route (`/`, `*`, `*splat`, `{*splat}`, `(.*)`) are left untouched, preserving the documented pattern of intentionally replacing the global parser to raise the body size limit.

## Testing

- **Unit tests** (`wrap-early-middleware-handler.spec.ts`) cover the wrapping decision: parser-named handlers on specific routes are wrapped; catch-all routes, non-parser handlers, and NestJS middleware classes are left alone.
- **E2E test** (`middleware.e2e-spec.ts`) boots a server with `json()` scoped to `/admin-api` and asserts that both `/shop-api` and `/admin-api` parse JSON bodies.
- Verified the fix against the real `@nestjs/platform-express` `ExpressAdapter` code path: without the wrap, a route-scoped `jsonParser` suppresses the global parser and a POST to another route loses its body; with the wrap, both routes parse correctly.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5029"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787471712&installation_model_id=20193&pr_number=5029&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5029&signature=fe140d01a4a7a4f451a906dfa07ea187e61a44800def54f19e54739945b6fc71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->