### PR TITLE
fix(core): Prevent relation custom fields being cleared by partial updates

### DIFF
--- a/packages/core/e2e/custom-field-relations.e2e-spec.ts
+++ b/packages/core/e2e/custom-field-relations.e2e-spec.ts
@@ -947,6 +947,29 @@ describe('Custom field relations', () => {
                 expect(updateProduct.customFields.primitive).toBe('test');
             });
 
+            // https://github.com/vendurehq/vendure/issues/5040
+            it('updating an unrelated scalar custom field does not clear relation custom fields', async () => {
+                const { updateProduct } = await adminClient.query(gql`
+                    mutation {
+                        updateProduct(
+                            input: {
+                                id: "${productId}"
+                                customFields: { primitive: "changed" }
+                            }
+                        ) {
+                            id
+                            ${customFieldsSelection}
+                        }
+                    }
+                `);
+                expect(updateProduct.customFields.primitive).toBe('changed');
+                expect(updateProduct.customFields.single).toEqual({ id: 'T_3' });
+                expect(updateProduct.customFields.multi.sort(sortById)).toEqual([
+                    { id: 'T_3' },
+                    { id: 'T_4' },
+                ]);
+            });
+
             let productVariantId: string;
             it('admin createProductVariant', async () => {
                 const { createProductVariants } = await adminClient.query(gql`

--- a/packages/core/src/entity/base/base.entity.spec.ts
+++ b/packages/core/src/entity/base/base.entity.spec.ts
@@ -18,6 +18,14 @@ class ChildEntity extends VendureEntity {
     }
 }
 
+class ChildEntityWithCustomFields extends VendureEntity {
+    constructor(input?: DeepPartial<ChildEntityWithCustomFields>) {
+        super(input);
+    }
+
+    customFields: { [key: string]: any };
+}
+
 class ChildEntityWithCalculated extends VendureEntity {
     constructor(input?: DeepPartial<ChildEntity>) {
         super(input);
@@ -50,6 +58,18 @@ describe('VendureEntity', () => {
 
         expect(child2.name).toBe('foo');
         expect(child2.nameLoud).toBe('FOO');
+    });
+
+    // https://github.com/vendurehq/vendure/issues/5040
+    it('clones customFields rather than sharing the input reference', () => {
+        const input = { customFields: { relatedId: 1 } };
+        const child = new ChildEntityWithCustomFields(input);
+
+        expect(child.customFields).toEqual({ relatedId: 1 });
+        expect(child.customFields).not.toBe(input.customFields);
+
+        child.customFields.relatedId = null;
+        expect(input.customFields.relatedId).toBe(1);
     });
 
     it('instantiating from existing entity with calculated getter', () => {

--- a/packages/core/src/entity/base/base.entity.ts
+++ b/packages/core/src/entity/base/base.entity.ts
@@ -20,7 +20,16 @@ export abstract class VendureEntity {
                     // and cannot be copied over to the new instance.
                     continue;
                 }
-                (this as any)[key] = descriptor.value;
+                if (key === 'customFields' && descriptor.value != null && typeof descriptor.value === 'object') {
+                    // Clone the customFields object rather than sharing the input's reference.
+                    // On save, TypeORM mutates the entity's embedded customFields object
+                    // (e.g. setting all absent nullable columns to null), and via a shared
+                    // reference those mutations would corrupt the input object, making
+                    // absent custom fields indistinguishable from explicit nulls.
+                    (this as any)[key] = { ...descriptor.value };
+                } else {
+                    (this as any)[key] = descriptor.value;
+                }
             }
         }
     }

--- a/packages/core/src/entity/base/base.entity.ts
+++ b/packages/core/src/entity/base/base.entity.ts
@@ -1,5 +1,5 @@
 import { DeepPartial, ID } from '@vendure/common/lib/shared-types';
-import { CreateDateColumn, PrimaryGeneratedColumn, UpdateDateColumn } from 'typeorm';
+import { CreateDateColumn, UpdateDateColumn } from 'typeorm';
 
 import { PrimaryGeneratedId } from '../entity-id.decorator';
 
@@ -20,7 +20,11 @@ export abstract class VendureEntity {
                     // and cannot be copied over to the new instance.
                     continue;
                 }
-                if (key === 'customFields' && descriptor.value != null && typeof descriptor.value === 'object') {
+                if (
+                    key === 'customFields' &&
+                    descriptor.value != null &&
+                    typeof descriptor.value === 'object'
+                ) {
                     // Clone the customFields object rather than sharing the input's reference.
                     // On save, TypeORM mutates the entity's embedded customFields object
                     // (e.g. setting all absent nullable columns to null), and via a shared


### PR DESCRIPTION
## Description

On the `minor` branch, a partial update that touches `customFields` clears every relation custom field that the input does not explicitly name. Setting an unrelated scalar custom field silently nulls the relation and writes `NULL` to the join column.

### Root cause

The `VendureEntity` constructor copies `input.customFields` onto the entity by reference, so in `TranslatableSaver.update` the entity being saved and the GraphQL input share a single `customFields` object.

Inside `repository.save()`, TypeORM's `SubjectExecutor.updateSpecialColumnsInInsertedAndUpdatedEntities` sets every nullable column whose value is `undefined` to an explicit `null` on the saved entity. Through the shared reference, this corrupts the GraphQL input: an input of `{ material: "aluminium" }` comes out of the save as `{ material: "aluminium", relatedChannelId: null, ... }`.

`CustomFieldRelationService.updateRelations` runs after that save, reads the corrupted input, and interprets each phantom `null` as an explicit instruction to remove the relation.

This null-filling has always happened, but before `v3.8.0-minor` it landed on the relation property itself (e.g. `single`), which `updateRelations` never reads. The relation id columns added for relation custom fields made `<name>Id` a real nullable column, so the null now lands on exactly the key the guard in `updateRelations` checks, and the wipe (previously also dropped by the TypeORM embedded-column bug) now reaches the database.

### Fix

The `VendureEntity` constructor now shallow-clones `customFields` instead of sharing the input's reference, so mutations TypeORM makes to the entity during save can no longer leak into the input object. This covers all constructor-based paths (translatable create/update, translation entities, plain creates) in one place. Removing a relation by passing an explicit `null` is unchanged and remains covered by existing tests.

Includes a regression e2e test based on the reproduction in the issue: it fails on `minor` without the fix and passes with it.

Fixes #5040

## Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](https://github.com/vendurehq/vendure/pull)

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787905645&installation_model_id=20193&pr_number=5047&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5047&signature=55cb93d5ecf936d6716dc8be5777c2410e5a874dfd3907f582c78e6c3111a2e1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->