### PR TITLE
fix(core): Add channel-scope guard to delete paths & cross-channel re…

### DIFF
--- a/packages/core/e2e/collection.e2e-spec.ts
+++ b/packages/core/e2e/collection.e2e-spec.ts
@@ -2161,6 +2161,76 @@ describe('Collection resolver', () => {
         });
     });
 
+    describe('cross-channel update protection', () => {
+        const CHANNEL_A_TOKEN = 'coll-cross-channel-a';
+        const CHANNEL_B_TOKEN = 'coll-cross-channel-b';
+        let targetCollectionId: string;
+
+        beforeAll(async () => {
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            for (const [code, token] of [
+                ['coll-cross-a', CHANNEL_A_TOKEN],
+                ['coll-cross-b', CHANNEL_B_TOKEN],
+            ]) {
+                await adminClient.query(createChannelDocument, {
+                    input: {
+                        code,
+                        token,
+                        defaultLanguageCode: LanguageCode.en,
+                        currencyCode: CurrencyCode.USD,
+                        pricesIncludeTax: true,
+                        defaultShippingZoneId: 'T_1',
+                        defaultTaxZoneId: 'T_1',
+                    },
+                });
+            }
+            adminClient.setChannelToken(CHANNEL_A_TOKEN);
+            const { createCollection } = await adminClient.query(createCollectionDocument, {
+                input: {
+                    filters: [],
+                    translations: [
+                        {
+                            languageCode: LanguageCode.en,
+                            name: 'Channel-A Collection',
+                            description: 'Belongs to Channel A only',
+                            slug: 'channel-a-collection',
+                        },
+                    ],
+                },
+            });
+            targetCollectionId = createCollection.id;
+        });
+
+        afterAll(() => {
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+        });
+
+        it('cannot update a Collection belonging to another channel', async () => {
+            adminClient.setChannelToken(CHANNEL_B_TOKEN);
+            await expect(
+                adminClient.query(updateCollectionDocument, {
+                    input: {
+                        id: targetCollectionId,
+                        translations: [
+                            {
+                                languageCode: LanguageCode.en,
+                                name: 'PWNED-BY-CHANNEL-B',
+                                description: 'TAMPERED',
+                                slug: 'pwned',
+                            },
+                        ],
+                    },
+                }),
+            ).rejects.toThrow(/No Collection with the id .* could be found/);
+
+            adminClient.setChannelToken(CHANNEL_A_TOKEN);
+            const { collection } = await adminClient.query(getCollectionDocument, {
+                id: targetCollectionId,
+            });
+            expect(collection?.name).toBe('Channel-A Collection');
+        });
+    });
+
     function getFacetValueId(code: string): string {
         const match = facetValues.find(fv => fv.code === code);
         if (!match) {

--- a/packages/core/e2e/facet.e2e-spec.ts
+++ b/packages/core/e2e/facet.e2e-spec.ts
@@ -844,6 +844,36 @@ describe('Facet resolver', () => {
             const value = facet?.values.find(v => v.id === valueId);
             expect(value?.name).toBe('Original Value');
         });
+
+        it('cannot update a Facet belonging to another channel', async () => {
+            adminClient.setChannelToken(CHANNEL_B_TOKEN);
+            await expect(
+                adminClient.query(updateFacetDocument, {
+                    input: {
+                        id: facetId,
+                        translations: [{ languageCode: LanguageCode.en, name: 'PWNED-FACET' }],
+                    },
+                }),
+            ).rejects.toThrow(/No Facet with the id .* could be found/);
+
+            adminClient.setChannelToken(CHANNEL_A_TOKEN);
+            const { facet } = await adminClient.query(getFacetWithValuesDocument, { id: facetId });
+            expect(facet?.name).toBe('Cross Channel Facet');
+        });
+
+        it('cannot delete a FacetValue belonging to another channel', async () => {
+            adminClient.setChannelToken(CHANNEL_B_TOKEN);
+            await expect(
+                adminClient.query(deleteFacetValuesDocument, {
+                    ids: [valueId],
+                }),
+            ).rejects.toThrow(/No FacetValue with the id .* could be found/);
+
+            adminClient.setChannelToken(CHANNEL_A_TOKEN);
+            const { facet } = await adminClient.query(getFacetWithValuesDocument, { id: facetId });
+            const value = facet?.values.find(v => v.id === valueId);
+            expect(value?.name).toBe('Original Value');
+        });
     });
 });
 

--- a/packages/core/e2e/product-option.e2e-spec.ts
+++ b/packages/core/e2e/product-option.e2e-spec.ts
@@ -569,6 +569,123 @@ describe('ProductOption resolver', () => {
             }
         });
     });
+
+    describe('cross-channel update protection', () => {
+        const CHANNEL_A_TOKEN = 'opt-cross-channel-a';
+        const CHANNEL_B_TOKEN = 'opt-cross-channel-b';
+        let targetGroupId: string;
+        let targetOptionId: string;
+
+        beforeAll(async () => {
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            for (const [code, token] of [
+                ['opt-cross-a', CHANNEL_A_TOKEN],
+                ['opt-cross-b', CHANNEL_B_TOKEN],
+            ]) {
+                await adminClient.query(createChannelDocument, {
+                    input: {
+                        code,
+                        token,
+                        defaultLanguageCode: LanguageCode.en,
+                        currencyCode: CurrencyCode.USD,
+                        pricesIncludeTax: true,
+                        defaultShippingZoneId: 'T_1',
+                        defaultTaxZoneId: 'T_1',
+                    },
+                });
+            }
+            adminClient.setChannelToken(CHANNEL_A_TOKEN);
+            const { createProductOptionGroup } = await adminClient.query(
+                createProductOptionGroupDocument,
+                {
+                    input: {
+                        code: 'cross-channel-group',
+                        translations: [
+                            { languageCode: LanguageCode.en, name: 'Cross Channel Group' },
+                        ],
+                        options: [
+                            {
+                                code: 'cross-channel-opt',
+                                translations: [
+                                    { languageCode: LanguageCode.en, name: 'Cross Channel Option' },
+                                ],
+                            },
+                        ],
+                    },
+                },
+            );
+            targetGroupId = createProductOptionGroup.id;
+            targetOptionId = createProductOptionGroup.options[0].id;
+        });
+
+        afterAll(() => {
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+        });
+
+        it('cannot update a ProductOptionGroup belonging to another channel', async () => {
+            adminClient.setChannelToken(CHANNEL_B_TOKEN);
+            await expect(
+                adminClient.query(updateProductOptionGroupLocalDocument, {
+                    input: {
+                        id: targetGroupId,
+                        translations: [
+                            { languageCode: LanguageCode.en, name: 'PWNED-GROUP' },
+                        ],
+                    },
+                }),
+            ).rejects.toThrow(/No ProductOptionGroup with the id .* could be found/);
+
+            adminClient.setChannelToken(CHANNEL_A_TOKEN);
+            const { productOptionGroup } = await adminClient.query(
+                getProductOptionGroupDocument,
+                { id: targetGroupId },
+            );
+            expect(productOptionGroup?.name).toBe('Cross Channel Group');
+        });
+
+        it('cannot update a ProductOption belonging to another channel', async () => {
+            adminClient.setChannelToken(CHANNEL_B_TOKEN);
+            await expect(
+                adminClient.query(updateProductOptionDocument, {
+                    input: {
+                        id: targetOptionId,
+                        translations: [
+                            { languageCode: LanguageCode.en, name: 'PWNED-OPTION' },
+                        ],
+                    },
+                }),
+            ).rejects.toThrow(/No ProductOption with the id .* could be found/);
+
+            adminClient.setChannelToken(CHANNEL_A_TOKEN);
+            const { productOptionGroup } = await adminClient.query(
+                getProductOptionGroupDocument,
+                { id: targetGroupId },
+            );
+            const option = productOptionGroup?.options.find(
+                (o: any) => o.id === targetOptionId,
+            );
+            expect(option?.name).toBe('Cross Channel Option');
+        });
+
+        it('cannot delete a ProductOption belonging to another channel', async () => {
+            adminClient.setChannelToken(CHANNEL_B_TOKEN);
+            await expect(
+                adminClient.query(deleteProductOptionDocument, {
+                    id: targetOptionId,
+                }),
+            ).rejects.toThrow(/No ProductOption with the id .* could be found/);
+
+            adminClient.setChannelToken(CHANNEL_A_TOKEN);
+            const { productOptionGroup } = await adminClient.query(
+                getProductOptionGroupDocument,
+                { id: targetGroupId },
+            );
+            const option = productOptionGroup?.options.find(
+                (o: any) => o.id === targetOptionId,
+            );
+            expect(option?.name).toBe('Cross Channel Option');
+        });
+    });
 });
 
 const updateProductOptionGroupLocalDocument = graphql(

--- a/packages/core/e2e/promotion.e2e-spec.ts
+++ b/packages/core/e2e/promotion.e2e-spec.ts
@@ -368,6 +368,23 @@ describe('Promotion resolver', () => {
             const { promotions } = await adminClient.query(getPromotionListDocument);
             expect(promotions.totalItems).toBe(0);
         });
+
+        it('cannot delete a Promotion belonging to another channel', async () => {
+            // promotion belongs to default channel only (removed from second channel above)
+            adminClient.setChannelToken(SECOND_CHANNEL_TOKEN);
+            await expect(
+                adminClient.query(deletePromotionDocument, {
+                    id: promotion.id,
+                }),
+            ).rejects.toThrow(/No Promotion with the id .* could be found/);
+
+            // Verify the Promotion still exists in the default channel
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            const { promotion: result } = await adminClient.query(getPromotionDocument, {
+                id: promotion.id,
+            });
+            expect(result?.name).toBe('test promotion');
+        });
     });
 
     describe('deletion', () => {

--- a/packages/core/src/service/services/facet-value.service.ts
+++ b/packages/core/src/service/services/facet-value.service.ts
@@ -225,7 +225,9 @@ export class FacetValueService {
         let message = '';
         let result: DeletionResult;
 
-        const facetValue = await this.connection.getEntityOrThrow(ctx, FacetValue, id);
+        const facetValue = await this.connection.getEntityOrThrow(ctx, FacetValue, id, {
+            channelId: ctx.channelId,
+        });
         const i18nVars = {
             products: productCount,
             variants: variantCount,

--- a/packages/core/src/service/services/product-option.service.ts
+++ b/packages/core/src/service/services/product-option.service.ts
@@ -143,7 +143,9 @@ export class ProductOptionService {
      * - If the ProductOption is not used by any ProductVariant at all, it will be hard-deleted.
      */
     async delete(ctx: RequestContext, id: ID): Promise<DeletionResponse> {
-        const productOption = await this.connection.getEntityOrThrow(ctx, ProductOption, id);
+        const productOption = await this.connection.getEntityOrThrow(ctx, ProductOption, id, {
+            channelId: ctx.channelId,
+        });
         const deletedProductOption = new ProductOption(productOption);
         const inUseByActiveVariants = await this.isInUse(ctx, productOption, 'active');
         if (0 < inUseByActiveVariants) {

--- a/packages/core/src/service/services/promotion.service.ts
+++ b/packages/core/src/service/services/promotion.service.ts
@@ -193,7 +193,9 @@ export class PromotionService {
     }
 
     async softDeletePromotion(ctx: RequestContext, promotionId: ID): Promise<DeletionResponse> {
-        const promotion = await this.connection.getEntityOrThrow(ctx, Promotion, promotionId);
+        const promotion = await this.connection.getEntityOrThrow(ctx, Promotion, promotionId, {
+            channelId: ctx.channelId,
+        });
         await this.connection
             .getRepository(ctx, Promotion)
             .update({ id: promotionId }, { deletedAt: new Date() });


### PR DESCRIPTION
Fixes #5042
Relates to #5003

# Description

Add `{ channelId: ctx.channelId }` guard to `delete()` in `FacetValueService`, `ProductOptionService`, and `PromotionService.softDeletePromotion()`. These had the same cross-channel bypass defect as the `update()` paths fixed in #5017.

Also adds cross-channel e2e regression tests for:
- **Delete protection:** FacetValue, ProductOption, Promotion
- **Update protection:** Collection, ProductOptionGroup, ProductOption, Facet (PR #4821 guards that had no e2e coverage)

# Breaking changes

No breaking changes.

# Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5043"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787821940&installation_model_id=20193&pr_number=5043&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5043&signature=11e1796e0f7b5db4ba14d88e35b97761ee05919c7094ea2a1e31666a8557e258"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->