### PR TITLE
fix(dashboard): Preserve context in operation value previews

### DIFF
--- a/docs/docs/reference/dashboard/components/configurable-operation-sentence.mdx
+++ b/docs/docs/reference/dashboard/components/configurable-operation-sentence.mdx
@@ -16,7 +16,7 @@ type OperationDescriptionSegment = | { type: 'text'; text: string }
 ```
 ## parseOperationDescription
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/components/shared/configurable-operation-description.ts" sourceLine="34" packageName="@vendure/dashboard" since="3.6.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/components/shared/configurable-operation-description.ts" sourceLine="45" packageName="@vendure/dashboard" since="3.6.0" />
 
 Parses a configurable operation's description template (e.g.
 `"buy at least { minimum } of the specified products"`) into an ordered list
@@ -36,7 +36,7 @@ Parameters
 
 ## formatScalarArgValue
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/components/shared/configurable-operation-description.ts" sourceLine="80" packageName="@vendure/dashboard" since="3.6.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/components/shared/configurable-operation-description.ts" sourceLine="91" packageName="@vendure/dashboard" since="3.6.0" />
 
 Formats a scalar configurable operation arg value for compact display,
 applying the same currency precision and date formatting rules as
@@ -61,7 +61,7 @@ Parameters
 
 ## OperationSentence
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/components/shared/configurable-operation-sentence.tsx" sourceLine="39" packageName="@vendure/dashboard" since="3.6.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/components/shared/configurable-operation-sentence.tsx" sourceLine="40" packageName="@vendure/dashboard" since="3.6.0" />
 
 Renders a configurable operation as an inline sentence based on its
 description template, where each argument is an interactive chip that opens

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -3861,7 +3861,7 @@
                   "title": "ConfigurableOperationSentence",
                   "slug": "configurable-operation-sentence",
                   "file": "docs/reference/dashboard/components/configurable-operation-sentence.mdx",
-                  "lastModified": "2026-07-15T13:23:53+02:00"
+                  "lastModified": "2026-07-24T15:51:18Z"
                 },
                 {
                   "title": "CopyableText",

--- a/packages/dashboard/e2e/tests/marketing/promotions.spec.ts
+++ b/packages/dashboard/e2e/tests/marketing/promotions.spec.ts
@@ -87,10 +87,10 @@ test.describe('Promotions CRUD', () => {
 
         const dp = detailPage(page);
 
-        // The condition renders as a sentence with the amount as a chip
-        // (default value 100 minor units → displayed as 1)
+        // The condition renders as a sentence with the amount and active
+        // channel currency as a chip (default value 100 minor units → $1.00).
         const amountChip = page.getByRole('button', { name: 'amount' });
-        await expect(amountChip).toHaveText('1');
+        await expect(amountChip).toHaveText('$1.00');
 
         // Edit the amount in the chip popover — changes apply live.
         // (MoneyInput does not forward the name attribute, so locate the
@@ -102,14 +102,14 @@ test.describe('Promotions CRUD', () => {
             .getByRole('textbox')
             .fill('50');
         await page.keyboard.press('Escape');
-        await expect(amountChip).toHaveText('50');
+        await expect(amountChip).toHaveText('$50.00');
 
         await dp.clickUpdate();
         await dp.expectSuccessToast(/Successfully updated promotion/);
 
         // The edited value persists across a reload
         await page.reload();
-        await expect(page.getByRole('button', { name: 'amount' })).toHaveText('50');
+        await expect(page.getByRole('button', { name: 'amount' })).toHaveText('$50.00');
     });
 
     test('should update the promotion', async ({ page }) => {

--- a/packages/dashboard/src/i18n/locales/ar.po
+++ b/packages/dashboard/src/i18n/locales/ar.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "تحديد {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "فشل في إنشاء المسؤول"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "لا"
 
@@ -1072,7 +1072,7 @@ msgstr "متغير واحد، بدون خيارات"
 msgid "Select the next state for the order"
 msgstr "حدد الحالة التالية للطلب"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "تم تحديد {count}"
 
@@ -2001,9 +2001,9 @@ msgstr "مجموعات العملاء"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "معطل"
@@ -2716,6 +2716,11 @@ msgstr "الحجم، اللون، إلخ."
 msgid "Browse facets"
 msgstr "تصفح الفئات"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "حفظ العرض"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} محدد"
 
@@ -3139,6 +3144,10 @@ msgstr "تم تحديث قيم الخصائص لـ {entityIdsLength} {entityType
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "فشل إزالة العميل من المجموعة"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "حدد عنوانًا"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "نعم"
 
@@ -5438,6 +5447,11 @@ msgstr "تحرير الأعضاء"
 msgid "Stock on hand"
 msgstr "المخزون المتاح"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "تصفية حسب {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "اسم المتغير"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "إزالة"
 
@@ -5938,7 +5952,7 @@ msgstr "اللغة الافتراضية"
 msgid "Status"
 msgstr "الحالة"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "لم يتم العثور على خيارات"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "تحديد {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "المقاييس"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "اللغة"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "رقم الهاتف"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "خاص"
 

--- a/packages/dashboard/src/i18n/locales/bg.po
+++ b/packages/dashboard/src/i18n/locales/bg.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Изберете {0}"
@@ -365,7 +365,7 @@ msgid "Failed to create administrator"
 msgstr "Неуспешно създаване на администратор"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Не"
 
@@ -1078,7 +1078,7 @@ msgstr "Единичен вариант, без опции"
 msgid "Select the next state for the order"
 msgstr "Изберете следващото състояние за поръчката"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} избрани"
 
@@ -2013,9 +2013,9 @@ msgstr "Групи клиенти"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Забранено"
@@ -2734,6 +2734,11 @@ msgstr "Размер, цвят и т.н."
 msgid "Browse facets"
 msgstr "Преглед на атрибути"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2776,7 +2781,7 @@ msgstr "Запазване на изгледа"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} избрани"
 
@@ -3159,6 +3164,10 @@ msgstr "Успешно актуализирани стойности на атр
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Неуспешно премахване на клиент от групата"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3850,7 +3859,7 @@ msgid "Select an address"
 msgstr "Изберете адрес"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Да"
 
@@ -5467,6 +5476,11 @@ msgstr "Редакция на членове"
 msgid "Stock on hand"
 msgstr "Склад на ръка"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Филтриране по {columnId}"
@@ -5705,7 +5719,7 @@ msgstr "Име на варианта"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Премахнете"
 
@@ -5967,7 +5981,7 @@ msgstr "Език по подразбиране"
 msgid "Status"
 msgstr "Статус"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Не са намерени опции"
@@ -6079,7 +6093,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Изберете {0}s"
 
@@ -6284,6 +6298,10 @@ msgstr "Метрики"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Език"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -7012,8 +7030,8 @@ msgstr "Телефонен номер"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Частно"
 

--- a/packages/dashboard/src/i18n/locales/cs.po
+++ b/packages/dashboard/src/i18n/locales/cs.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Vybrat {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Vytvoření administrátora se nezdařilo"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Ne"
 
@@ -1072,7 +1072,7 @@ msgstr "Jedna varianta, bez voleb"
 msgid "Select the next state for the order"
 msgstr "Vyberte další stav pro objednávku"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} vybráno"
 
@@ -2001,9 +2001,9 @@ msgstr "Skupiny zákazníků"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Zakázáno"
@@ -2716,6 +2716,11 @@ msgstr "Velikost, barva atd."
 msgid "Browse facets"
 msgstr "Procházet fasety"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Uložit zobrazení"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} vybráno"
 
@@ -3139,6 +3144,10 @@ msgstr "Úspěšně aktualizovány hodnoty vlastností pro {entityIdsLength} {en
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Nepodařilo se odebrat zákazníka ze skupiny"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Vyberte adresu"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Ano"
 
@@ -5438,6 +5447,11 @@ msgstr "Upravit členy"
 msgid "Stock on hand"
 msgstr "Sklad na skladě"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filtrovat podle {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Název varianty"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Odebrat"
 
@@ -5938,7 +5952,7 @@ msgstr "Výchozí jazyk"
 msgid "Status"
 msgstr "Stav"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Nebyly nalezeny žádné možnosti"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Vybrat {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "Metriky"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Jazyk"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Telefonní číslo"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Soukromé"
 

--- a/packages/dashboard/src/i18n/locales/de.po
+++ b/packages/dashboard/src/i18n/locales/de.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "{0} auswählen"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Administrator konnte nicht erstellt werden"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Nein"
 
@@ -1072,7 +1072,7 @@ msgstr "Einzelvariante, keine Optionen"
 msgid "Select the next state for the order"
 msgstr "Nächsten Status für die Bestellung auswählen"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} ausgewählt"
 
@@ -2001,9 +2001,9 @@ msgstr "Kundengruppen"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Deaktiviert"
@@ -2716,6 +2716,11 @@ msgstr "Größe, Farbe usw."
 msgid "Browse facets"
 msgstr "Facetten durchsuchen"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Ansicht speichern"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} ausgewählt"
 
@@ -3139,6 +3144,10 @@ msgstr "Facettenwerte für {entityIdsLength} {entityType} erfolgreich aktualisie
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Fehler beim Entfernen des Kunden aus der Gruppe"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Eine Adresse auswählen"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Ja"
 
@@ -5438,6 +5447,11 @@ msgstr "Mitglieder bearbeiten"
 msgid "Stock on hand"
 msgstr "Lagerbestand"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Nach {columnId} filtern"
@@ -5676,7 +5690,7 @@ msgstr "Variantenname"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Entfernen"
 
@@ -5938,7 +5952,7 @@ msgstr "Standardsprache"
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Keine Optionen gefunden"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "{0} auswählen"
 
@@ -6252,6 +6266,10 @@ msgstr "Metriken"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Sprache"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Telefonnummer"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privat"
 

--- a/packages/dashboard/src/i18n/locales/en.po
+++ b/packages/dashboard/src/i18n/locales/en.po
@@ -186,7 +186,7 @@ msgstr "The default currency is chosen from this list."
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Select {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Failed to create administrator"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "No"
 
@@ -1072,7 +1072,7 @@ msgstr "Single variant, no options"
 msgid "Select the next state for the order"
 msgstr "Select the next state for the order"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} selected"
 
@@ -2001,9 +2001,9 @@ msgstr "Customer Groups"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Disabled"
@@ -2716,6 +2716,11 @@ msgstr "Size, colour, etc."
 msgid "Browse facets"
 msgstr "Browse facets"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr "{0} items"
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Save View"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} selected"
 
@@ -3139,6 +3144,10 @@ msgstr "Successfully updated facet values for {entityIdsLength} {entityType}"
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Failed to remove customer from group"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr "1 property"
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Select an address"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Yes"
 
@@ -5438,6 +5447,11 @@ msgstr "Edit members"
 msgid "Stock on hand"
 msgstr "Stock on hand"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr "{0} properties"
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filter by {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Variant name"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Remove"
 
@@ -5938,7 +5952,7 @@ msgstr "Default language"
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "No options found"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr "Inherit from global settings (Track)"
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Select {0}s"
 
@@ -6252,6 +6266,10 @@ msgstr "Metrics"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Language"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr "1 item"
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Phone number"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Private"
 

--- a/packages/dashboard/src/i18n/locales/es.po
+++ b/packages/dashboard/src/i18n/locales/es.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Seleccionar {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Error al crear el administrador"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "No"
 
@@ -1072,7 +1072,7 @@ msgstr "Variante única, sin opciones"
 msgid "Select the next state for the order"
 msgstr "Seleccione el siguiente estado del pedido"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} seleccionados"
 
@@ -2001,9 +2001,9 @@ msgstr "Grupos de clientes"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Deshabilitado"
@@ -2716,6 +2716,11 @@ msgstr "Tamaño, color, etc."
 msgid "Browse facets"
 msgstr "Explorar facetas"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Guardar vista"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} seleccionado(s)"
 
@@ -3139,6 +3144,10 @@ msgstr "Valores de faceta actualizados exitosamente para {entityIdsLength} {enti
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Error al quitar cliente del grupo"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Seleccione una dirección"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Sí"
 
@@ -5438,6 +5447,11 @@ msgstr "Editar miembros"
 msgid "Stock on hand"
 msgstr "Stock disponible"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filtrar por {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Nombre de la variante"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Quitar"
 
@@ -5938,7 +5952,7 @@ msgstr "Idioma predeterminado"
 msgid "Status"
 msgstr "Estado"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "No se encontraron opciones"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Seleccionar {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "Métricas"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Idioma"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Número de teléfono"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privado"
 

--- a/packages/dashboard/src/i18n/locales/fa.po
+++ b/packages/dashboard/src/i18n/locales/fa.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "انتخاب {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "ایجاد مدیر ناموفق بود"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "خیر"
 
@@ -1072,7 +1072,7 @@ msgstr "یک گونه، بدون گزینه"
 msgid "Select the next state for the order"
 msgstr "وضعیت بعدی را برای سفارش انتخاب کنید"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} انتخاب شده"
 
@@ -2001,9 +2001,9 @@ msgstr "گروه‌های مشتری"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "غیرفعال"
@@ -2716,6 +2716,11 @@ msgstr "اندازه، رنگ و غیره"
 msgid "Browse facets"
 msgstr "مرور فاست‌ها"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "ذخیره نما"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} انتخاب شده"
 
@@ -3139,6 +3144,10 @@ msgstr "مقادیر ویژگی برای {entityIdsLength} {entityType} با م�
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "حذف مشتری از گروه ناموفق بود"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "یک آدرس انتخاب کنید"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "بله"
 
@@ -5438,6 +5447,11 @@ msgstr "ویرایش اعضا"
 msgid "Stock on hand"
 msgstr "موجودی در دست"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "فیلتر بر اساس {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "نام نوع"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "حذف"
 
@@ -5938,7 +5952,7 @@ msgstr "زبان پیش‌فرض"
 msgid "Status"
 msgstr "وضعیت"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "هیچ گزینه‌ای یافت نشد"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "انتخاب {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "معیارها"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "زبان"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "شماره تلفن"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "خصوصی"
 

--- a/packages/dashboard/src/i18n/locales/fr.po
+++ b/packages/dashboard/src/i18n/locales/fr.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Sélectionner {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Échec de la création de l'administrateur"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Non"
 
@@ -1072,7 +1072,7 @@ msgstr "Variante unique, sans options"
 msgid "Select the next state for the order"
 msgstr "Sélectionnez l'état suivant pour la commande"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} sélectionnés"
 
@@ -2001,9 +2001,9 @@ msgstr "Groupes de clients"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Désactivé"
@@ -2716,6 +2716,11 @@ msgstr "Taille, couleur, etc."
 msgid "Browse facets"
 msgstr "Parcourir les facettes"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Enregistrer la vue"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} sélectionné(s)"
 
@@ -3139,6 +3144,10 @@ msgstr "Valeurs de facette mises à jour avec succès pour {entityIdsLength} {en
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Échec de la suppression du client du groupe"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Sélectionner une adresse"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Oui"
 
@@ -5438,6 +5447,11 @@ msgstr "Modifier les membres"
 msgid "Stock on hand"
 msgstr "Stock en main"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filtrer par {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Nom de la variante"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Supprimer"
 
@@ -5938,7 +5952,7 @@ msgstr "Langue par défaut"
 msgid "Status"
 msgstr "Statut"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Aucune option trouvée"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Sélectionner {0}s"
 
@@ -6252,6 +6266,10 @@ msgstr "Métriques"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Langue"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Numéro de téléphone"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privé"
 

--- a/packages/dashboard/src/i18n/locales/he.po
+++ b/packages/dashboard/src/i18n/locales/he.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "בחר {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "יצירת מנהל נכשלה"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "לא"
 
@@ -1072,7 +1072,7 @@ msgstr "גרסה אחת, ללא אפשרויות"
 msgid "Select the next state for the order"
 msgstr "בחר את המצב הבא להזמנה"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} נבחרו"
 
@@ -2001,9 +2001,9 @@ msgstr "קבוצות לקוחות"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "מושבת"
@@ -2716,6 +2716,11 @@ msgstr "גודל, צבע וכו'"
 msgid "Browse facets"
 msgstr "עיון בפאספטים"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "שמור תצוגה"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} נבחרו"
 
@@ -3139,6 +3144,10 @@ msgstr "ערכי המאפיינים עבור {entityIdsLength} {entityType} עו
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "הסרת הלקוח מהקבוצה נכשלה"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "בחר כתובת"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "כן"
 
@@ -5438,6 +5447,11 @@ msgstr "ערוך חברים"
 msgid "Stock on hand"
 msgstr "מלאי זמין"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "סנן לפי {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "שם הגרסה"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "הסר"
 
@@ -5938,7 +5952,7 @@ msgstr "שפת ברירת מחדל"
 msgid "Status"
 msgstr "סטטוס"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "לא נמצאו אפשרויות"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "בחר {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "מדדים"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "שפה"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "מספר טלפון"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "פרטי"
 

--- a/packages/dashboard/src/i18n/locales/hr.po
+++ b/packages/dashboard/src/i18n/locales/hr.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Odaberi {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Neuspješno kreiranje administratora"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Ne"
 
@@ -1072,7 +1072,7 @@ msgstr "Jedna varijanta, bez opcija"
 msgid "Select the next state for the order"
 msgstr "Odaberite sljedeće stanje za narudžbu"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} odabrano"
 
@@ -2001,9 +2001,9 @@ msgstr "Grupe kupaca"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Onemogućeno"
@@ -2716,6 +2716,11 @@ msgstr "Veličina, boja itd."
 msgid "Browse facets"
 msgstr "Pregledaj facete"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Spremi prikaz"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} odabrano"
 
@@ -3139,6 +3144,10 @@ msgstr "Vrijednosti svojstava uspješno ažurirane za {entityIdsLength} {entityT
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Uklanjanje kupca iz grupe nije uspjelo"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Odaberite adresu"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Da"
 
@@ -5438,6 +5447,11 @@ msgstr "Uredi članove"
 msgid "Stock on hand"
 msgstr "Zaliha na skladištu"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filtriraj po {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Naziv varijante"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Ukloni"
 
@@ -5938,7 +5952,7 @@ msgstr "Zadani jezik"
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Nema pronađenih opcija"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Odaberi {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "Metrike"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Jezik"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Telefonski broj"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privatno"
 

--- a/packages/dashboard/src/i18n/locales/hu.po
+++ b/packages/dashboard/src/i18n/locales/hu.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "{0} kiválasztása"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Rendszergazda létrehozása sikertelen"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Nem"
 
@@ -1072,7 +1072,7 @@ msgstr "Egyetlen variáns, opciók nélkül"
 msgid "Select the next state for the order"
 msgstr "Válassza ki a megrendelés következő állapotát"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} kijelölve"
 
@@ -2001,9 +2001,9 @@ msgstr "Vásárlói csoportok"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Letiltva"
@@ -2710,6 +2710,11 @@ msgstr "Méret, szín stb."
 msgid "Browse facets"
 msgstr "Tulajdonságok böngészése"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2752,7 +2757,7 @@ msgstr "Nézet mentése"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} kijelölve"
 
@@ -3129,6 +3134,10 @@ msgstr "{entityIdsLength} {entityType} tulajdonságértékei sikeresen frissítv
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Vásárló eltávolítása a csoportból sikertelen"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3820,7 +3829,7 @@ msgid "Select an address"
 msgstr "Válasszon egy címet"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Igen"
 
@@ -5425,6 +5434,11 @@ msgstr "Tagok szerkesztése"
 msgid "Stock on hand"
 msgstr "Aktuális készlet"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Szűrés: {columnId}"
@@ -5663,7 +5677,7 @@ msgstr "Termékváltozat neve"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Eltávolítás"
 
@@ -5925,7 +5939,7 @@ msgstr "Alapértelmezett nyelv"
 msgid "Status"
 msgstr "Státusz"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Nincs találat"
@@ -6034,7 +6048,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "{0} kiválasztása"
 
@@ -6239,6 +6253,10 @@ msgstr "Mutatók"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Nyelv"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6958,8 +6976,8 @@ msgstr "Telefonszám"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privát"
 

--- a/packages/dashboard/src/i18n/locales/it.po
+++ b/packages/dashboard/src/i18n/locales/it.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Seleziona {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Creazione amministratore non riuscita"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "No"
 
@@ -1072,7 +1072,7 @@ msgstr "Variante singola, senza opzioni"
 msgid "Select the next state for the order"
 msgstr "Seleziona lo stato successivo per l'ordine"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} selezionati"
 
@@ -2001,9 +2001,9 @@ msgstr "Gruppi clienti"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Disabilitato"
@@ -2716,6 +2716,11 @@ msgstr "Taglia, colore, ecc."
 msgid "Browse facets"
 msgstr "Sfoglia facet"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Salva vista"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} selezionati"
 
@@ -3139,6 +3144,10 @@ msgstr "Valori attributo aggiornati con successo per {entityIdsLength} {entityTy
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Impossibile rimuovere cliente dal gruppo"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Seleziona un indirizzo"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Sì"
 
@@ -5438,6 +5447,11 @@ msgstr "Modifica membri"
 msgid "Stock on hand"
 msgstr "Scorta disponibile"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filtra per {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Nome variante"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Rimuovi"
 
@@ -5938,7 +5952,7 @@ msgstr "Lingua predefinita"
 msgid "Status"
 msgstr "Stato"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Nessuna opzione trovata"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Seleziona {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "Metriche"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Lingua"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Numero di telefono"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privato"
 

--- a/packages/dashboard/src/i18n/locales/ja.po
+++ b/packages/dashboard/src/i18n/locales/ja.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "{0}を選択"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "管理者の作成に失敗しました"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "いいえ"
 
@@ -1072,7 +1072,7 @@ msgstr "単一バリエーション、オプションなし"
 msgid "Select the next state for the order"
 msgstr "注文の次の状態を選択"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count}件選択中"
 
@@ -2001,9 +2001,9 @@ msgstr "顧客グループ"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "無効"
@@ -2716,6 +2716,11 @@ msgstr "サイズ、カラーなど"
 msgid "Browse facets"
 msgstr "ファセットを参照"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "ビューを保存"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} 件選択中"
 
@@ -3139,6 +3144,10 @@ msgstr "{entityIdsLength}個の{entityType}のファセット値を更新しま�
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "グループからの顧客の削除に失敗しました"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "住所を選択"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "はい"
 
@@ -5438,6 +5447,11 @@ msgstr "メンバーを編集"
 msgid "Stock on hand"
 msgstr "手持ち在庫"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "{columnId}でフィルター"
@@ -5676,7 +5690,7 @@ msgstr "バリエーション名"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "削除"
 
@@ -5938,7 +5952,7 @@ msgstr "デフォルト言語"
 msgid "Status"
 msgstr "ステータス"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "オプションが見つかりません"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "{0}を選択"
 
@@ -6252,6 +6266,10 @@ msgstr "指標"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "言語"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "電話番号"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "非公開"
 

--- a/packages/dashboard/src/i18n/locales/nb.po
+++ b/packages/dashboard/src/i18n/locales/nb.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Velg {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Kunne ikke opprette administrator"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Nei"
 
@@ -1072,7 +1072,7 @@ msgstr "Enkel variant, ingen opsjoner"
 msgid "Select the next state for the order"
 msgstr "Velg neste tilstand for bestillingen"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} valgt"
 
@@ -2001,9 +2001,9 @@ msgstr "Kundegrupper"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Deaktivert"
@@ -2716,6 +2716,11 @@ msgstr "Størrelse, farge, osv."
 msgid "Browse facets"
 msgstr "Bla gjennom fasetter"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Lagre visning"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} valgt"
 
@@ -3139,6 +3144,10 @@ msgstr "Fasettverdier oppdatert for {entityIdsLength} {entityType}"
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Kunne ikke fjerne kunde fra gruppe"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Velg en adresse"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Ja"
 
@@ -5438,6 +5447,11 @@ msgstr "Rediger medlemmer"
 msgid "Stock on hand"
 msgstr "Lager på hånd"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filtrer etter {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Variantnavn"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Fjern"
 
@@ -5938,7 +5952,7 @@ msgstr "Standardspråk"
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Ingen alternativer funnet"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Velg {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "Beregninger"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Språk"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Telefonnummer"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privat"
 

--- a/packages/dashboard/src/i18n/locales/ne.po
+++ b/packages/dashboard/src/i18n/locales/ne.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "{0} चयन गर्नुहोस्"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "प्रशासक सिर्जना गर्न असफल"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "होइन"
 
@@ -1072,7 +1072,7 @@ msgstr "एकल भेरियन्ट, विकल्पहरू छै�
 msgid "Select the next state for the order"
 msgstr "अर्डरको लागि अर्को स्थिति चयन गर्नुहोस्"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} चयन गरिएको"
 
@@ -2001,9 +2001,9 @@ msgstr "ग्राहक समूहहरू"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "असक्षम"
@@ -2716,6 +2716,11 @@ msgstr "आकार, रङ, आदि"
 msgid "Browse facets"
 msgstr "फासेटहरू ब्राउज गर्नुहोस्"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "दृश्य सुरक्षित गर्नुहोस्"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} चयन गरियो"
 
@@ -3139,6 +3144,10 @@ msgstr "{entityIdsLength} {entityType} को लागि विशेषता
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "समूहबाट ग्राहक हटाउन असफल"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "ठेगाना चयन गर्नुहोस्"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "हो"
 
@@ -5438,6 +5447,11 @@ msgstr "सदस्यहरू सम्पादन गर्नुहोस�
 msgid "Stock on hand"
 msgstr "हातमा स्टक"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "{columnId} द्वारा फिल्टर गर्नुहोस्"
@@ -5676,7 +5690,7 @@ msgstr "भिन्नता नाम"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "हटाउनुहोस्"
 
@@ -5938,7 +5952,7 @@ msgstr "पूर्वनिर्धारित भाषा"
 msgid "Status"
 msgstr "स्थिति"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "कुनै विकल्प फेला परेन"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "{0} चयन गर्नुहोस्"
 
@@ -6252,6 +6266,10 @@ msgstr "मेट्रिक्स"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "भाषा"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "फोन नम्बर"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "निजी"
 

--- a/packages/dashboard/src/i18n/locales/nl.po
+++ b/packages/dashboard/src/i18n/locales/nl.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Selecteer {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Aanmaken van beheerder mislukt"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Nee"
 
@@ -1076,7 +1076,7 @@ msgstr "Enkele variant, geen opties"
 msgid "Select the next state for the order"
 msgstr "Selecteer de volgende status voor de bestelling"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} geselecteerd"
 
@@ -2005,9 +2005,9 @@ msgstr "Klantengroepen"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Uitgeschakeld"
@@ -2714,6 +2714,11 @@ msgstr "Maat, kleur, etc."
 msgid "Browse facets"
 msgstr "Facetten doorbladeren"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2756,7 +2761,7 @@ msgstr "Weergave opslaan"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} geselecteerd"
 
@@ -3133,6 +3138,10 @@ msgstr "Facetwaarden succesvol bijgewerkt voor {entityIdsLength} {entityType}"
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Klant uit groep verwijderen mislukt"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3824,7 +3833,7 @@ msgid "Select an address"
 msgstr "Selecteer een adres"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Ja"
 
@@ -5433,6 +5442,11 @@ msgstr "Leden bewerken"
 msgid "Stock on hand"
 msgstr "Voorraad op voorraad"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filteren op {columnId}"
@@ -5671,7 +5685,7 @@ msgstr "Variantnaam"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Verwijderen"
 
@@ -5933,7 +5947,7 @@ msgstr "Standaardtaal"
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Geen opties gevonden"
@@ -6042,7 +6056,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Selecteer {0}"
 
@@ -6247,6 +6261,10 @@ msgstr "Statistieken"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Taal"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6970,8 +6988,8 @@ msgstr "Telefoonnummer"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privé"
 

--- a/packages/dashboard/src/i18n/locales/pl.po
+++ b/packages/dashboard/src/i18n/locales/pl.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Wybierz {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Nie udało się utworzyć administratora"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Nie"
 
@@ -1072,7 +1072,7 @@ msgstr "Pojedynczy wariant, bez opcji"
 msgid "Select the next state for the order"
 msgstr "Wybierz następny stan dla zamówienia"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "Wybrano: {count}"
 
@@ -2001,9 +2001,9 @@ msgstr "Grupy klientów"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Wyłączono"
@@ -2716,6 +2716,11 @@ msgstr "Rozmiar, kolor itp."
 msgid "Browse facets"
 msgstr "Przeglądaj fasety"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Zapisz widok"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} wybranych"
 
@@ -3139,6 +3144,10 @@ msgstr "Pomyślnie zaktualizowano wartości aspektów dla {entityIdsLength} {ent
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Nie udało się usunąć klienta z grupy"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Wybierz adres"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Tak"
 
@@ -5438,6 +5447,11 @@ msgstr "Edytuj członków"
 msgid "Stock on hand"
 msgstr "Stan magazynowy"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filtruj według {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Nazwa wariantu"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Usuń"
 
@@ -5938,7 +5952,7 @@ msgstr "Domyślny język"
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Nie znaleziono opcji"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Wybierz {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "Metryki"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Język"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Numer telefonu"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Prywatne"
 

--- a/packages/dashboard/src/i18n/locales/pt_BR.po
+++ b/packages/dashboard/src/i18n/locales/pt_BR.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Selecionar {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Falha ao criar administrador"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Nao"
 
@@ -1072,7 +1072,7 @@ msgstr "Variante unica, sem opcoes"
 msgid "Select the next state for the order"
 msgstr "Selecione o próximo estado para o pedido"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} selecionados"
 
@@ -2001,9 +2001,9 @@ msgstr "Grupos de clientes"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Desabilitado"
@@ -2716,6 +2716,11 @@ msgstr "Tamanho, cor, etc."
 msgid "Browse facets"
 msgstr "Navegar por facetas"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Salvar visualização"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} selecionados"
 
@@ -3139,6 +3144,10 @@ msgstr "Valores de faceta atualizados com sucesso para {entityIdsLength} {entity
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Falha ao remover cliente do grupo"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Selecione um endereço"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Sim"
 
@@ -5438,6 +5447,11 @@ msgstr "Editar membros"
 msgid "Stock on hand"
 msgstr "Estoque disponível"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filtrar por {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Nome da variante"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Remover"
 
@@ -5938,7 +5952,7 @@ msgstr "Idioma padrão"
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Nenhuma opção encontrada"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Selecionar {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "Métricas"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Idioma"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Número de telefone"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privado"
 

--- a/packages/dashboard/src/i18n/locales/pt_PT.po
+++ b/packages/dashboard/src/i18n/locales/pt_PT.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Selecionar {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Falha ao criar administrador"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Nao"
 
@@ -1072,7 +1072,7 @@ msgstr "Variante unica, sem opcoes"
 msgid "Select the next state for the order"
 msgstr "Selecione o próximo estado para a encomenda"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} selecionados"
 
@@ -2001,9 +2001,9 @@ msgstr "Grupos de clientes"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Desativado"
@@ -2716,6 +2716,11 @@ msgstr "Tamanho, cor, etc."
 msgid "Browse facets"
 msgstr "Explorar facetas"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Guardar vista"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} selecionados"
 
@@ -3139,6 +3144,10 @@ msgstr "Valores de faceta atualizados com sucesso para {entityIdsLength} {entity
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Falha ao remover cliente do grupo"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Selecione uma morada"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Sim"
 
@@ -5438,6 +5447,11 @@ msgstr "Editar membros"
 msgid "Stock on hand"
 msgstr "Stock disponível"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filtrar por {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Nome da variante"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Remover"
 
@@ -5938,7 +5952,7 @@ msgstr "Idioma predefinido"
 msgid "Status"
 msgstr "Estado"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Nenhuma opção encontrada"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Selecionar {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "Métricas"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Idioma"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Número de telefone"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privado"
 

--- a/packages/dashboard/src/i18n/locales/ro.po
+++ b/packages/dashboard/src/i18n/locales/ro.po
@@ -182,7 +182,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Selectează {0}"
@@ -338,7 +338,7 @@ msgid "Failed to create administrator"
 msgstr "Nu s-a putut crea administratorul"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Nu"
 
@@ -1044,7 +1044,7 @@ msgstr "Variantă unică, fără opțiuni"
 msgid "Select the next state for the order"
 msgstr "Selectează statusul următor pentru comandă"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} selectate"
 
@@ -1940,9 +1940,9 @@ msgstr "Grupuri de clienți"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Dezactivat"
@@ -2649,6 +2649,11 @@ msgstr "Mărime, culoare etc."
 msgid "Browse facets"
 msgstr "Caută atribute"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2691,7 +2696,7 @@ msgstr "Salvează vizualizarea"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} selectate"
 
@@ -3055,6 +3060,10 @@ msgstr "Valorile atributului au fost actualizate cu succes pentru {entityIdsLeng
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Nu s-a putut elimina clientul din grup"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3738,7 +3747,7 @@ msgid "Select an address"
 msgstr "Selectează o adresă"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Da"
 
@@ -5286,6 +5295,11 @@ msgstr "Editează membri"
 msgid "Stock on hand"
 msgstr "Stoc disponibil"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filtrează după {columnId}"
@@ -5512,7 +5526,7 @@ msgstr "Nume variantă"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Elimină"
 
@@ -5758,7 +5772,7 @@ msgstr "Limbă implicită"
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Nu au fost găsite opțiuni"
@@ -5863,7 +5877,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Selectează {0}"
 
@@ -6064,6 +6078,10 @@ msgstr "Metrici"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Limbă"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6767,8 +6785,8 @@ msgstr "Număr de telefon"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privat"
 

--- a/packages/dashboard/src/i18n/locales/ru.po
+++ b/packages/dashboard/src/i18n/locales/ru.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Выбрать {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Не удалось создать администратора"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Нет"
 
@@ -1072,7 +1072,7 @@ msgstr "Один вариант, без опций"
 msgid "Select the next state for the order"
 msgstr "Выберите следующее состояние для заказа"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "Выбрано: {count}"
 
@@ -2001,9 +2001,9 @@ msgstr "Группы клиентов"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Отключено"
@@ -2716,6 +2716,11 @@ msgstr "Размер, цвет и т.д."
 msgid "Browse facets"
 msgstr "Просмотр фасетов"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Сохранить вид"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} выбрано"
 
@@ -3139,6 +3144,10 @@ msgstr "Значения фасета успешно обновлены для {
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Не удалось удалить клиента из группы"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Выберите адрес"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Да"
 
@@ -5438,6 +5447,11 @@ msgstr "Редактировать участников"
 msgid "Stock on hand"
 msgstr "Запас в наличии"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Фильтровать по {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Название варианта"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Удалить"
 
@@ -5938,7 +5952,7 @@ msgstr "Язык по умолчанию"
 msgid "Status"
 msgstr "Статус"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Опции не найдены"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Выбрать {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "Метрики"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Язык"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Номер телефона"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Приватное"
 

--- a/packages/dashboard/src/i18n/locales/sv.po
+++ b/packages/dashboard/src/i18n/locales/sv.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Välj {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Misslyckades med att skapa administratör"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Nej"
 
@@ -1072,7 +1072,7 @@ msgstr "En variant, inga alternativ"
 msgid "Select the next state for the order"
 msgstr "Välj nästa status för beställningen"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} valda"
 
@@ -2001,9 +2001,9 @@ msgstr "Kundgrupper"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Inaktiverad"
@@ -2716,6 +2716,11 @@ msgstr "Storlek, färg etc."
 msgid "Browse facets"
 msgstr "Bläddra bland fasetter"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Spara vy"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} valda"
 
@@ -3139,6 +3144,10 @@ msgstr "Facettvärden uppdaterade för {entityIdsLength} {entityType}"
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Misslyckades att ta bort kund från grupp"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Välj en adress"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Ja"
 
@@ -5438,6 +5447,11 @@ msgstr "Redigera medlemmar"
 msgid "Stock on hand"
 msgstr "Lager tillgängligt"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Filtrera efter {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Variantnamn"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Ta bort"
 
@@ -5938,7 +5952,7 @@ msgstr "Standardspråk"
 msgid "Status"
 msgstr "Status"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Inga alternativ hittades"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Välj {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "Mätvärden"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Språk"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Telefonnummer"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Privat"
 

--- a/packages/dashboard/src/i18n/locales/tr.po
+++ b/packages/dashboard/src/i18n/locales/tr.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "{0} seç"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Yönetici oluşturulamadı"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Hayır"
 
@@ -1072,7 +1072,7 @@ msgstr "Tek varyant, seçenek yok"
 msgid "Select the next state for the order"
 msgstr "Sipariş için sonraki durumu seçin"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} seçildi"
 
@@ -2001,9 +2001,9 @@ msgstr "Müşteri Grupları"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Devre dışı"
@@ -2716,6 +2716,11 @@ msgstr "Boyut, renk, vb."
 msgid "Browse facets"
 msgstr "Fasetlere göz at"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Görünümü Kaydet"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} seçildi"
 
@@ -3139,6 +3144,10 @@ msgstr "{entityIdsLength} {entityType} için özellik değerleri başarıyla gü
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Müşteri gruptan kaldırılamadı"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Bir adres seçin"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Evet"
 
@@ -5438,6 +5447,11 @@ msgstr "Üyeleri düzenle"
 msgid "Stock on hand"
 msgstr "Eldeki stok"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "{columnId} ile filtrele"
@@ -5676,7 +5690,7 @@ msgstr "Varyant adı"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Kaldır"
 
@@ -5938,7 +5952,7 @@ msgstr "Varsayılan dil"
 msgid "Status"
 msgstr "Durum"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Seçenek bulunamadı"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "{0} seç"
 
@@ -6252,6 +6266,10 @@ msgstr "Metrikler"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Dil"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Telefon numarası"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Özel"
 

--- a/packages/dashboard/src/i18n/locales/uk.po
+++ b/packages/dashboard/src/i18n/locales/uk.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "Вибрати {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "Не вдалося створити адміністратора"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Ні"
 
@@ -1072,7 +1072,7 @@ msgstr "Один варіант, без опцій"
 msgid "Select the next state for the order"
 msgstr "Виберіть наступний стан для замовлення"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "Вибрано: {count}"
 
@@ -2001,9 +2001,9 @@ msgstr "Групи клієнтів"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "Вимкнено"
@@ -2716,6 +2716,11 @@ msgstr "Розмір, колір тощо"
 msgid "Browse facets"
 msgstr "Перегляд фасетів"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "Зберегти вигляд"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} вибрано"
 
@@ -3139,6 +3144,10 @@ msgstr "Значення фасетів успішно оновлено для {
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Не вдалося видалити клієнта з групи"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "Виберіть адресу"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Так"
 
@@ -5438,6 +5447,11 @@ msgstr "Редагувати учасників"
 msgid "Stock on hand"
 msgstr "Запас у наявності"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "Фільтрувати за {columnId}"
@@ -5676,7 +5690,7 @@ msgstr "Назва варіанта"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Видалити"
 
@@ -5938,7 +5952,7 @@ msgstr "Мова за замовчуванням"
 msgid "Status"
 msgstr "Статус"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Опцій не знайдено"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "Вибрати {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "Метрики"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Мова"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "Номер телефону"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Приватне"
 

--- a/packages/dashboard/src/i18n/locales/uz.po
+++ b/packages/dashboard/src/i18n/locales/uz.po
@@ -182,7 +182,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "{0} ni tanlang"
@@ -338,7 +338,7 @@ msgid "Failed to create administrator"
 msgstr "Administrator yaratib bo'lmadi"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "Yo'q"
 
@@ -1044,7 +1044,7 @@ msgstr "Yagona variant, optsiyalarsiz"
 msgid "Select the next state for the order"
 msgstr "Buyurtma uchun keyingi holatni tanlang"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "{count} ta tanlandi"
 
@@ -1940,9 +1940,9 @@ msgstr "Mijozlar guruhlari"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "O'chirilgan"
@@ -2649,6 +2649,11 @@ msgstr "O'lcham, rang va h.k."
 msgid "Browse facets"
 msgstr "Fasetlarni ko'rib chiqish"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2691,7 +2696,7 @@ msgstr "Ko'rinishni saqlash"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "{0} tanlangan"
 
@@ -3055,6 +3060,10 @@ msgstr "{entityIdsLength} {entityType} uchun faset qiymatlari yangilandi"
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "Mijozni guruhdan olib tashlab boʻlmadi"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3738,7 +3747,7 @@ msgid "Select an address"
 msgstr "Manzilni tanlang"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "Ha"
 
@@ -5286,6 +5295,11 @@ msgstr "A'zolarni tahrirlash"
 msgid "Stock on hand"
 msgstr "Mavjud zaxira"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "{columnId} bo'yicha filtrlash"
@@ -5512,7 +5526,7 @@ msgstr "Variant nomi"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "Olib tashlash"
 
@@ -5758,7 +5772,7 @@ msgstr "Standart til"
 msgid "Status"
 msgstr "Holat"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "Variantlar topilmadi"
@@ -5863,7 +5877,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "{0} larni tanlang"
 
@@ -6064,6 +6078,10 @@ msgstr "Metrikalar"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "Til"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6767,8 +6785,8 @@ msgstr "Telefon raqami"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "Maxfiy"
 

--- a/packages/dashboard/src/i18n/locales/zh_Hans.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hans.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "选择 {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "创建管理员失败"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "否"
 
@@ -1072,7 +1072,7 @@ msgstr "单一变体，无选项"
 msgid "Select the next state for the order"
 msgstr "选择订单的下一个状态"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "已选择 {count} 项"
 
@@ -2001,9 +2001,9 @@ msgstr "客户组"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "已禁用"
@@ -2716,6 +2716,11 @@ msgstr "大小、颜色等"
 msgid "Browse facets"
 msgstr "浏览分面"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "保存视图"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "已选择 {0} 个"
 
@@ -3139,6 +3144,10 @@ msgstr "已成功为 {entityIdsLength} {entityType} 更新属性值"
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "从组中删除客户失败"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "选择一个地址"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "是"
 
@@ -5438,6 +5447,11 @@ msgstr "编辑成员"
 msgid "Stock on hand"
 msgstr "现有库存"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "按 {columnId} 筛选"
@@ -5676,7 +5690,7 @@ msgstr "变体名称"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "删除"
 
@@ -5938,7 +5952,7 @@ msgstr "默认语言"
 msgid "Status"
 msgstr "状态"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "未找到选项"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "选择 {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "指标"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "语言"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "电话号码"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "私有"
 

--- a/packages/dashboard/src/i18n/locales/zh_Hant.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hant.po
@@ -186,7 +186,7 @@ msgstr ""
 #. placeholder {0}: entityName.toLowerCase()
 #. placeholder {0}: group.name
 #: src/app/routes/_authenticated/_products/components/product-option-select.tsx:57
-#: src/lib/components/data-input/default-relation-input.tsx:671
+#: src/lib/components/data-input/default-relation-input.tsx:674
 #: src/lib/components/shared/asset/asset-gallery.tsx:976
 msgid "Select {0}"
 msgstr "選取 {0}"
@@ -362,7 +362,7 @@ msgid "Failed to create administrator"
 msgstr "建立管理員失敗"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:402
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "No"
 msgstr "否"
 
@@ -1072,7 +1072,7 @@ msgstr "單一變體，無選項"
 msgid "Select the next state for the order"
 msgstr "選取訂單的下一個狀態"
 
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:200
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:334
 msgid "{count} selected"
 msgstr "已選取 {count} 項"
 
@@ -2001,9 +2001,9 @@ msgstr "客戶群組"
 #: src/app/routes/_authenticated/_system/scheduled-tasks.tsx:139
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:59
 #: src/lib/components/data-display/boolean.tsx:22
-#: src/lib/components/data-input/default-relation-input.tsx:214
-#: src/lib/components/data-input/default-relation-input.tsx:445
-#: src/lib/components/data-input/default-relation-input.tsx:536
+#: src/lib/components/data-input/default-relation-input.tsx:217
+#: src/lib/components/data-input/default-relation-input.tsx:448
+#: src/lib/components/data-input/default-relation-input.tsx:539
 #: src/lib/components/layout/nav-user.tsx:149
 msgid "Disabled"
 msgstr "已停用"
@@ -2716,6 +2716,11 @@ msgstr "大小、顏色等"
 msgid "Browse facets"
 msgstr "瀏覽分面"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "{0} items"
+msgstr ""
+
 #: src/app/routes/_authenticated/_tax-rates/tax-rates_.$id.tsx:135
 #: src/app/routes/_authenticated/_tax-rates/tax-rates.tsx:73
 msgid "Zone"
@@ -2758,7 +2763,7 @@ msgstr "儲存檢視"
 #: src/lib/components/data-table/data-table-bulk-actions.tsx:91
 #: src/lib/components/data-table/data-table-facet-value-faceted-filter.tsx:137
 #: src/lib/components/data-table/data-table-faceted-filter.tsx:139
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:67
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:94
 msgid "{0} selected"
 msgstr "已選取 {0} 個"
 
@@ -3139,6 +3144,10 @@ msgstr "已成功為 {entityIdsLength} {entityType} 更新屬性值"
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx:148
 msgid "Failed to remove customer from group"
 msgstr "從群組中移除客戶失敗"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "1 property"
+msgstr ""
 
 #: src/lib/components/layout/nav-user.tsx:129
 msgctxt "theme"
@@ -3830,7 +3839,7 @@ msgid "Select an address"
 msgstr "選取一個地址"
 
 #: src/app/routes/_authenticated/_system/settings-store.tsx:401
-#: src/lib/components/shared/configurable-operation-arg-summary.tsx:71
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:98
 msgid "Yes"
 msgstr "是"
 
@@ -5438,6 +5447,11 @@ msgstr "編輯成員"
 msgid "Stock on hand"
 msgstr "現有庫存"
 
+#. placeholder {0}: summary.count
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:181
+msgid "{0} properties"
+msgstr ""
+
 #: src/lib/components/data-table/data-table-filter-dialog.tsx:55
 msgid "Filter by {columnId}"
 msgstr "按 {columnId} 篩選"
@@ -5676,7 +5690,7 @@ msgstr "變體名稱"
 
 #: src/app/routes/_authenticated/_orders/orders_.draft.$id.tsx:580
 #: src/app/routes/_authenticated/_profile/profile.tsx:203
-#: src/lib/components/shared/configurable-operation-input.tsx:117
+#: src/lib/components/shared/configurable-operation-input.tsx:120
 msgid "Remove"
 msgstr "移除"
 
@@ -5938,7 +5952,7 @@ msgstr "預設語言"
 msgid "Status"
 msgstr "狀態"
 
-#: src/lib/components/shared/configurable-operation-multi-selector.tsx:320
+#: src/lib/components/shared/configurable-operation-multi-selector.tsx:327
 #: src/lib/components/shared/configurable-operation-selector.tsx:155
 msgid "No options found"
 msgstr "找不到選項"
@@ -6047,7 +6061,7 @@ msgid "Inherit from global settings (Track)"
 msgstr ""
 
 #. placeholder {0}: entityName.toLowerCase()
-#: src/lib/components/data-input/default-relation-input.tsx:658
+#: src/lib/components/data-input/default-relation-input.tsx:661
 msgid "Select {0}s"
 msgstr "選取 {0}"
 
@@ -6252,6 +6266,10 @@ msgstr "指標"
 #: src/lib/components/layout/nav-user.tsx:106
 msgid "Language"
 msgstr "語言"
+
+#: src/lib/components/shared/configurable-operation-arg-summary.tsx:178
+msgid "1 item"
+msgstr ""
 
 #: src/app/routes/_authenticated/_collections/collections.tsx:583
 msgid "New Collection"
@@ -6975,8 +6993,8 @@ msgstr "電話號碼"
 
 #: src/app/routes/_authenticated/_collections/collections_.$id.tsx:180
 #: src/app/routes/_authenticated/_facets/facets_.$id.tsx:109
-#: src/lib/components/data-input/default-relation-input.tsx:247
-#: src/lib/components/data-input/default-relation-input.tsx:277
+#: src/lib/components/data-input/default-relation-input.tsx:250
+#: src/lib/components/data-input/default-relation-input.tsx:280
 msgid "Private"
 msgstr "私人"
 

--- a/packages/dashboard/src/lib/components/data-input/affixed-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/affixed-input.tsx
@@ -28,8 +28,14 @@ export type AffixedInputProps = Omit<React.InputHTMLAttributes<HTMLInputElement>
  * @docsCategory form-components
  * @docsPage AffixedInput
  */
-export function AffixedInput({ prefix, suffix, className = '', ...props }: Readonly<AffixedInputProps>) {
-    const readOnly = props.disabled || isReadonlyField(props.fieldDef);
+export function AffixedInput({
+    prefix,
+    suffix,
+    className = '',
+    fieldDef,
+    ...inputProps
+}: Readonly<AffixedInputProps>) {
+    const readOnly = inputProps.disabled || isReadonlyField(fieldDef);
     const prefixRef = useRef<HTMLSpanElement>(null);
     const suffixRef = useRef<HTMLSpanElement>(null);
     const [prefixWidth, setPrefixWidth] = useState(0);
@@ -44,7 +50,7 @@ export function AffixedInput({ prefix, suffix, className = '', ...props }: Reado
         }
     }, [prefix, suffix]);
 
-    const style = {
+    const affixStyle = {
         paddingLeft: prefix ? `calc(1rem + ${prefixWidth}px)` : undefined,
         paddingRight: suffix ? `calc(1rem + ${suffixWidth}px)` : undefined,
     };
@@ -57,19 +63,10 @@ export function AffixedInput({ prefix, suffix, className = '', ...props }: Reado
                 </span>
             )}
             <Input
-                value={props.value}
-                onChange={props.onChange}
-                onBlur={props.onBlur}
-                onFocus={props.onFocus}
-                onKeyDown={props.onKeyDown}
-                type={props.type}
-                ref={props.ref}
+                {...inputProps}
                 className={className}
-                style={style}
+                style={{ ...inputProps.style, ...affixStyle }}
                 disabled={readOnly}
-                min={props.min}
-                max={props.max}
-                step={props.step}
             />
             {suffix && (
                 <span ref={suffixRef} className="absolute right-3 text-muted-foreground whitespace-nowrap">

--- a/packages/dashboard/src/lib/components/data-input/text-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/text-input.tsx
@@ -1,4 +1,4 @@
-// Simple built-in components using the single DashboardFormComponent interface
+import { AffixedInput } from '@/vdb/components/data-input/affixed-input.js';
 import { Input } from '@/vdb/components/ui/input.js';
 import { DashboardFormComponent } from '@/vdb/framework/form-engine/form-engine-types.js';
 import { isFieldDisabled } from '@/vdb/framework/form-engine/utils.js';
@@ -12,5 +12,22 @@ import { isFieldDisabled } from '@/vdb/framework/form-engine/utils.js';
  */
 export const TextInput: DashboardFormComponent = ({ value, onChange, fieldDef, disabled, ...rest }) => {
     const readOnly = isFieldDisabled(disabled, fieldDef);
-    return <Input value={value ?? ''} onChange={e => onChange(e.target.value)} disabled={readOnly} {...rest} />;
+    const prefix = fieldDef?.ui?.prefix;
+    const suffix = fieldDef?.ui?.suffix;
+    if (prefix || suffix) {
+        return (
+            <AffixedInput
+                {...rest}
+                fieldDef={fieldDef}
+                value={value ?? ''}
+                onChange={event => onChange(event.target.value)}
+                disabled={readOnly}
+                prefix={prefix}
+                suffix={suffix}
+            />
+        );
+    }
+    return (
+        <Input value={value ?? ''} onChange={e => onChange(e.target.value)} disabled={readOnly} {...rest} />
+    );
 };

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-arg-summary.spec.ts
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-arg-summary.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+    compactText,
+    getJsonSummary,
+    shouldUseListCountSummary,
+} from './configurable-operation-arg-summary.js';
+
+describe('shouldUseListCountSummary', () => {
+    it('uses a count when a scalar component is wrapped for a list field', () => {
+        expect(shouldUseListCountSummary(true, [100, 200], undefined)).toBe(true);
+    });
+
+    it('keeps semantic summaries for list-aware components', () => {
+        expect(shouldUseListCountSummary(true, ['1', '2'], true)).toBe(false);
+        expect(shouldUseListCountSummary(true, ['1', '2'], 'dynamic')).toBe(false);
+    });
+});
+
+describe('compactText', () => {
+    it('strips HTML and normalizes whitespace', () => {
+        expect(
+            compactText(
+                '<style>.hidden { display: none }</style><p>Hello <strong>world</strong></p><p>Next</p>',
+            ).full,
+        ).toBe('Hello world Next');
+    });
+
+    it('truncates long content for sentence chips', () => {
+        const result = compactText('a'.repeat(100));
+        expect(result.compact).toHaveLength(80);
+        expect(result.compact.endsWith('\u2026')).toBe(true);
+    });
+});
+
+describe('getJsonSummary', () => {
+    it('summarizes arrays and objects', () => {
+        expect(getJsonSummary('[1, 2, 3]')).toEqual({ type: 'items', count: 3 });
+        expect(getJsonSummary('{"one": 1, "two": 2}')).toEqual({ type: 'properties', count: 2 });
+    });
+
+    it('uses compact text for invalid JSON', () => {
+        expect(getJsonSummary('not json')).toEqual({ type: 'text', value: 'not json' });
+    });
+});

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-arg-summary.tsx
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-arg-summary.tsx
@@ -7,6 +7,7 @@ import { extractFieldOptions } from '@/vdb/framework/form-engine/utils.js';
 import { transformValue } from '@/vdb/framework/form-engine/value-transformers.js';
 import { api } from '@/vdb/graphql/api.js';
 import { graphql } from '@/vdb/graphql/graphql.js';
+import { useChannel } from '@/vdb/hooks/use-channel.js';
 import { useLocalFormat } from '@/vdb/hooks/use-local-format.js';
 import { useUserSettings } from '@/vdb/hooks/use-user-settings.js';
 import { useLingui } from '@lingui/react/macro';
@@ -33,6 +34,17 @@ export interface ArgSummaryProps {
     fieldDef: ConfigurableFieldDef;
     /** The raw json-string encoded arg value */
     value: string;
+    omitPrefix?: boolean;
+    omitSuffix?: boolean;
+}
+
+export function shouldUseListCountSummary(
+    isListField: boolean,
+    value: unknown,
+    listInputMode: boolean | 'dynamic' | undefined,
+): boolean {
+    const componentHandlesList = listInputMode === true || listInputMode === 'dynamic';
+    return isListField && Array.isArray(value) && !componentHandlesList;
 }
 
 /**
@@ -47,17 +59,32 @@ export interface ArgSummaryProps {
  * 3. A default summary based on the arg type (boolean, datetime, list count,
  *    plain value)
  */
-export function ArgSummary({ fieldDef, value }: Readonly<ArgSummaryProps>) {
+export function ArgSummary({ fieldDef, value, omitPrefix, omitSuffix }: Readonly<ArgSummaryProps>) {
     const componentId = fieldDef.ui?.component as string | undefined;
     const CustomComponent = getInputComponent(componentId);
     const parsedValue = transformValue(value, fieldDef, 'json-string', 'parse');
+    const isListValue = fieldDef.list === true && Array.isArray(parsedValue);
+    const listInputMode = CustomComponent?.metadata?.isListInput;
+    const useListCountSummary = shouldUseListCountSummary(fieldDef.list, parsedValue, listInputMode);
 
-    const Summary =
-        CustomComponent?.metadata?.summary ??
-        (componentId ? BUILT_IN_SUMMARIES[componentId] : undefined) ??
-        DefaultArgSummary;
+    const Summary = useListCountSummary
+        ? DefaultArgSummary
+        : (CustomComponent?.metadata?.summary ??
+          (componentId ? BUILT_IN_SUMMARIES[componentId] : undefined) ??
+          DefaultArgSummary);
 
-    return <Summary value={parsedValue} fieldDef={fieldDef} />;
+    const isAffixedComponent =
+        !isListValue && (componentId === 'number-form-input' || componentId === 'text-form-input');
+    const prefix = isAffixedComponent && !omitPrefix ? fieldDef.ui?.prefix : undefined;
+    const suffix = isAffixedComponent && !omitSuffix ? fieldDef.ui?.suffix : undefined;
+
+    return (
+        <>
+            {prefix}
+            <Summary value={parsedValue} fieldDef={fieldDef} />
+            {suffix}
+        </>
+    );
 }
 
 function DefaultArgSummary({ value, fieldDef }: Readonly<DashboardFormComponentSummaryProps>) {
@@ -77,8 +104,83 @@ function DefaultArgSummary({ value, fieldDef }: Readonly<DashboardFormComponentS
 }
 
 function CurrencySummary({ value }: Readonly<DashboardFormComponentSummaryProps>) {
-    const { toMajorUnits, formatNumber } = useLocalFormat();
-    return <>{formatNumber(toMajorUnits(Number(value)))}</>;
+    const { activeChannel } = useChannel();
+    const { formatCurrency, toMajorUnits, formatNumber } = useLocalFormat();
+    const currencyCode = activeChannel?.defaultCurrencyCode;
+    return (
+        <>
+            {currencyCode
+                ? formatCurrency(Number(value), currencyCode)
+                : formatNumber(toMajorUnits(Number(value)))}
+        </>
+    );
+}
+
+function PasswordSummary() {
+    return <>{'\u2022'.repeat(8)}</>;
+}
+
+const MAX_TEXT_SUMMARY_LENGTH = 80;
+
+export function compactText(value: unknown): { full: string; compact: string } {
+    const raw = String(value ?? '')
+        .replace(/<(script|style)[^>]*>[\s\S]*?<\/\1>/gi, '')
+        .replace(
+            /<\/(address|article|aside|blockquote|div|figcaption|figure|footer|header|h[1-6]|li|main|nav|ol|p|pre|section|table|tr|ul)>/gi,
+            ' ',
+        );
+    let plainText: string;
+    if (typeof DOMParser === 'undefined') {
+        plainText = raw.replace(/<[^>]*>/g, ' ');
+    } else {
+        plainText = new DOMParser().parseFromString(raw, 'text/html').body.textContent ?? '';
+    }
+    const full = plainText.replace(/\s+/g, ' ').trim();
+    const compact =
+        full.length > MAX_TEXT_SUMMARY_LENGTH
+            ? `${full.slice(0, MAX_TEXT_SUMMARY_LENGTH - 1).trimEnd()}\u2026`
+            : full;
+    return { full, compact };
+}
+
+function RichTextSummary({ value }: Readonly<DashboardFormComponentSummaryProps>) {
+    const { full, compact } = compactText(value);
+    return <span title={full}>{compact}</span>;
+}
+
+export type JsonSummary =
+    | { type: 'items'; count: number }
+    | { type: 'properties'; count: number }
+    | { type: 'text'; value: string };
+
+export function getJsonSummary(value: unknown): JsonSummary {
+    let parsed = value;
+    if (typeof value === 'string') {
+        try {
+            parsed = JSON.parse(value);
+        } catch {
+            return { type: 'text', value: compactText(value).compact };
+        }
+    }
+    if (Array.isArray(parsed)) {
+        return { type: 'items', count: parsed.length };
+    }
+    if (parsed !== null && typeof parsed === 'object') {
+        return { type: 'properties', count: Object.keys(parsed).length };
+    }
+    return { type: 'text', value: String(parsed) };
+}
+
+function JsonSummary({ value }: Readonly<DashboardFormComponentSummaryProps>) {
+    const { t } = useLingui();
+    const summary = getJsonSummary(value);
+    if (summary.type === 'items') {
+        return <>{summary.count === 1 ? t`1 item` : t`${summary.count} items`}</>;
+    }
+    if (summary.type === 'properties') {
+        return <>{summary.count === 1 ? t`1 property` : t`${summary.count} properties`}</>;
+    }
+    return <>{summary.value}</>;
 }
 
 function SelectOptionsSummary({ value, fieldDef }: Readonly<DashboardFormComponentSummaryProps>) {
@@ -143,8 +245,7 @@ function ProductVariantSummary({ value }: Readonly<DashboardFormComponentSummary
     const ids = toIdArray(value);
     const { data } = useQuery({
         queryKey: ['ProductVariantSummary', ids],
-        queryFn: () =>
-            api.query(productVariantSummaryDocument, { options: { filter: { id: { in: ids } } } }),
+        queryFn: () => api.query(productVariantSummaryDocument, { options: { filter: { id: { in: ids } } } }),
         enabled: ids.length > 0,
         placeholderData: undefined,
     });
@@ -153,6 +254,40 @@ function ProductVariantSummary({ value }: Readonly<DashboardFormComponentSummary
         return <EntityCountFallback count={ids.length} />;
     }
     return <NameList names={items.map(item => item.name)} />;
+}
+
+const productSummaryDocument = graphql(`
+    query ProductSummary($options: ProductListOptions) {
+        products(options: $options) {
+            items {
+                id
+                name
+            }
+        }
+    }
+`);
+
+function ProductSummary({ value }: Readonly<DashboardFormComponentSummaryProps>) {
+    const ids = toIdArray(value);
+    const { data } = useQuery({
+        queryKey: ['ProductSummary', ids],
+        queryFn: () => api.query(productSummaryDocument, { options: { filter: { id: { in: ids } } } }),
+        enabled: ids.length > 0,
+        placeholderData: undefined,
+    });
+    const items = data?.products.items;
+    if (!items) {
+        return <EntityCountFallback count={ids.length} />;
+    }
+    return <NameList names={items.map(item => item.name)} />;
+}
+
+function ProductMultiSummary({ value, fieldDef }: Readonly<DashboardFormComponentSummaryProps>) {
+    return fieldDef.ui?.selectionMode === 'variant' ? (
+        <ProductVariantSummary value={value} fieldDef={fieldDef} />
+    ) : (
+        <ProductSummary value={value} fieldDef={fieldDef} />
+    );
 }
 
 const customerGroupSummaryDocument = graphql(`
@@ -170,8 +305,7 @@ function CustomerGroupSummary({ value }: Readonly<DashboardFormComponentSummaryP
     const ids = toIdArray(value);
     const { data } = useQuery({
         queryKey: ['CustomerGroupSummary', ids],
-        queryFn: () =>
-            api.query(customerGroupSummaryDocument, { options: { filter: { id: { in: ids } } } }),
+        queryFn: () => api.query(customerGroupSummaryDocument, { options: { filter: { id: { in: ids } } } }),
         enabled: ids.length > 0,
         placeholderData: undefined,
     });
@@ -212,6 +346,12 @@ function toIdArray(value: any): string[] {
 
 const BUILT_IN_SUMMARIES: Record<string, ComponentType<DashboardFormComponentSummaryProps>> = {
     'currency-form-input': CurrencySummary,
+    'html-editor-form-input': RichTextSummary,
+    'json-editor-form-input': JsonSummary,
+    'password-form-input': PasswordSummary,
+    'product-multi-form-input': ProductMultiSummary,
+    'product-multi-input': ProductMultiSummary,
+    'rich-text-form-input': RichTextSummary,
     'select-form-input': SelectOptionsSummary,
     'facet-value-form-input': FacetValueSummary,
     'facet-value-input': FacetValueSummary,

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-description.spec.ts
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-description.spec.ts
@@ -1,7 +1,11 @@
 import { ConfigurableOperationDefFragment } from '@/vdb/graphql/fragments.js';
 import { describe, expect, it } from 'vitest';
 
-import { formatScalarArgValue, parseOperationDescription } from './configurable-operation-description.js';
+import {
+    descriptionIncludesAdjacentAffix,
+    formatScalarArgValue,
+    parseOperationDescription,
+} from './configurable-operation-description.js';
 
 type ConfigArgDef = ConfigurableOperationDefFragment['args'][number];
 
@@ -115,5 +119,17 @@ describe('formatScalarArgValue', () => {
     it('passes plain values through', () => {
         expect(formatScalarArgValue(argDef({ type: 'int' }), '5')).toBe('5');
         expect(formatScalarArgValue(argDef({ type: 'string' }), 'abc')).toBe('abc');
+    });
+});
+
+describe('descriptionIncludesAdjacentAffix', () => {
+    it('detects affixes already adjacent to a placeholder', () => {
+        expect(descriptionIncludesAdjacentAffix('Discount by $ ', '$', 'before')).toBe(true);
+        expect(descriptionIncludesAdjacentAffix('% discount', '%', 'after')).toBe(true);
+    });
+
+    it('does not match affixes elsewhere in the surrounding text', () => {
+        expect(descriptionIncludesAdjacentAffix('$ discount by ', '$', 'before')).toBe(false);
+        expect(descriptionIncludesAdjacentAffix(' discount (%)', '%', 'after')).toBe(false);
     });
 });

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-description.ts
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-description.ts
@@ -18,6 +18,17 @@ export type OperationDescriptionSegment =
 
 const PLACEHOLDER_RE = /{\s*([a-zA-Z0-9]+)\s*}/g;
 
+export function descriptionIncludesAdjacentAffix(
+    text: string | undefined,
+    affix: string | undefined,
+    side: 'before' | 'after',
+): boolean {
+    if (!text || !affix) {
+        return false;
+    }
+    return side === 'before' ? text.trimEnd().endsWith(affix) : text.trimStart().startsWith(affix);
+}
+
 /**
  * @description
  * Parses a configurable operation's description template (e.g.

--- a/packages/dashboard/src/lib/components/shared/configurable-operation-sentence.tsx
+++ b/packages/dashboard/src/lib/components/shared/configurable-operation-sentence.tsx
@@ -8,6 +8,7 @@ import { Field, FieldLabel } from '../ui/field.js';
 import { ConfigurableOperationArgInput } from './configurable-operation-arg-input.js';
 import { ArgSummary, isEmptyArgValue } from './configurable-operation-arg-summary.js';
 import {
+    descriptionIncludesAdjacentAffix,
     OperationDescriptionSegment,
     parseOperationDescription,
 } from './configurable-operation-description.js';
@@ -55,7 +56,10 @@ export function OperationSentence({
         (s): s is Extract<OperationDescriptionSegment, { type: 'arg' }> => s.type === 'arg' && !s.referenced,
     );
 
-    const renderChip = (arg: ConfigurableOperationArgDef) => (
+    const renderChip = (
+        arg: ConfigurableOperationArgDef,
+        options?: { omitPrefix?: boolean; omitSuffix?: boolean },
+    ) => (
         <ArgChip
             key={arg.name}
             arg={arg}
@@ -63,14 +67,28 @@ export function OperationSentence({
             onChange={newValue => onArgChange(arg.name, newValue)}
             readonly={readonly}
             defaultOpen={firstEmptyArg?.name === arg.name}
+            {...options}
         />
     );
 
     return (
         <span className="text-sm leading-7">
-            {referenced.map((segment, i) =>
-                segment.type === 'text' ? <span key={i}>{segment.text}</span> : renderChip(segment.arg),
-            )}
+            {referenced.map((segment, i) => {
+                if (segment.type === 'text') {
+                    return <span key={i}>{segment.text}</span>;
+                }
+                const prefix = segment.arg.ui?.prefix;
+                const suffix = segment.arg.ui?.suffix;
+                const previous = referenced[i - 1];
+                const next = referenced[i + 1];
+                return renderChip(segment.arg, {
+                    omitPrefix:
+                        previous?.type === 'text' &&
+                        descriptionIncludesAdjacentAffix(previous.text, prefix, 'before'),
+                    omitSuffix:
+                        next?.type === 'text' && descriptionIncludesAdjacentAffix(next.text, suffix, 'after'),
+                });
+            })}
             {trailing.map((segment, i) => (
                 <span key={segment.arg.name}>
                     <span className="text-muted-foreground">
@@ -90,15 +108,29 @@ interface ArgChipProps {
     onChange: (value: string) => void;
     readonly?: boolean;
     defaultOpen?: boolean;
+    omitPrefix?: boolean;
+    omitSuffix?: boolean;
 }
 
-function ArgChip({ arg, value, onChange, readonly, defaultOpen }: Readonly<ArgChipProps>) {
+function ArgChip({
+    arg,
+    value,
+    onChange,
+    readonly,
+    defaultOpen,
+    omitPrefix,
+    omitSuffix,
+}: Readonly<ArgChipProps>) {
     const [open, setOpen] = useState(defaultOpen ?? false);
     const isEmpty = isEmptyArgValue(arg, value);
     const isRequiredEmpty = isEmpty && arg.required && !arg.list;
     const label = arg.label || arg.name;
 
-    const chipContent = isEmpty ? label : <ArgSummary fieldDef={arg} value={value} />;
+    const chipContent = isEmpty ? (
+        label
+    ) : (
+        <ArgSummary fieldDef={arg} value={value} omitPrefix={omitPrefix} omitSuffix={omitSuffix} />
+    );
 
     const chipClasses = cn(
         'inline-flex max-w-72 items-center truncate align-middle rounded-md border px-1.5 py-0.5 text-sm font-medium',


### PR DESCRIPTION
# Description

Improves configurable-operation sentence previews by preserving currency, affixes, option and entity names, rich-text meaning, and compact JSON context while masking passwords and handling scalar lists safely. The root cause was that compact summaries discarded input-component semantics and could duplicate affixes already present in sentence templates.

# Breaking changes

No breaking changes.

# Screenshots

Not applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787499830&installation_model_id=20193&pr_number=5033&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5033&signature=fbb2d98beb314d7c13dd58df5a44231c3db55b5e01c805d8821eec573a3de094"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->