### PR TITLE
feat(dashboard): Support multi-channel selection in assign-to-channel follow-up

### DIFF
--- a/packages/dashboard/src/i18n/locales/ar.po
+++ b/packages/dashboard/src/i18n/locales/ar.po
@@ -541,6 +541,14 @@ msgstr "إزالة الرابط"
 msgid "This field is readonly"
 msgstr "هذا الحقل للقراءة فقط"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "عرض البيانات"
 msgid "Delete View"
 msgstr "حذف العرض"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "أضف عنوانًا جديدًا للعميل."
@@ -3068,10 +3080,9 @@ msgstr "حفظ التغييرات"
 msgid "Address updated"
 msgstr "تم تحديث العنوان"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "تعيين"
 msgid "Successfully created seller"
 msgstr "تم إنشاء البائع بنجاح"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "تحديد عنصر"
 msgid "New product"
 msgstr "منتج جديد"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "إدارة العلامات"
@@ -3714,6 +3727,13 @@ msgstr "{0} متغير"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "فشل تسوية الدفع"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/bg.po
+++ b/packages/dashboard/src/i18n/locales/bg.po
@@ -547,6 +547,14 @@ msgstr "Премахване на връзката"
 msgid "This field is readonly"
 msgstr "Това поле е само за четене"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2675,6 +2683,10 @@ msgstr "Виж данни"
 msgid "Delete View"
 msgstr "Изтриване на изглед"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Добавете нов адрес към клиента."
@@ -3088,10 +3100,9 @@ msgstr "Запазване на промените"
 msgid "Address updated"
 msgstr "Адресът е актуализиран"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3344,11 +3355,9 @@ msgstr "Присвояване"
 msgid "Successfully created seller"
 msgstr "Успешно създаден продавач"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3575,6 +3584,10 @@ msgstr "Изберете елемент"
 msgid "New product"
 msgstr "Нов продукт"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Управление на етикети"
@@ -3734,6 +3747,13 @@ msgstr "{0} варианта"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Неуспешно плащане"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/cs.po
+++ b/packages/dashboard/src/i18n/locales/cs.po
@@ -541,6 +541,14 @@ msgstr "Odebrat odkaz"
 msgid "This field is readonly"
 msgstr "Toto pole je pouze pro čtení"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Zobrazit data"
 msgid "Delete View"
 msgstr "Smazat pohled"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Přidejte novou adresu k zákazníkovi."
@@ -3068,10 +3080,9 @@ msgstr "Uložit změny"
 msgid "Address updated"
 msgstr "Adresa aktualizována"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Přiřadit"
 msgid "Successfully created seller"
 msgstr "Prodejce úspěšně vytvořen"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Vybrat položku"
 msgid "New product"
 msgstr "Nový produkt"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Spravovat štítky"
@@ -3714,6 +3727,13 @@ msgstr "{0} variant"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Nepodařilo se vypořádat platbu"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/de.po
+++ b/packages/dashboard/src/i18n/locales/de.po
@@ -541,6 +541,14 @@ msgstr "Link entfernen"
 msgid "This field is readonly"
 msgstr "Dieses Feld ist schreibgeschützt"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Daten anzeigen"
 msgid "Delete View"
 msgstr "Ansicht löschen"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Neue Adresse zum Kunden hinzufügen."
@@ -3068,10 +3080,9 @@ msgstr "Änderungen speichern"
 msgid "Address updated"
 msgstr "Adresse aktualisiert"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Zuweisen"
 msgid "Successfully created seller"
 msgstr "Verkäufer erfolgreich erstellt"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Artikel auswählen"
 msgid "New product"
 msgstr "Neues Produkt"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Tags verwalten"
@@ -3714,6 +3727,13 @@ msgstr "{0} Varianten"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Fehler beim Abwickeln der Zahlung"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/en.po
+++ b/packages/dashboard/src/i18n/locales/en.po
@@ -541,6 +541,14 @@ msgstr "Remove link"
 msgid "This field is readonly"
 msgstr "This field is readonly"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "View data"
 msgid "Delete View"
 msgstr "Delete View"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Add a new address to the customer."
@@ -3068,10 +3080,9 @@ msgstr "Save Changes"
 msgid "Address updated"
 msgstr "Address updated"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Assign"
 msgid "Successfully created seller"
 msgstr "Successfully created seller"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Select item"
 msgid "New product"
 msgstr "New product"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr "Failed for: {failedCodes}"
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Manage Tags"
@@ -3714,6 +3727,13 @@ msgstr "{0} variants"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Failed to settle payment"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/es.po
+++ b/packages/dashboard/src/i18n/locales/es.po
@@ -541,6 +541,14 @@ msgstr "Eliminar enlace"
 msgid "This field is readonly"
 msgstr "Este campo es de solo lectura"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Ver datos"
 msgid "Delete View"
 msgstr "Eliminar Vista"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Agregar una nueva dirección al cliente."
@@ -3068,10 +3080,9 @@ msgstr "Guardar cambios"
 msgid "Address updated"
 msgstr "Dirección actualizada"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Asignar"
 msgid "Successfully created seller"
 msgstr "Vendedor creado exitosamente"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Seleccionar elemento"
 msgid "New product"
 msgstr "Nuevo producto"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gestionar Etiquetas"
@@ -3714,6 +3727,13 @@ msgstr "{0} variantes"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Error al liquidar pago"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/fa.po
+++ b/packages/dashboard/src/i18n/locales/fa.po
@@ -541,6 +541,14 @@ msgstr "حذف پیوند"
 msgid "This field is readonly"
 msgstr "این فیلد فقط خواندنی است"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "مشاهده داده‌ها"
 msgid "Delete View"
 msgstr "حذف نما"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "یک آدرس جدید به مشتری اضافه کنید."
@@ -3068,10 +3080,9 @@ msgstr "ذخیره تغییرات"
 msgid "Address updated"
 msgstr "آدرس به‌روزرسانی شد"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "اختصاص دادن"
 msgid "Successfully created seller"
 msgstr "فروشنده با موفقیت ایجاد شد"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "انتخاب مورد"
 msgid "New product"
 msgstr "محصول جدید"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "مدیریت برچسب‌ها"
@@ -3714,6 +3727,13 @@ msgstr "{0} نوع"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "تسویه پرداخت ناموفق بود"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/fr.po
+++ b/packages/dashboard/src/i18n/locales/fr.po
@@ -541,6 +541,14 @@ msgstr "Supprimer le lien"
 msgid "This field is readonly"
 msgstr "Ce champ est en lecture seule"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Voir les données"
 msgid "Delete View"
 msgstr "Supprimer la vue"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Ajouter une nouvelle adresse au client."
@@ -3068,10 +3080,9 @@ msgstr "Enregistrer les modifications"
 msgid "Address updated"
 msgstr "Adresse mise à jour"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Assigner"
 msgid "Successfully created seller"
 msgstr "Vendeur créé avec succès"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Sélectionner un élément"
 msgid "New product"
 msgstr "Nouveau produit"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gérer les étiquettes"
@@ -3714,6 +3727,13 @@ msgstr "{0} variantes"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Échec du règlement du paiement"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/he.po
+++ b/packages/dashboard/src/i18n/locales/he.po
@@ -541,6 +541,14 @@ msgstr "הסר קישור"
 msgid "This field is readonly"
 msgstr "שדה זה הוא לקריאה בלבד"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "צפה בנתונים"
 msgid "Delete View"
 msgstr "מחק תצוגה"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "הוסף כתובת חדשה ללקוח."
@@ -3068,10 +3080,9 @@ msgstr "שמור שינויים"
 msgid "Address updated"
 msgstr "הכתובת עודכנה"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "הקצה"
 msgid "Successfully created seller"
 msgstr "המוכר נוצר בהצלחה"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "בחר פריט"
 msgid "New product"
 msgstr "מוצר חדש"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "נהל תגיות"
@@ -3714,6 +3727,13 @@ msgstr "{0} גרסאות"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "סילוק התשלום נכשל"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/hr.po
+++ b/packages/dashboard/src/i18n/locales/hr.po
@@ -541,6 +541,14 @@ msgstr "Ukloni poveznicu"
 msgid "This field is readonly"
 msgstr "Ovo polje je samo za čitanje"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Pregled podataka"
 msgid "Delete View"
 msgstr "Obriši prikaz"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Dodajte novu adresu kupcu."
@@ -3068,10 +3080,9 @@ msgstr "Spremi izmjene"
 msgid "Address updated"
 msgstr "Adresa ažurirana"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Dodijeli"
 msgid "Successfully created seller"
 msgstr "Prodavač uspješno stvoren"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Odaberi stavku"
 msgid "New product"
 msgstr "Novi proizvod"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Upravljaj oznakama"
@@ -3714,6 +3727,13 @@ msgstr "{0} varijanti"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Izvršenje plaćanja nije uspjelo"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/hu.po
+++ b/packages/dashboard/src/i18n/locales/hu.po
@@ -541,6 +541,14 @@ msgstr "Hivatkozás eltávolítása"
 msgid "This field is readonly"
 msgstr "Ez a mező csak olvasható"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2648,6 +2656,10 @@ msgstr "Adatok megtekintése"
 msgid "Delete View"
 msgstr "Nézet törlése"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Új cím hozzáadása a vásárlóhoz."
@@ -3058,10 +3070,9 @@ msgstr "Változtatások mentése"
 msgid "Address updated"
 msgstr "Cím frissítve"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3314,11 +3325,9 @@ msgstr "Hozzárendelés"
 msgid "Successfully created seller"
 msgstr "Az eladó sikeresen létrehozva"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3545,6 +3554,10 @@ msgstr "Válasszon elemet"
 msgid "New product"
 msgstr "Új termék"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Címkék kezelése"
@@ -3701,6 +3714,13 @@ msgstr "{0} termékváltozat"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Fizetés rendezése sikertelen"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/it.po
+++ b/packages/dashboard/src/i18n/locales/it.po
@@ -541,6 +541,14 @@ msgstr "Rimuovi link"
 msgid "This field is readonly"
 msgstr "Questo campo è di sola lettura"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Visualizza dati"
 msgid "Delete View"
 msgstr "Elimina vista"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Aggiungi un nuovo indirizzo al cliente."
@@ -3068,10 +3080,9 @@ msgstr "Salva modifiche"
 msgid "Address updated"
 msgstr "Indirizzo aggiornato"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Assegna"
 msgid "Successfully created seller"
 msgstr "Venditore creato con successo"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Seleziona articolo"
 msgid "New product"
 msgstr "Nuovo prodotto"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gestisci tag"
@@ -3714,6 +3727,13 @@ msgstr "{0} varianti"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Impossibile completare pagamento"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/ja.po
+++ b/packages/dashboard/src/i18n/locales/ja.po
@@ -541,6 +541,14 @@ msgstr "リンクを削除"
 msgid "This field is readonly"
 msgstr "このフィールドは読み取り専用です"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "データを表示"
 msgid "Delete View"
 msgstr "ビューを削除"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "顧客に新しい住所を追加します。"
@@ -3068,10 +3080,9 @@ msgstr "変更を保存"
 msgid "Address updated"
 msgstr "住所を更新しました"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr "{entityIdsLength} 件の{entityType}を {0} 件のチャネルに割り当てました"
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr "{entityIdsLength} 件の{entityType}を {0} 件のチャネルに割り当てました"
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "割り当て"
 msgid "Successfully created seller"
 msgstr "販売者を作成しました"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr "{entityIdsLength} 件の{entityType}を {1} 件中 {0} 件のチャネルに割り当てられませんでした"
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr "{entityIdsLength} 件の{entityType}を {1} 件中 {0} 件のチャネルに割り当てられませんでした"
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "アイテムを選択"
 msgid "New product"
 msgstr "新しい商品"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "タグを管理"
@@ -3714,6 +3727,13 @@ msgstr "{0} 件のバリエーション"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "支払いの決済に失敗しました"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/ko.po
+++ b/packages/dashboard/src/i18n/locales/ko.po
@@ -529,6 +529,14 @@ msgstr "링크 제거"
 msgid "This field is readonly"
 msgstr "이 필드는 읽기 전용입니다"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2636,6 +2644,10 @@ msgstr "데이터 보기"
 msgid "Delete View"
 msgstr "뷰 삭제"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "고객에게 새 주소를 추가합니다."
@@ -3042,10 +3054,9 @@ msgstr "변경사항 저장"
 msgid "Address updated"
 msgstr "주소가 업데이트되었습니다"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr "{entityIdsLength}개 {entityType}이(가) {0}개 채널에 할당되었습니다"
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr "{entityIdsLength}개 {entityType}이(가) {0}개 채널에 할당되었습니다"
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3294,11 +3305,9 @@ msgstr "할당"
 msgid "Successfully created seller"
 msgstr "판매자가 생성되었습니다"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr "{entityIdsLength}개 {entityType}을(를) {1}개 채널 중 {0}개에 할당 실패"
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr "{entityIdsLength}개 {entityType}을(를) {1}개 채널 중 {0}개에 할당 실패"
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3525,6 +3534,10 @@ msgstr "항목 선택"
 msgid "New product"
 msgstr "새 상품"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "태그 관리"
@@ -3681,6 +3694,13 @@ msgstr "{0}개 변형"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "결제 정산 실패"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/nb.po
+++ b/packages/dashboard/src/i18n/locales/nb.po
@@ -541,6 +541,14 @@ msgstr "Fjern lenke"
 msgid "This field is readonly"
 msgstr "Dette feltet er skrivebeskyttet"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Vis data"
 msgid "Delete View"
 msgstr "Slett visning"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Legg til en ny adresse til kunden."
@@ -3068,10 +3080,9 @@ msgstr "Lagre endringer"
 msgid "Address updated"
 msgstr "Adresse oppdatert"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Tildel"
 msgid "Successfully created seller"
 msgstr "Selger opprettet"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Velg vare"
 msgid "New product"
 msgstr "Nytt produkt"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Administrer tagger"
@@ -3714,6 +3727,13 @@ msgstr "{0} varianter"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Kunne ikke gjennomføre betaling"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/ne.po
+++ b/packages/dashboard/src/i18n/locales/ne.po
@@ -541,6 +541,14 @@ msgstr "लिङ्क हटाउनुहोस्"
 msgid "This field is readonly"
 msgstr "यो फिल्ड पढ्न मात्र हो"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "डेटा हेर्नुहोस्"
 msgid "Delete View"
 msgstr "दृश्य मेट्नुहोस्"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "ग्राहकमा नयाँ ठेगाना थप्नुहोस्।"
@@ -3068,10 +3080,9 @@ msgstr "परिवर्तनहरू सुरक्षित गर्न�
 msgid "Address updated"
 msgstr "ठेगाना अपडेट गरियो"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "असाइन गर्नुहोस्"
 msgid "Successfully created seller"
 msgstr "विक्रेता सफलतापूर्वक सिर्जना गरियो"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "वस्तु चयन गर्नुहोस्"
 msgid "New product"
 msgstr "नयाँ उत्पादन"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "ट्यागहरू व्यवस्थापन गर्नुहोस्"
@@ -3714,6 +3727,13 @@ msgstr "{0} प्रकारहरू"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "भुक्तानी सम्पन्न गर्न असफल"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/nl.po
+++ b/packages/dashboard/src/i18n/locales/nl.po
@@ -541,6 +541,14 @@ msgstr "Link verwijderen"
 msgid "This field is readonly"
 msgstr "Dit veld is alleen-lezen"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2652,6 +2660,10 @@ msgstr "Gegevens bekijken"
 msgid "Delete View"
 msgstr "Weergave verwijderen"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Voeg een nieuw adres toe aan de klant."
@@ -3062,10 +3074,9 @@ msgstr "Wijzigingen opslaan"
 msgid "Address updated"
 msgstr "Adres bijgewerkt"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3318,11 +3329,9 @@ msgstr "Toewijzen"
 msgid "Successfully created seller"
 msgstr "Verkoper succesvol aangemaakt"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3549,6 +3558,10 @@ msgstr "Selecteer item"
 msgid "New product"
 msgstr "Nieuw product"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Tags beheren"
@@ -3705,6 +3718,13 @@ msgstr "{0} varianten"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Betaling afhandelen mislukt"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/pl.po
+++ b/packages/dashboard/src/i18n/locales/pl.po
@@ -541,6 +541,14 @@ msgstr "Usuń link"
 msgid "This field is readonly"
 msgstr "To pole jest tylko do odczytu"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Zobacz dane"
 msgid "Delete View"
 msgstr "Usuń widok"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Dodaj nowy adres do klienta."
@@ -3068,10 +3080,9 @@ msgstr "Zapisz zmiany"
 msgid "Address updated"
 msgstr "Adres został zaktualizowany"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Przypisz"
 msgid "Successfully created seller"
 msgstr "Pomyślnie utworzono sprzedawcę"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Wybierz pozycję"
 msgid "New product"
 msgstr "Nowy produkt"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Zarządzaj tagami"
@@ -3714,6 +3727,13 @@ msgstr "{0} wariantów"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Nie udało się rozliczyć płatności"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/pt_BR.po
+++ b/packages/dashboard/src/i18n/locales/pt_BR.po
@@ -541,6 +541,14 @@ msgstr "Remover link"
 msgid "This field is readonly"
 msgstr "Este campo e somente leitura"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Ver dados"
 msgid "Delete View"
 msgstr "Excluir visão"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Adicionar um novo endereço ao cliente."
@@ -3068,10 +3080,9 @@ msgstr "Salvar alterações"
 msgid "Address updated"
 msgstr "Endereço atualizado"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Atribuir"
 msgid "Successfully created seller"
 msgstr "Vendedor criado com sucesso"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Selecionar item"
 msgid "New product"
 msgstr "Novo produto"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gerenciar tags"
@@ -3714,6 +3727,13 @@ msgstr "{0} variantes"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Falha ao liquidar pagamento"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/pt_PT.po
+++ b/packages/dashboard/src/i18n/locales/pt_PT.po
@@ -541,6 +541,14 @@ msgstr "Remover ligação"
 msgid "This field is readonly"
 msgstr "Este campo e apenas de leitura"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Ver dados"
 msgid "Delete View"
 msgstr "Eliminar vista"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Adicionar uma nova morada ao cliente."
@@ -3068,10 +3080,9 @@ msgstr "Guardar alterações"
 msgid "Address updated"
 msgstr "Morada atualizada"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Atribuir"
 msgid "Successfully created seller"
 msgstr "Vendedor criado com sucesso"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Selecionar item"
 msgid "New product"
 msgstr "Novo produto"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gerir etiquetas"
@@ -3714,6 +3727,13 @@ msgstr "{0} variantes"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Falha ao liquidar pagamento"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/ro.po
+++ b/packages/dashboard/src/i18n/locales/ro.po
@@ -513,6 +513,14 @@ msgstr "Elimină link"
 msgid "This field is readonly"
 msgstr "Acest câmp este doar în citire"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2583,6 +2591,10 @@ msgstr "Vizualizează datele"
 msgid "Delete View"
 msgstr "Șterge vizualizarea"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Adaugă o adresă nouă pentru client."
@@ -2976,10 +2988,9 @@ msgstr "Salvează modificările"
 msgid "Address updated"
 msgstr "Adresă actualizată"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3232,11 +3243,9 @@ msgstr "Atribuie"
 msgid "Successfully created seller"
 msgstr "Vânzătorul a fost creat cu succes"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3455,6 +3464,10 @@ msgstr "Selectează elementul"
 msgid "New product"
 msgstr "Produs nou"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Gestionează Etichete"
@@ -3603,6 +3616,13 @@ msgstr "{0} variante"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Nu s-a putut soluționa plata"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/ru.po
+++ b/packages/dashboard/src/i18n/locales/ru.po
@@ -541,6 +541,14 @@ msgstr "Удалить ссылку"
 msgid "This field is readonly"
 msgstr "Это поле доступно только для чтения"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Посмотреть данные"
 msgid "Delete View"
 msgstr "Удалить представление"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Добавить новый адрес клиенту."
@@ -3068,10 +3080,9 @@ msgstr "Сохранить изменения"
 msgid "Address updated"
 msgstr "Адрес обновлён"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Назначить"
 msgid "Successfully created seller"
 msgstr "Продавец успешно создан"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Выбрать элемент"
 msgid "New product"
 msgstr "Новый товар"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Управление тегами"
@@ -3714,6 +3727,13 @@ msgstr "{0} вариантов"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Не удалось провести платёж"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/sv.po
+++ b/packages/dashboard/src/i18n/locales/sv.po
@@ -541,6 +541,14 @@ msgstr "Ta bort länk"
 msgid "This field is readonly"
 msgstr "Det här fältet är skrivskyddat"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Visa data"
 msgid "Delete View"
 msgstr "Ta bort vy"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Lägg till en ny adress till kunden."
@@ -3068,10 +3080,9 @@ msgstr "Spara ändringar"
 msgid "Address updated"
 msgstr "Adress uppdaterad"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Tilldela"
 msgid "Successfully created seller"
 msgstr "Säljare skapad"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Välj artikel"
 msgid "New product"
 msgstr "Ny produkt"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Hantera taggar"
@@ -3714,6 +3727,13 @@ msgstr "{0} varianter"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Misslyckades att genomföra betalning"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/tr.po
+++ b/packages/dashboard/src/i18n/locales/tr.po
@@ -541,6 +541,14 @@ msgstr "Bağlantıyı kaldır"
 msgid "This field is readonly"
 msgstr "Bu alan salt okunurdur"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Verileri görüntüle"
 msgid "Delete View"
 msgstr "Görünümü Sil"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Müşteriye yeni bir adres ekleyin."
@@ -3068,10 +3080,9 @@ msgstr "Değişiklikleri Kaydet"
 msgid "Address updated"
 msgstr "Adres güncellendi"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Ata"
 msgid "Successfully created seller"
 msgstr "Satıcı başarıyla oluşturuldu"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Öğe seç"
 msgid "New product"
 msgstr "Yeni ürün"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Etiketleri Yönet"
@@ -3714,6 +3727,13 @@ msgstr "{0} varyant"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Ödeme tamamlanamadı"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/uk.po
+++ b/packages/dashboard/src/i18n/locales/uk.po
@@ -541,6 +541,14 @@ msgstr "Видалити посилання"
 msgid "This field is readonly"
 msgstr "Це поле доступне лише для читання"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "Переглянути дані"
 msgid "Delete View"
 msgstr "Видалити подання"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Додати нову адресу клієнту."
@@ -3068,10 +3080,9 @@ msgstr "Зберегти зміни"
 msgid "Address updated"
 msgstr "Адресу оновлено"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "Призначити"
 msgid "Successfully created seller"
 msgstr "Продавця успішно створено"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "Вибрати елемент"
 msgid "New product"
 msgstr "Новий товар"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Керування тегами"
@@ -3714,6 +3727,13 @@ msgstr "{0} варіантів"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "Не вдалося провести платіж"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/uz.po
+++ b/packages/dashboard/src/i18n/locales/uz.po
@@ -513,6 +513,14 @@ msgstr "Havolani olib tashlash"
 msgid "This field is readonly"
 msgstr "Bu maydon faqat o'qish uchun"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2583,6 +2591,10 @@ msgstr "Maʼlumotlarni koʻrish"
 msgid "Delete View"
 msgstr "Koʻrinishni oʻchirish"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "Mijozga yangi manzil qoʻshish."
@@ -2976,10 +2988,9 @@ msgstr "Oʻzgarishlarni saqlash"
 msgid "Address updated"
 msgstr "Manzil yangilandi"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3232,11 +3243,9 @@ msgstr "Tayinlash"
 msgid "Successfully created seller"
 msgstr "Sotuvchi yaratildi"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3455,6 +3464,10 @@ msgstr "Elementni tanlash"
 msgid "New product"
 msgstr "Yangi mahsulot"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "Teglarni boshqarish"
@@ -3603,6 +3616,13 @@ msgstr "{0} ta variant"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "To'lovni yakunlab bo'lmadi"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/zh_Hans.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hans.po
@@ -541,6 +541,14 @@ msgstr "删除链接"
 msgid "This field is readonly"
 msgstr "此字段为只读"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "查看数据"
 msgid "Delete View"
 msgstr "删除视图"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "为客户添加新地址。"
@@ -3068,10 +3080,9 @@ msgstr "保存更改"
 msgid "Address updated"
 msgstr "地址已更新"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "分配"
 msgid "Successfully created seller"
 msgstr "已成功创建卖家"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "选择项目"
 msgid "New product"
 msgstr "新商品"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "管理标签"
@@ -3714,6 +3727,13 @@ msgstr "{0} 个变体"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "完成支付失败"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/i18n/locales/zh_Hant.po
+++ b/packages/dashboard/src/i18n/locales/zh_Hant.po
@@ -541,6 +541,14 @@ msgstr "移除連結"
 msgid "This field is readonly"
 msgstr "此欄位為唯讀"
 
+#. placeholder {0}: succeeded.length
+#. placeholder {1}: succeeded.length
+#. placeholder {2}: succeeded.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Assigned {entityIdsLength} {entityType} to {1} channel} other {Assigned {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
+
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 #: src/lib/framework/dashboard-widget/metrics-widget/index.tsx
 msgid "Order Count"
@@ -2658,6 +2666,10 @@ msgstr "檢視資料"
 msgid "Delete View"
 msgstr "刪除檢視"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed to assign {entityIdsLength} {entityType} to the selected channels"
+msgstr ""
+
 #: src/app/routes/_authenticated/_customers/customers_.$id.tsx
 msgid "Add a new address to the customer."
 msgstr "為客戶新增地址。"
@@ -3068,10 +3080,9 @@ msgstr "儲存變更"
 msgid "Address updated"
 msgstr "地址已更新"
 
-#. placeholder {0}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
-msgstr ""
+#~ msgid "Successfully assigned {entityIdsLength} {entityType} to {0} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_orders/hooks/use-refund-order.ts
 msgid "Refund processed successfully"
@@ -3324,11 +3335,9 @@ msgstr "指派"
 msgid "Successfully created seller"
 msgstr "已成功建立賣家"
 
-#. placeholder {0}: failedChannelIds.length
-#. placeholder {1}: selectedChannelIds.length
 #: src/lib/components/shared/assign-to-channel-dialog.tsx
-msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
-msgstr ""
+#~ msgid "Failed to assign {entityIdsLength} {entityType} to {0} of {1} channels"
+#~ msgstr ""
 
 #: src/app/routes/_authenticated/_shipping-methods/shipping-methods_.$id.tsx
 msgid "Successfully updated shipping method"
@@ -3555,6 +3564,10 @@ msgstr "選取項目"
 msgid "New product"
 msgstr "新增商品"
 
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "Failed for: {failedCodes}"
+msgstr ""
+
 #: src/app/routes/_authenticated/_assets/components/manage-tags-dialog.tsx
 msgid "Manage Tags"
 msgstr "管理標籤"
@@ -3714,6 +3727,13 @@ msgstr "{0} 個變體"
 #: src/app/routes/_authenticated/_orders/components/payment-details.tsx
 msgid "Failed to settle payment"
 msgstr "完成付款失敗"
+
+#. placeholder {0}: failed.length
+#. placeholder {1}: failed.length
+#. placeholder {2}: failed.length
+#: src/lib/components/shared/assign-to-channel-dialog.tsx
+msgid "{0, plural, one {Failed to assign {entityIdsLength} {entityType} to {1} channel} other {Failed to assign {entityIdsLength} {entityType} to {2} channels}}"
+msgstr ""
 
 #: src/app/routes/_authenticated/_orders/orders_.$id_.modify.tsx
 msgid "No billing address"

--- a/packages/dashboard/src/lib/components/shared/assign-to-channel-dialog.tsx
+++ b/packages/dashboard/src/lib/components/shared/assign-to-channel-dialog.tsx
@@ -1,8 +1,10 @@
-import { toast } from '@/vdb/components/ui/sonner.js';
+import { useMutation } from '@tanstack/react-query';
 import { ReactNode, useEffect, useState } from 'react';
+import { toast } from '@/vdb/components/ui/sonner.js';
 
 import { ChannelCodeLabel } from '@/vdb/components/shared/channel-code-label.js';
 import { MultiSelect } from '@/vdb/components/shared/multi-select.js';
+import { assignToChannels } from '@/vdb/components/shared/assign-to-channels.js';
 import { Button } from '@/vdb/components/ui/button.js';
 import {
     Dialog,
@@ -14,6 +16,7 @@ import {
 } from '@/vdb/components/ui/dialog.js';
 import { Input } from '@/vdb/components/ui/input.js';
 import { ResultOf } from '@/vdb/graphql/graphql.js';
+import { plural } from '@lingui/core/macro';
 import { Trans, useLingui } from '@lingui/react/macro';
 
 import { useChannel } from '@/vdb/hooks/use-channel.js';
@@ -55,7 +58,6 @@ export function AssignToChannelDialog({
 }: Readonly<AssignToChannelDialogProps>) {
     const { t } = useLingui();
     const [selectedChannelIds, setSelectedChannelIds] = useState<string[]>([]);
-    const [isAssigning, setIsAssigning] = useState(false);
     const { channels, activeChannel } = useChannel();
     const entityIdsLength = entityIds.length;
 
@@ -63,7 +65,7 @@ export function AssignToChannelDialog({
         if (!open) setSelectedChannelIds([]);
     }, [open]);
 
-    // Filter out the currently selected channel from available options
+    // Filter out the currently active channel from available options
     const availableChannels = channels.filter(channel => channel.id !== activeChannel?.id);
 
     const selectItems = availableChannels.map(ch => ({
@@ -72,42 +74,64 @@ export function AssignToChannelDialog({
         display: <ChannelCodeLabel code={ch.code} />,
     }));
 
-    const handleAssign = async () => {
-        setIsAssigning(true);
-        try {
-            const results = await Promise.allSettled(
-                selectedChannelIds.map(channelId =>
-                    mutationFn({ input: buildInput(channelId, additionalData) }),
-                ),
-            );
+    const { mutate, isPending } = useMutation({
+        mutationFn: () =>
+            assignToChannels(
+                selectedChannelIds,
+                channelId => buildInput(channelId, additionalData),
+                mutationFn,
+            ),
+        onSuccess: ({ succeeded, failed }) => {
+            if (failed.length) {
+                console.error('Failed to assign to channels', failed);
+            }
 
-            const failedChannelIds = results.flatMap((r, i) =>
-                r.status === 'rejected' ? [selectedChannelIds[i]] : [],
-            );
-            const succeededCount = results.length - failedChannelIds.length;
+            const failedCodes = failed
+                .map(f => channels.find(c => c.id === f.channelId)?.code ?? f.channelId)
+                .join(', ');
 
-            if (succeededCount > 0) {
+            if (failed.length === 0) {
+                toast.success(
+                    plural(succeeded.length, {
+                        one: `Assigned ${entityIdsLength} ${entityType} to ${succeeded.length} channel`,
+                        other: `Assigned ${entityIdsLength} ${entityType} to ${succeeded.length} channels`,
+                    }),
+                );
+                setSelectedChannelIds([]);
+                onSuccess?.();
+                onOpenChange(false);
+            } else if (succeeded.length === 0) {
+                toast.error(
+                    plural(failed.length, {
+                        one: `Failed to assign ${entityIdsLength} ${entityType} to ${failed.length} channel`,
+                        other: `Failed to assign ${entityIdsLength} ${entityType} to ${failed.length} channels`,
+                    }),
+                    { description: failedCodes },
+                );
+            } else {
+                toast.warning(
+                    plural(succeeded.length, {
+                        one: `Assigned ${entityIdsLength} ${entityType} to ${succeeded.length} channel`,
+                        other: `Assigned ${entityIdsLength} ${entityType} to ${succeeded.length} channels`,
+                    }),
+                    { description: t`Failed for: ${failedCodes}` },
+                );
+                // Keep the dialog open and narrow the selection to the failures, so retrying
+                // is one click and doesn't re-assign the channels that already succeeded.
+                setSelectedChannelIds(failed.map(f => f.channelId));
                 onSuccess?.();
             }
+        },
+        onError: () => {
+            toast.error(t`Failed to assign ${entityIdsLength} ${entityType} to the selected channels`);
+        },
+    });
 
-            if (failedChannelIds.length === 0) {
-                toast.success(
-                    t`Successfully assigned ${entityIdsLength} ${entityType} to ${selectedChannelIds.length} channels`,
-                );
-                onOpenChange(false);
-            } else {
-                const firstRejected = results.find(r => r.status === 'rejected');
-                const firstReason = firstRejected?.status === 'rejected' ? firstRejected.reason : undefined;
-                const description = firstReason instanceof Error ? firstReason.message : undefined;
-                setSelectedChannelIds(failedChannelIds);
-                toast.error(
-                    t`Failed to assign ${entityIdsLength} ${entityType} to ${failedChannelIds.length} of ${selectedChannelIds.length} channels`,
-                    { description },
-                );
-            }
-        } finally {
-            setIsAssigning(false);
+    const handleAssign = () => {
+        if (selectedChannelIds.length === 0) {
+            return;
         }
+        mutate();
     };
 
     return (
@@ -135,6 +159,7 @@ export function AssignToChannelDialog({
                             onChange={setSelectedChannelIds}
                             placeholder={t`Select one or more channels`}
                             searchPlaceholder={t`Search channels...`}
+                            showSearch
                             className="w-full"
                         />
                     </div>
@@ -144,7 +169,7 @@ export function AssignToChannelDialog({
                     <Button variant="outline" onClick={() => onOpenChange(false)}>
                         <Trans>Cancel</Trans>
                     </Button>
-                    <Button onClick={handleAssign} disabled={selectedChannelIds.length === 0 || isAssigning}>
+                    <Button onClick={handleAssign} disabled={selectedChannelIds.length === 0 || isPending}>
                         <Trans>Assign</Trans>
                     </Button>
                 </DialogFooter>

--- a/packages/dashboard/src/lib/components/shared/assign-to-channels.spec.ts
+++ b/packages/dashboard/src/lib/components/shared/assign-to-channels.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { assignToChannels } from './assign-to-channels.js';
+
+const buildInput = (channelId: string) => ({ channelId });
+
+describe('assignToChannels', () => {
+    it('reports all successes', async () => {
+        const result = await assignToChannels(['a', 'b'], buildInput, vi.fn().mockResolvedValue({}));
+        expect(result).toEqual({ succeeded: ['a', 'b'], failed: [] });
+    });
+
+    it('reports all failures with their reasons', async () => {
+        const error = new Error('nope');
+        const result = await assignToChannels(['a'], buildInput, vi.fn().mockRejectedValue(error));
+        expect(result.succeeded).toEqual([]);
+        expect(result.failed).toEqual([{ channelId: 'a', reason: error }]);
+    });
+
+    it('records which channels failed on partial failure', async () => {
+        const mutationFn = vi.fn(({ input }) =>
+            input.channelId === 'b' ? Promise.reject(new Error('boom')) : Promise.resolve({}),
+        );
+        const result = await assignToChannels(['a', 'b', 'c'], buildInput, mutationFn);
+        expect(result.succeeded).toEqual(['a', 'c']);
+        expect(result.failed.map(f => f.channelId)).toEqual(['b']);
+    });
+
+    it('continues with remaining channels after a failure', async () => {
+        const mutationFn = vi.fn().mockRejectedValue(new Error('x'));
+        await assignToChannels(['a', 'b', 'c'], buildInput, mutationFn);
+        expect(mutationFn).toHaveBeenCalledTimes(3);
+    });
+
+    it('captures synchronous buildInput errors as failures', async () => {
+        const throwing = () => {
+            throw new Error('bad input');
+        };
+        const result = await assignToChannels(['a'], throwing, vi.fn());
+        expect(result.succeeded).toEqual([]);
+        expect(result.failed.length).toBe(1);
+        expect(result.failed[0].channelId).toBe('a');
+        expect(result.failed[0].reason).toBeInstanceOf(Error);
+    });
+});

--- a/packages/dashboard/src/lib/components/shared/assign-to-channels.ts
+++ b/packages/dashboard/src/lib/components/shared/assign-to-channels.ts
@@ -1,0 +1,31 @@
+export interface AssignToChannelsResult {
+    succeeded: string[];
+    failed: Array<{ channelId: string; reason: unknown }>;
+}
+
+/**
+ * Sequentially assigns entities to multiple channels via the provided mutation function.
+ *
+ * Sequential execution is intentional: each mutation writes channel relations for the same
+ * entity rows, so a parallel fan-out only buys lock contention and N overlapping reindex jobs.
+ *
+ * @param channelIds - Channel IDs to assign to
+ * @param buildInput - Builds the mutation input for a given channel ID
+ * @param mutationFn - The GraphQL mutation function to call per channel
+ */
+export async function assignToChannels(
+    channelIds: string[],
+    buildInput: (channelId: string) => Record<string, any>,
+    mutationFn: (variables: any) => Promise<unknown>,
+): Promise<AssignToChannelsResult> {
+    const result: AssignToChannelsResult = { succeeded: [], failed: [] };
+    for (const channelId of channelIds) {
+        try {
+            await mutationFn({ input: buildInput(channelId) });
+            result.succeeded.push(channelId);
+        } catch (reason) {
+            result.failed.push({ channelId, reason });
+        }
+    }
+    return result;
+}


### PR DESCRIPTION
# Description

Extends the "Assign to channel" bulk action dialog to support selecting **multiple channels** in a single operation, replacing the previous single-select dropdown.

Fixes #4812

## What changed

The `AssignToChannelDialog` shared component (used by all 9 entity types with channel assignment bulk actions) now uses the existing `MultiSelect` component instead of the single-select `Select` dropdown. When the user selects multiple channels, the existing per-channel mutation is fanned out in parallel via `Promise.allSettled` inside `useMutation`, following the same pattern as `cancel-jobs-bulk-action.tsx`.

**Affected entities (zero per-entity changes needed):**
Products, Product Variants, Collections, Facets, Promotions, Shipping Methods, Payment Methods, Stock Locations, Product Option Groups

## Why only "Assign to channel" and not "Remove from channel"

The "Remove from channel" action has a fundamentally different UX: it currently has no dialog — it removes from the **active channel** with an inline confirmation. Supporting multi-channel removal would require:

- A new `RemoveFromChannelDialog` component (~80 LOC)
- Changing the `buildInput` signature from `() => Record` to `(channelId: string) => Record` (breaking change to all 9 entity callers)
- Updating all 9 per-entity bulk action files
- Handling 2 callers (facets, option-groups) with custom `onSuccess` result inspection

This is a ~4x larger scope change. It can be done as a follow-up if there's interest, but the assign side covers the primary pain point described in #4812 (assigning entities across many channels).

## Implementation approach

**Option B from the issue (UI-level fan-out)** was chosen over Option A (API-level `channelIds` array) because:

- **Zero API/GraphQL schema changes** — no breaking changes for plugins or external consumers
- **Simpler implementation** — 1 file changed vs 18+ input types, 10 resolvers, 10 services


## Toast behavior

- **All succeed**: `"Successfully assigned N entityType to M channel(s)"`
- **All fail**: `"Failed to assign N entityType to M channel(s)"`
- **Partial**: `"Assigned N entityType to M channel(s), failed for F"` (uses `toast.warning`, matching the existing pattern in `use-refund-order.ts`)

# Breaking changes

None. The `AssignToChannelDialogProps` interface is unchanged. The `buildInput(channelId, additionalData)` callback signature is unchanged — the dialog calls it once per selected channel instead of once. All existing callers (9 bulk actions + `AssignedChannels` detail page) work without modification.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5036"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787599895&installation_model_id=20193&pr_number=5036&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5036&signature=e0a8fd91dd8536d5c132dcd6d5d24e3d991633a37bfd8dde8c0bad96601e3402"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->