### PR TITLE
fix(create): Read the server port from VENDURE_SERVER_PORT

### DIFF
--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -153,7 +153,9 @@ export async function createVendureApp(
         outro(e.message);
         process.exit(1);
     }
-    process.env.PORT = port.toString();
+    // Read back by the generated vendure-config when the dashboard build
+    // introspects it later in this same process.
+    process.env.VENDURE_SERVER_PORT = port.toString();
 
     const root = path.resolve(name);
     const appName = path.basename(root);

--- a/packages/create/src/create-vendure-app.ts
+++ b/packages/create/src/create-vendure-app.ts
@@ -153,9 +153,10 @@ export async function createVendureApp(
         outro(e.message);
         process.exit(1);
     }
-    // Read back by the generated vendure-config when the dashboard build
-    // introspects it later in this same process.
-    process.env.VENDURE_SERVER_PORT = port.toString();
+    // Read back by the generated vendure-config when the dashboard build introspects it later in
+    // this same process. Set as PORT because that is the name the config resolves first, so an
+    // unrelated PORT already in the shell environment cannot override the port we just verified.
+    process.env.PORT = port.toString();
 
     const root = path.resolve(name);
     const appName = path.basename(root);

--- a/packages/create/templates/.env.hbs
+++ b/packages/create/templates/.env.hbs
@@ -1,5 +1,5 @@
 APP_ENV=dev
-PORT={{ port }}
+VENDURE_SERVER_PORT={{ port }}
 COOKIE_SECRET={{ cookieSecret }}
 SUPERADMIN_USERNAME={{{ escapeSingle superadminIdentifier }}}
 SUPERADMIN_PASSWORD={{{ escapeSingle superadminPassword }}}

--- a/packages/create/templates/environment.d.hbs
+++ b/packages/create/templates/environment.d.hbs
@@ -6,6 +6,7 @@ declare global {
     namespace NodeJS {
         interface ProcessEnv {
             APP_ENV: string;
+            VENDURE_SERVER_PORT: string;
             PORT: string;
             COOKIE_SECRET: string;
             SUPERADMIN_USERNAME: string;

--- a/packages/create/templates/vendure-config.hbs
+++ b/packages/create/templates/vendure-config.hbs
@@ -13,7 +13,8 @@ import 'dotenv/config';
 import path from 'path';
 
 const IS_DEV = process.env.APP_ENV === 'dev';
-const serverPort = +process.env.PORT || 3000;
+// PORT is the fallback because most hosting platforms inject it under that name.
+const serverPort = +process.env.VENDURE_SERVER_PORT || +process.env.PORT || 3000;
 
 export const config: VendureConfig = {
     apiOptions: {

--- a/packages/create/templates/vendure-config.hbs
+++ b/packages/create/templates/vendure-config.hbs
@@ -13,8 +13,9 @@ import 'dotenv/config';
 import path from 'path';
 
 const IS_DEV = process.env.APP_ENV === 'dev';
-// PORT is the fallback because most hosting platforms inject it under that name.
-const serverPort = +process.env.VENDURE_SERVER_PORT || +process.env.PORT || 3000;
+// PORT wins because hosting platforms inject it into the environment at runtime, and that
+// must take precedence over any value baked into the .env file at scaffold time.
+const serverPort = +process.env.PORT || +process.env.VENDURE_SERVER_PORT || 3000;
 
 export const config: VendureConfig = {
     apiOptions: {


### PR DESCRIPTION
# Description

The scaffold reads its HTTP port from `PORT`. That name is generic enough that a hosting platform which needs the application to listen on a particular port has no way to say so without colliding with whatever else the container sets, and the name gives no indication of which server it refers to in a project that also runs a storefront.

This changes the generated config to read `VENDURE_SERVER_PORT` first, falling back to `PORT`:

```ts
const serverPort = +process.env.VENDURE_SERVER_PORT || +process.env.PORT || 3000;
```

The fallback is deliberate. Heroku, Railway, Render and Fly all inject the port as `PORT`, and the deployment guides for Railway and Render tell people to read it, so dropping it would break those deploys. Apps that set neither still get 3000.

The generated `.env` now writes `VENDURE_SERVER_PORT`, and `environment.d.ts` declares both names. `create-vendure-app.ts` sets `process.env.VENDURE_SERVER_PORT` rather than `PORT`, because the generated config is loaded back in that same process when the dashboard build introspects it.

Concretely this came out of deploying a freshly scaffolded app to a managed host that routes to a fixed internal port. The application bound to 3000, the platform routed to its own port, and the only symptom was a health-check timeout with nothing in the logs. A descriptive, Vendure-specific name lets the platform set the port without guessing what else in the container might be reading `PORT`.

# Breaking changes

None for existing projects — nothing reads the scaffold templates after generation, and the `PORT` fallback means an existing config keeps working unchanged.

Newly generated projects get `VENDURE_SERVER_PORT` in `.env` instead of `PORT`. Anything outside the Vendure config that reads `process.env.PORT` in a new project (a Procfile, a container healthcheck, a custom script) would need updating to match.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

No new tests: the change is to Handlebars templates and one assignment, and the create package has no test coverage of generated template contents. `packages/create` typecheck and its existing 53 tests pass.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5046"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787840550&installation_model_id=20193&pr_number=5046&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5046&signature=84464264bf2c8aa3f641c6ae0b7b13f469a7e8f33cf097c7b9ef68f32ab49447"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->