### PR TITLE
fix(core): Enforce channel scope on product variant soft-deletion

### DIFF
--- a/packages/core/e2e/graphql/shared-definitions.ts
+++ b/packages/core/e2e/graphql/shared-definitions.ts
@@ -672,6 +672,15 @@ export const deleteProductVariantDocument = graphql(`
     }
 `);
 
+export const deleteProductVariantsDocument = graphql(`
+    mutation DeleteProductVariants($ids: [ID!]!) {
+        deleteProductVariants(ids: $ids) {
+            result
+            message
+        }
+    }
+`);
+
 export const assignProductToChannelDocument = graphql(
     `
         mutation AssignProductsToChannel($input: AssignProductsToChannelInput!) {

--- a/packages/core/e2e/product-channel.e2e-spec.ts
+++ b/packages/core/e2e/product-channel.e2e-spec.ts
@@ -25,6 +25,7 @@ import {
     createRoleDocument,
     deleteProductDocument,
     deleteProductVariantDocument,
+    deleteProductVariantsDocument,
     getChannelsDocument,
     getProductVariantListDocument,
     getProductWithVariantsDocument,
@@ -1102,7 +1103,9 @@ describe('ChannelAware Products and ProductVariants', () => {
                 await adminClient.asUserWithCredentials('deleter2@test.com', 'test');
                 adminClient.setChannelToken(SECOND_CHANNEL_TOKEN);
                 await adminClient.query(deleteProductVariantDocument, { id: defaultOnlyVariantId });
-            }, 'No ProductVariant with the id'),
+                // Deferred so `defaultOnlyVariantId` (set in beforeAll) is read at throw time, not
+                // at test-registration time when it is still undefined.
+            }, () => `No ProductVariant with the id "${defaultOnlyVariantId.replace(/^T_/, '')}" could be found`),
         );
 
         it('the variant still exists after the cross-channel delete attempt', async () => {
@@ -1208,6 +1211,103 @@ describe('ChannelAware Products and ProductVariants', () => {
             });
             expect(productVariants.items).toEqual([]);
         });
+
+        it(
+            'deleting an unknown variant id throws rather than reporting DELETED',
+            assertThrowsWithMessage(async () => {
+                await adminClient.asSuperAdmin();
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                await adminClient.query(deleteProductVariantDocument, { id: 'T_999999' });
+            }, 'No ProductVariant with the id "999999" could be found'),
+        );
+
+        // deleteProductVariants is @Transaction()-wrapped, so a batch containing an id outside the
+        // active channel is rejected in full rather than partially applied. Skipped on sqljs, whose
+        // transaction rollback is a no-op (see database-transactions.e2e-spec.ts), so a partial
+        // delete would persist and mask the guarantee this test asserts.
+        it.skipIf(!process.env.DB || process.env.DB === 'sqljs')(
+            'deleteProductVariants discards the whole batch when one id is not in the active channel',
+            async () => {
+                await adminClient.asSuperAdmin();
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+
+                // A variant which lives only in the default channel, plus one assigned to T_2 as well.
+                const { createProduct } = await adminClient.query(createProductDocument, {
+                    input: {
+                        translations: [
+                            {
+                                languageCode: LanguageCode.en,
+                                name: 'OSS-666 Bulk Product',
+                                slug: 'oss-666-bulk',
+                                description: '',
+                            },
+                        ],
+                    },
+                });
+                const { createProductVariants } = await adminClient.query(createProductVariantsDocument, {
+                    input: [
+                        {
+                            productId: createProduct.id,
+                            sku: 'OSS-666-BULK',
+                            optionIds: [],
+                            translations: [{ languageCode: LanguageCode.en, name: 'OSS-666 Bulk Variant' }],
+                        },
+                    ],
+                });
+                productVariantGuard.assertSuccess(createProductVariants[0]);
+                const defaultOnlyId = createProductVariants[0].id;
+
+                const { createProduct: sharedProduct } = await adminClient.query(createProductDocument, {
+                    input: {
+                        translations: [
+                            {
+                                languageCode: LanguageCode.en,
+                                name: 'OSS-666 Bulk Shared Product',
+                                slug: 'oss-666-bulk-shared',
+                                description: '',
+                            },
+                        ],
+                    },
+                });
+                const { createProductVariants: sharedVariants } = await adminClient.query(
+                    createProductVariantsDocument,
+                    {
+                        input: [
+                            {
+                                productId: sharedProduct.id,
+                                sku: 'OSS-666-BULK-SHARED',
+                                optionIds: [],
+                                translations: [
+                                    { languageCode: LanguageCode.en, name: 'OSS-666 Bulk Shared Variant' },
+                                ],
+                            },
+                        ],
+                    },
+                );
+                productVariantGuard.assertSuccess(sharedVariants[0]);
+                const sharedId = sharedVariants[0].id;
+                await adminClient.query(assignProductToChannelDocument, {
+                    input: { channelId: 'T_2', productIds: [sharedProduct.id] },
+                });
+
+                // A T_2 admin deletes both in one call. Only one of them is in T_2.
+                await adminClient.asUserWithCredentials('deleter2@test.com', 'test');
+                adminClient.setChannelToken(SECOND_CHANNEL_TOKEN);
+                await expect(
+                    adminClient.query(deleteProductVariantsDocument, { ids: [sharedId, defaultOnlyId] }),
+                ).rejects.toThrow('No ProductVariant with the id');
+
+                // The batch was rejected in full: the variant the admin *could* have deleted survives.
+                await adminClient.asSuperAdmin();
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                const { productVariants } = await adminClient.query(getProductVariantListDocument, {
+                    options: { filter: { id: { in: [sharedId, defaultOnlyId] } } },
+                });
+                expect(productVariants.items.map(v => v.id).sort()).toEqual(
+                    [sharedId, defaultOnlyId].sort(),
+                );
+            },
+        );
     });
 });
 

--- a/packages/core/e2e/product-channel.e2e-spec.ts
+++ b/packages/core/e2e/product-channel.e2e-spec.ts
@@ -1,4 +1,4 @@
-import { CurrencyCode, LanguageCode, Permission } from '@vendure/common/lib/generated-types';
+import { CurrencyCode, DeletionResult, LanguageCode, Permission } from '@vendure/common/lib/generated-types';
 import type { ErrorResultGuard } from '@vendure/testing';
 import { createErrorResultGuard, createTestEnvironment, E2E_DEFAULT_CHANNEL_TOKEN } from '@vendure/testing';
 import { fail } from 'assert';
@@ -23,6 +23,8 @@ import {
     createProductOptionGroupDocument,
     createProductVariantsDocument,
     createRoleDocument,
+    deleteProductDocument,
+    deleteProductVariantDocument,
     getChannelsDocument,
     getProductVariantListDocument,
     getProductWithVariantsDocument,
@@ -1025,6 +1027,186 @@ describe('ChannelAware Products and ProductVariants', () => {
                 slug: 'unique-slug',
             });
             expect(result2?.name).toBe('Channel 3 Product');
+        });
+    });
+
+    // OSS-666 — ProductVariantService.softDelete must be channel-scoped. Without it, an admin
+    // scoped to one channel can soft-delete a ProductVariant that belongs only to another channel
+    // (a cross-channel data-integrity bypass — the delete-path analogue of the #5043 guards).
+    describe('cross-channel ProductVariant deletion protection', () => {
+        let defaultOnlyVariantId: string;
+
+        beforeAll(async () => {
+            await adminClient.asSuperAdmin();
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+
+            // A product — and therefore its variant — that lives only in the default channel (T_1).
+            const { createProduct } = await adminClient.query(createProductDocument, {
+                input: {
+                    translations: [
+                        {
+                            languageCode: LanguageCode.en,
+                            name: 'OSS-666 Default-only Product',
+                            slug: 'oss-666-default-only',
+                            description: '',
+                        },
+                    ],
+                },
+            });
+            const { createProductVariants } = await adminClient.query(createProductVariantsDocument, {
+                input: [
+                    {
+                        productId: createProduct.id,
+                        sku: 'OSS-666-VARIANT',
+                        optionIds: [],
+                        translations: [{ languageCode: LanguageCode.en, name: 'OSS-666 Variant' }],
+                    },
+                ],
+            });
+            const variant = createProductVariants[0];
+            productVariantGuard.assertSuccess(variant);
+            defaultOnlyVariantId = variant.id;
+
+            // An administrator scoped to the second channel (T_2) with delete permissions.
+            const { createRole } = await adminClient.query(createRoleDocument, {
+                input: {
+                    description: 'second channel deleter',
+                    code: 'second-channel-deleter',
+                    channelIds: ['T_2'],
+                    permissions: [
+                        Permission.ReadCatalog,
+                        Permission.DeleteCatalog,
+                        Permission.DeleteProduct,
+                    ],
+                },
+            });
+            await adminClient.query(createAdministratorDocument, {
+                input: {
+                    firstName: 'Deleter',
+                    lastName: 'Two',
+                    emailAddress: 'deleter2@test.com',
+                    password: 'test',
+                    roleIds: [createRole.id],
+                },
+            });
+        });
+
+        afterAll(async () => {
+            await adminClient.asSuperAdmin();
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+        });
+
+        it(
+            'a second-channel admin cannot delete a variant that lives only in the default channel',
+            assertThrowsWithMessage(async () => {
+                await adminClient.asUserWithCredentials('deleter2@test.com', 'test');
+                adminClient.setChannelToken(SECOND_CHANNEL_TOKEN);
+                await adminClient.query(deleteProductVariantDocument, { id: defaultOnlyVariantId });
+            }, 'No ProductVariant with the id'),
+        );
+
+        it('the variant still exists after the cross-channel delete attempt', async () => {
+            await adminClient.asSuperAdmin();
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            const { productVariants } = await adminClient.query(getProductVariantListDocument, {
+                options: { filter: { id: { eq: defaultOnlyVariantId } } },
+            });
+            expect(productVariants.items.map(v => v.id)).toEqual([defaultOnlyVariantId]);
+        });
+
+        it('the variant can still be deleted from its own (default) channel', async () => {
+            await adminClient.asSuperAdmin();
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            const { deleteProductVariant } = await adminClient.query(deleteProductVariantDocument, {
+                id: defaultOnlyVariantId,
+            });
+            expect(deleteProductVariant.result).toBe(DeletionResult.DELETED);
+        });
+
+        // The channel guard must not leak into the product-deletion cascade: deleting a Product is
+        // a global operation and must still soft-delete every one of its variants, including any
+        // that were individually removed from the deleting admin's channel.
+        it('a channel-scoped product delete still cascades to a variant removed from that channel', async () => {
+            await adminClient.asSuperAdmin();
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+
+            const { createProduct } = await adminClient.query(createProductDocument, {
+                input: {
+                    translations: [
+                        {
+                            languageCode: LanguageCode.en,
+                            name: 'OSS-666 Cascade Product',
+                            slug: 'oss-666-cascade',
+                            description: '',
+                        },
+                    ],
+                },
+            });
+            // Two variants (via an option group), so removing one from a channel leaves the other —
+            // and therefore the product — assigned to that channel.
+            const { createProductOptionGroup } = await adminClient.query(createProductOptionGroupDocument, {
+                input: {
+                    code: 'oss-666-size',
+                    translations: [{ languageCode: LanguageCode.en, name: 'Size' }],
+                    options: [
+                        { code: 'oss-666-s', translations: [{ languageCode: LanguageCode.en, name: 'S' }] },
+                        { code: 'oss-666-l', translations: [{ languageCode: LanguageCode.en, name: 'L' }] },
+                    ],
+                },
+            });
+            await adminClient.query(addOptionGroupToProductDocument, {
+                productId: createProduct.id,
+                optionGroupId: createProductOptionGroup.id,
+            });
+            const { createProductVariants } = await adminClient.query(createProductVariantsDocument, {
+                input: [
+                    {
+                        productId: createProduct.id,
+                        sku: 'OSS-666-CASCADE-S',
+                        price: 1000,
+                        optionIds: [createProductOptionGroup.options[0].id],
+                        translations: [{ languageCode: LanguageCode.en, name: 'Cascade S' }],
+                    },
+                    {
+                        productId: createProduct.id,
+                        sku: 'OSS-666-CASCADE-L',
+                        price: 1000,
+                        optionIds: [createProductOptionGroup.options[1].id],
+                        translations: [{ languageCode: LanguageCode.en, name: 'Cascade L' }],
+                    },
+                ],
+            });
+            productVariantGuard.assertSuccess(createProductVariants[0]);
+            productVariantGuard.assertSuccess(createProductVariants[1]);
+            const stayingVariantId = createProductVariants[0].id;
+            const removedVariantId = createProductVariants[1].id;
+
+            // Assign the product (and both variants) to the second channel, then remove only the
+            // second variant from it. The product stays in T_2 (via the first variant) while the
+            // second variant lives only in the default channel.
+            await adminClient.query(assignProductToChannelDocument, {
+                input: { channelId: 'T_2', productIds: [createProduct.id] },
+            });
+            await adminClient.query(removeProductVariantFromChannelDocument, {
+                input: { channelId: 'T_2', productVariantIds: [removedVariantId] },
+            });
+
+            // A second-channel admin deletes the product from T_2. The cascade must still soft-delete
+            // the out-of-channel variant rather than throwing.
+            await adminClient.asUserWithCredentials('deleter2@test.com', 'test');
+            adminClient.setChannelToken(SECOND_CHANNEL_TOKEN);
+            const { deleteProduct } = await adminClient.query(deleteProductDocument, {
+                id: createProduct.id,
+            });
+            expect(deleteProduct.result).toBe(DeletionResult.DELETED);
+
+            // Both variants — including the one removed from T_2 — were soft-deleted by the cascade.
+            await adminClient.asSuperAdmin();
+            adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            const { productVariants } = await adminClient.query(getProductVariantListDocument, {
+                options: { filter: { id: { in: [stayingVariantId, removedVariantId] } } },
+            });
+            expect(productVariants.items).toEqual([]);
         });
     });
 });

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -789,8 +789,7 @@ export class ProductVariantService {
         let variants: ProductVariant[];
         if (checkChannel) {
             variants = await this.connection.findByIdsInChannel(ctx, ProductVariant, ids, ctx.channelId, {});
-            const foundIds = new Set(variants.map(variant => `${variant.id}`));
-            const missingId = ids.find(candidate => !foundIds.has(`${candidate}`));
+            const missingId = ids.find(candidate => !variants.some(v => idsAreEqual(v.id, candidate)));
             if (missingId != null) {
                 throw new EntityNotFoundError('ProductVariant', missingId);
             }

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -773,19 +773,25 @@ export class ProductVariantService {
         }
     }
 
+    /**
+     * @description
+     * Soft-deletes the ProductVariant(s) with the given id(s).
+     *
+     * The lookup is scoped to the active Channel, so an id which does not belong to
+     * `ctx.channelId` throws an {@link EntityNotFoundError}. Previously an unknown or
+     * out-of-channel id was silently reported as deleted.
+     *
+     * @param checkChannel - Set to `false` only for trusted internal cascades which have
+     * already verified the parent entity's Channel, such as `ProductService.softDelete`.
+     * A global Product deletion must reach every one of its variants, including any which
+     * were individually removed from the active Channel.
+     */
     async softDelete(
         ctx: RequestContext,
         id: ID | ID[],
         checkChannel: boolean = true,
     ): Promise<DeletionResponse> {
         const ids = Array.isArray(id) ? id : [id];
-        // Scope the lookup to the active channel so a channel-scoped admin cannot soft-delete a
-        // ProductVariant that belongs only to another channel via the deleteProductVariant(s)
-        // mutations. A requested id not in the active channel is treated as not found, consistent
-        // with the channel-scoped lookups used elsewhere (e.g. `ProductService.softDelete`).
-        // The check is skipped for the trusted product-deletion cascade (see `ProductService.softDelete`),
-        // which has already verified the parent Product's channel and must cascade to every one of
-        // its variants regardless of their individual channel membership.
         let variants: ProductVariant[];
         if (checkChannel) {
             variants = await this.connection.findByIdsInChannel(ctx, ProductVariant, ids, ctx.channelId, {});

--- a/packages/core/src/service/services/product-variant.service.ts
+++ b/packages/core/src/service/services/product-variant.service.ts
@@ -18,7 +18,7 @@ import { In, IsNull } from 'typeorm';
 import { RequestContext } from '../../api/common/request-context';
 import { RelationPaths } from '../../api/decorators/relations.decorator';
 import { RequestContextCacheService } from '../../cache/request-context-cache.service';
-import { ForbiddenError, UserInputError } from '../../common/error/errors';
+import { EntityNotFoundError, ForbiddenError, UserInputError } from '../../common/error/errors';
 import { Instrument } from '../../common/instrument-decorator';
 import { roundMoney } from '../../common/round-money';
 import { ListQueryOptions } from '../../common/types/common-types';
@@ -773,11 +773,32 @@ export class ProductVariantService {
         }
     }
 
-    async softDelete(ctx: RequestContext, id: ID | ID[]): Promise<DeletionResponse> {
+    async softDelete(
+        ctx: RequestContext,
+        id: ID | ID[],
+        checkChannel: boolean = true,
+    ): Promise<DeletionResponse> {
         const ids = Array.isArray(id) ? id : [id];
-        const variants = await this.connection
-            .getRepository(ctx, ProductVariant)
-            .find({ where: { id: In(ids) } });
+        // Scope the lookup to the active channel so a channel-scoped admin cannot soft-delete a
+        // ProductVariant that belongs only to another channel via the deleteProductVariant(s)
+        // mutations. A requested id not in the active channel is treated as not found, consistent
+        // with the channel-scoped lookups used elsewhere (e.g. `ProductService.softDelete`).
+        // The check is skipped for the trusted product-deletion cascade (see `ProductService.softDelete`),
+        // which has already verified the parent Product's channel and must cascade to every one of
+        // its variants regardless of their individual channel membership.
+        let variants: ProductVariant[];
+        if (checkChannel) {
+            variants = await this.connection.findByIdsInChannel(ctx, ProductVariant, ids, ctx.channelId, {});
+            const foundIds = new Set(variants.map(variant => `${variant.id}`));
+            const missingId = ids.find(candidate => !foundIds.has(`${candidate}`));
+            if (missingId != null) {
+                throw new EntityNotFoundError('ProductVariant', missingId);
+            }
+        } else {
+            variants = await this.connection
+                .getRepository(ctx, ProductVariant)
+                .find({ where: { id: In(ids) } });
+        }
         for (const variant of variants) {
             variant.deletedAt = new Date();
         }

--- a/packages/core/src/service/services/product.service.ts
+++ b/packages/core/src/service/services/product.service.ts
@@ -303,9 +303,13 @@ export class ProductService {
         await this.connection.getRepository(ctx, Product).save(product, { reload: false });
         await this.eventBus.publish(new ProductEvent(ctx, product, 'deleted', productId));
 
+        // The Product's channel was already verified above, so cascade to every one of its
+        // variants (passing `checkChannel: false`): a global product soft-delete must delete all
+        // its variants, including any that were individually removed from the active channel.
         const variantResult = await this.productVariantService.softDelete(
             ctx,
             product.variants.map(v => v.id),
+            false,
         );
         if (variantResult.result === DeletionResult.NOT_DELETED) {
             await this.connection.rollBackTransaction(ctx);


### PR DESCRIPTION
## Description

`ProductVariantService.softDelete` resolved the variants to delete with a channel-unaware lookup (`getRepository(...).find({ where: { id: In(ids) } })`). Since it is reachable directly through the `deleteProductVariant` / `deleteProductVariants` admin mutations (`@Allow(DeleteCatalog, DeleteProduct)`), an administrator scoped to one channel could soft-delete a `ProductVariant` belonging only to **another** channel — a cross-channel data-integrity bypass. `ProductVariant` is `ChannelAware`.

This is the delete-path counterpart to the channel-scoping already enforced on `ProductService.softDelete` (which resolves the Product via `getEntityOrThrow(..., { channelId })`).

### Fix

- `ProductVariantService.softDelete` now scopes the lookup to the active channel via `findByIdsInChannel(ctx, ProductVariant, ids, ctx.channelId, {})` and throws `EntityNotFoundError` for any requested id that is not in the active channel — the same convention (`EntityNotFoundError`, not `ForbiddenError`) used by the sibling channel-scoped lookups, so cross-channel existence isn't leaked.
- The trusted **product-deletion cascade** (`ProductService.softDelete`) opts out (`checkChannel: false`): deleting a Product is a global operation and must still cascade to every one of its variants, including any that were individually removed from the active channel (via `removeProductVariantsFromChannel`). Without the opt-out, deleting such a product from a sub-channel would incorrectly throw.

### Tests

Adds cross-channel regression tests to `product-channel.e2e-spec.ts`:
- a second-channel admin **cannot** soft-delete a variant that lives only in the default channel (throws), the variant **survives**, and it **can** still be deleted from its own channel;
- a channel-scoped **product** delete still cascades to a variant that was removed from that channel (verifies the cascade opt-out);
- an unknown variant id **throws** rather than reporting `DELETED`;
- `deleteProductVariants` **discards the whole batch** when one id is outside the active channel — the variant the admin *could* have deleted survives. This asserts the all-or-nothing guarantee below and is the test that would fail if the `@Transaction()` wrapper were ever dropped. It is skipped on sqljs, whose transaction rollback is a no-op (same pattern as `database-transactions.e2e-spec.ts`), so a partial delete would otherwise persist and mask the guarantee.

Verified red→green for the direct-mutation guard and the cascade (each test fails against the pre-fix / pre-opt-out code). Full `product-channel` suite green on postgres (35 tests, bulk case included) and on sqljs (34 + 1 skipped).

### Behavioural note

`deleteProductVariant` / `deleteProductVariants` now throw `EntityNotFoundError` for an id that is unknown or not in the active channel, where they previously returned `DELETED` silently. This aligns variant deletion with how `deleteProduct` already behaves.

`deleteProductVariants` is `@Transaction()`-wrapped, so the throw makes the **bulk** mutation all-or-nothing: a batch containing any unknown or out-of-channel id is rejected in full rather than partially applied, and the mutation returns a top-level error instead of a `DeletionResponse[]`. Consequently the Dashboard bulk action (`product-variant-list-bulk-actions.ts:101`) no longer reaches its per-item `.message` path on such a failure. This matches `deleteProducts`, and a partial cross-channel delete is worse than a failed one.

Relates to OSS-666.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5049"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787915960&installation_model_id=20193&pr_number=5049&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5049&signature=e7117681144f3b0e7514111186c203738d17f866dac3eab55772f80095d49d1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->