### PR TITLE
feat(dashboard): Support page block descriptions

### DIFF
--- a/docs/docs/reference/dashboard/extensions-api/page-blocks.mdx
+++ b/docs/docs/reference/dashboard/extensions-api/page-blocks.mdx
@@ -13,6 +13,7 @@ on any page in the dashboard.
 interface DashboardPageBlockDefinition {
     id: string;
     title?: React.ReactNode;
+    description?: React.ReactNode;
     location: PageBlockLocation;
     component?: React.FunctionComponent<{ context: PageContextValue }>;
     shouldRender?: (context: PageContextValue) => boolean;
@@ -33,6 +34,11 @@ to the page in which it appears.
 <MemberInfo kind="property" type={`React.ReactNode`}   />
 
 An optional title for the page block
+### description
+
+<MemberInfo kind="property" type={`React.ReactNode`}  since="3.8.0"  />
+
+Optional supporting text displayed below the page block title.
 ### location
 
 <MemberInfo kind="property" type={`<a href='/reference/dashboard/extensions-api/page-blocks#pageblocklocation'>PageBlockLocation</a>`}   />

--- a/docs/docs/reference/dashboard/page-layout/page-action-bar.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-action-bar.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageActionBar
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="405" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="406" packageName="@vendure/dashboard" since="3.3.0" />
 
 A component for displaying the main actions for a page. This should be used inside the [Page](/reference/dashboard/page-layout/page#page) component.
 
@@ -117,7 +117,7 @@ Parameters
 
 ## PageActionBarLeft
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="560" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="561" packageName="@vendure/dashboard" since="3.3.0" />
 
 The PageActionBarLeft component is not used and will be removed in a future version.
 
@@ -132,7 +132,7 @@ Parameters
 
 ## PageActionBarRight
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="800" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="801" packageName="@vendure/dashboard" since="3.3.0" />
 
 The PageActionBarRight component is used to display the right content of the action bar.
 

--- a/docs/docs/reference/dashboard/page-layout/page-block.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-block.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## PageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="937" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="938" packageName="@vendure/dashboard" since="3.3.0" />
 
 *
 A component for displaying a block of content on a page. This should be used inside the [PageLayout](/reference/dashboard/page-layout/#pagelayout) component.
@@ -30,7 +30,7 @@ Parameters
 
 ## PageBlockProps
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="875" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="876" packageName="@vendure/dashboard" since="3.3.0" />
 
 Props used to configure the [PageBlock](/reference/dashboard/page-layout/page-block#pageblock) component.
 
@@ -91,7 +91,7 @@ title and description are rendered as a heading above the content.
 </div>
 ## FullWidthPageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="997" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="998" packageName="@vendure/dashboard" since="3.3.0" />
 
 **Status: Developer Preview**
 
@@ -109,7 +109,7 @@ Parameters
 
 ## CustomFieldsPageBlock
 
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="1027" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="1028" packageName="@vendure/dashboard" since="3.3.0" />
 
 *
 A component for displaying an auto-generated form for custom fields on a page.

--- a/docs/docs/reference/dashboard/page-layout/page-title.mdx
+++ b/docs/docs/reference/dashboard/page-layout/page-title.mdx
@@ -2,7 +2,7 @@
 title: "PageTitle"
 generated: true
 ---
-<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="374" packageName="@vendure/dashboard" since="3.3.0" />
+<GenerationInfo sourceFile="packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx" sourceLine="375" packageName="@vendure/dashboard" since="3.3.0" />
 
 A component for displaying the title of a page. This should be used inside the [Page](/reference/dashboard/page-layout/page#page) component.
 

--- a/docs/docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx
+++ b/docs/docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx
@@ -4,7 +4,7 @@ generated: true
 ---
 ## vendureDashboardPlugin
 
-<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="242" packageName="@vendure/dashboard" since="3.4.0" />
+<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="254" packageName="@vendure/dashboard" since="3.4.0" />
 
 This is the Vite plugin which powers the Vendure Dashboard, including:
 
@@ -23,7 +23,7 @@ Parameters
 
 ## VitePluginVendureDashboardOptions
 
-<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="39" packageName="@vendure/dashboard" since="3.4.0" />
+<GenerationInfo sourceFile="packages/dashboard/vite/vite-plugin-vendure-dashboard.ts" sourceLine="40" packageName="@vendure/dashboard" since="3.4.0" />
 
 Options for the [vendureDashboardPlugin](/reference/dashboard/vite-plugin/vendure-dashboard-plugin#venduredashboardplugin) Vite plugin.
 
@@ -85,6 +85,17 @@ type VitePluginVendureDashboardOptions = {
      * The path to the directory where the generated GraphQL Tada files will be output.
      */
     gqlOutputPath?: string;
+    /**
+     * @description
+     * The directory into which the VendureConfig is transpiled and loaded in order
+     * to introspect the configuration during the dashboard build.
+     *
+     * Defaults to `<project>/node_modules/.cache/vendure-dashboard-temp`. It must
+     * not be located inside a `"type": "module"` package (such as
+     * `@vendure/dashboard` itself), because the config is compiled to CommonJS and
+     * Node would then load it as ESM, failing with
+     * `exports is not defined in ES module scope`.
+     */
     tempCompilationDir?: string;
     /**
      * @description

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -4009,7 +4009,7 @@
                   "title": "Page Blocks",
                   "slug": "page-blocks",
                   "file": "docs/reference/dashboard/extensions-api/page-blocks.mdx",
-                  "lastModified": "2026-04-20T16:08:16+02:00"
+                  "lastModified": "2026-07-29T14:18:10Z"
                 },
                 {
                   "title": "Routes",
@@ -4275,19 +4275,19 @@
                   "title": "PageActionBar",
                   "slug": "page-action-bar",
                   "file": "docs/reference/dashboard/page-layout/page-action-bar.mdx",
-                  "lastModified": "2026-07-15T13:23:53+02:00"
+                  "lastModified": "2026-07-29T14:18:10Z"
                 },
                 {
                   "title": "PageBlock",
                   "slug": "page-block",
                   "file": "docs/reference/dashboard/page-layout/page-block.mdx",
-                  "lastModified": "2026-07-16T14:41:21+02:00"
+                  "lastModified": "2026-07-29T14:18:10Z"
                 },
                 {
                   "title": "PageTitle",
                   "slug": "page-title",
                   "file": "docs/reference/dashboard/page-layout/page-title.mdx",
-                  "lastModified": "2026-07-15T13:23:53+02:00"
+                  "lastModified": "2026-07-29T14:18:10Z"
                 },
                 {
                   "title": "UsePageBlock",
@@ -4307,7 +4307,7 @@
                   "title": "VendureDashboardPlugin",
                   "slug": "vendure-dashboard-plugin",
                   "file": "docs/reference/dashboard/vite-plugin/vendure-dashboard-plugin.mdx",
-                  "lastModified": "2026-07-15T13:23:53+02:00"
+                  "lastModified": "2026-07-29T14:18:10Z"
                 }
               ],
               "lastModified": "2026-01-28T14:49:21+01:00"

--- a/packages/dashboard/src/lib/framework/extension-api/types/layout.ts
+++ b/packages/dashboard/src/lib/framework/extension-api/types/layout.ts
@@ -139,6 +139,13 @@ export interface DashboardPageBlockDefinition {
     title?: React.ReactNode;
     /**
      * @description
+     * Optional supporting text displayed below the page block title.
+     *
+     * @since 3.8.0
+     */
+    description?: React.ReactNode;
+    /**
+     * @description
      * The location of the page block. It specifies the pageId, and then the
      * relative location compared to another existing block.
      */

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.spec.tsx
@@ -234,6 +234,27 @@ describe('PageLayout', () => {
         ]);
     });
 
+    it('renders an extension block description below its title', () => {
+        registerDashboardPageBlock({
+            id: 'described-block',
+            title: 'Block title',
+            description: 'Supporting description',
+            location: {
+                pageId: 'customer-list',
+                column: 'main',
+                position: { blockId: 'list-table', order: 'before' },
+            },
+            component: () => <div data-testid="page-block-described">content</div>,
+        });
+
+        const markup = renderWithOriginal();
+
+        expect(markup).toContain('Block title');
+        expect(markup).toContain(
+            'data-slot="card-description" class="text-muted-foreground text-sm">Supporting description</div>',
+        );
+    });
+
     // A directly-authored full-width block must render inside PageLayout on desktop. Regression:
     // the layout engine only routed the FullWidthPageBlock *type* into the full-width column, so a
     // plain <PageBlock column="full"> matched none of the main/side/full filters and silently vanished.

--- a/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
+++ b/packages/dashboard/src/lib/framework/layout-engine/page-layout.tsx
@@ -316,6 +316,7 @@ export function PageLayout({ children, className }: Readonly<PageLayoutProps>) {
                             column={extensionBlock.location.column}
                             blockId={extensionBlock.id}
                             title={extensionBlock.title}
+                            description={extensionBlock.description}
                         >
                             <extensionBlock.component context={page} />
                         </BlockComponent>,


### PR DESCRIPTION
# Description

Adds an optional `description` to extension-defined Dashboard page blocks and forwards it to the existing card description renderer, displaying muted supporting text below the title only when provided. Includes regression coverage for the rendered title and description.

# Breaking changes

No breaking changes.

# Screenshots

Not applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5050"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787926510&installation_model_id=20193&pr_number=5050&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5050&signature=211094eb877833ef5995fdb8261c1833784e72593e4377a5874a7b045228680a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->