### PR TITLE
fix(dashboard): Use updateActiveAdministrator for profile page

### DIFF
--- a/packages/dashboard/e2e/tests/settings/profile.spec.ts
+++ b/packages/dashboard/e2e/tests/settings/profile.spec.ts
@@ -1,5 +1,7 @@
 import { expect, test } from '@playwright/test';
 
+import { VendureAdminClient } from '../../utils/vendure-admin-client.js';
+
 test.describe('Profile', () => {
     test('should display profile page with form fields', async ({ page }) => {
         await page.goto('/profile');
@@ -86,5 +88,66 @@ test.describe('Profile', () => {
 
         // Reset to original value (don't submit)
         await firstNameInput.fill(originalValue);
+    });
+
+    // #5037 — an admin without UpdateAdministrator permission must still be able to
+    // edit their own profile (the page uses updateActiveAdministrator, gated by Owner)
+    test('should allow an admin without UpdateAdministrator permission to update own profile', async ({
+        page,
+        browser,
+    }) => {
+        const suffix = Date.now();
+        const emailAddress = `restricted-${suffix}@test.com`;
+        const password = 'test-password';
+
+        const client = new VendureAdminClient(page);
+        await client.login();
+        const { createRole } = await client.gql(
+            `mutation ($input: CreateRoleInput!) { createRole(input: $input) { id } }`,
+            {
+                input: {
+                    code: `restricted-${suffix}`,
+                    description: 'No admin permissions',
+                    permissions: ['ReadCatalog'],
+                },
+            },
+        );
+        await client.gql(
+            `mutation ($input: CreateAdministratorInput!) { createAdministrator(input: $input) { id } }`,
+            {
+                input: {
+                    firstName: 'Restricted',
+                    lastName: 'Admin',
+                    emailAddress,
+                    password,
+                    roleIds: [createRole.id],
+                },
+            },
+        );
+
+        // Fresh context so we browse as the restricted admin, not the superadmin
+        const context = await browser.newContext({ storageState: { cookies: [], origins: [] } });
+        const restrictedPage = await context.newPage();
+        await restrictedPage.goto('/login');
+        await restrictedPage.getByPlaceholder('Email').fill(emailAddress);
+        await restrictedPage.getByPlaceholder('Password').fill(password);
+        await restrictedPage.getByRole('button', { name: 'Sign in' }).click();
+        await expect(restrictedPage).not.toHaveURL(/\/login/, { timeout: 15_000 });
+
+        await restrictedPage.goto('/profile');
+        const firstNameField = restrictedPage.locator('[data-slot="field"]').filter({
+            has: restrictedPage.locator('[data-slot="field-label"]').getByText('First name', { exact: true }),
+        });
+        await firstNameField.getByRole('textbox').fill('Renamed');
+        await restrictedPage.getByRole('button', { name: 'Update' }).click();
+
+        await expect(
+            restrictedPage.locator('[data-sonner-toast]').filter({ hasText: 'Successfully updated profile' }),
+        ).toBeVisible({ timeout: 10_000 });
+
+        await restrictedPage.reload();
+        await expect(firstNameField.getByRole('textbox')).toHaveValue('Renamed');
+
+        await context.close();
     });
 });

--- a/packages/dashboard/src/app/routes/_authenticated/_profile/profile.graphql.ts
+++ b/packages/dashboard/src/app/routes/_authenticated/_profile/profile.graphql.ts
@@ -21,9 +21,9 @@ export const activeAdministratorDocument = graphql(`
     }
 `);
 
-export const updateAdministratorDocument = graphql(`
-    mutation UpdateAdministrator($input: UpdateAdministratorInput!) {
-        updateAdministrator(input: $input) {
+export const updateActiveAdministratorDocument = graphql(`
+    mutation UpdateActiveAdministrator($input: UpdateActiveAdministratorInput!) {
+        updateActiveAdministrator(input: $input) {
             id
         }
     }

--- a/packages/dashboard/src/app/routes/_authenticated/_profile/profile.tsx
+++ b/packages/dashboard/src/app/routes/_authenticated/_profile/profile.tsx
@@ -20,7 +20,7 @@ import { useLocalFormat } from '@/vdb/hooks/use-local-format.js';
 import { Trans, useLingui } from '@lingui/react/macro';
 import { createFileRoute } from '@tanstack/react-router';
 import { toast } from 'sonner';
-import { activeAdministratorDocument, updateAdministratorDocument } from './profile.graphql.js';
+import { activeAdministratorDocument, updateActiveAdministratorDocument } from './profile.graphql.js';
 
 const pageId = 'profile';
 
@@ -49,11 +49,10 @@ function ProfilePage() {
     const { form, submitHandler, isPending, entity } = useDetailPage({
         queryDocument: activeAdministratorDocument,
         entityField: 'activeAdministrator',
-        updateDocument: updateAdministratorDocument,
+        updateDocument: updateActiveAdministratorDocument,
         pageId,
         setValuesForUpdate: entity => {
             return {
-                id: entity.id,
                 firstName: entity.firstName,
                 lastName: entity.lastName,
                 emailAddress: entity.emailAddress,


### PR DESCRIPTION
# Description

The profile page (`/profile`) uses the `updateAdministrator` mutation, which requires `Permission.UpdateAdministrator`. This means any administrator whose role does not include that permission cannot edit their own first name, last name, email, or password — the form loads fine (the query uses `activeAdministrator` gated by `Permission.Owner`), but saving fails with a `FORBIDDEN` error.

The Admin API already has `updateActiveAdministrator` for exactly this case — it's gated by `Permission.Owner` and resolves the target from `ctx.activeUserId`, so it can only ever modify the calling user's own record.

This PR switches the profile page to use `updateActiveAdministrator`.

Fixes #5037

## What changed

| File | Change |
|---|---|
| `profile.graphql.ts` | `updateAdministrator` → `updateActiveAdministrator` (mutation name + input type) |
| `profile.tsx` | Updated import, `updateDocument` reference, removed `id` from `setValuesForUpdate` (`UpdateActiveAdministratorInput` has no `id` field — the server infers it from the active user) |

## Why this is safe

- `updateActiveAdministrator` is `@Allow(Permission.Owner)` — any authenticated admin can call it
- The resolver resolves the target admin from `ctx.activeUserId` (cannot modify other admins)
- `UpdateActiveAdministratorInput` has no `roleIds` field — prevents privilege escalation
- `customFields` is dynamically added via `graphql-custom-fields.ts` `extend input`, so custom fields on the profile page continue to work
- The separate admin detail page (`/administrators/:id`) still uses `updateAdministrator` with `Permission.UpdateAdministrator` — unchanged

# Breaking changes

None.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR

👍 Most of the time:
- [ ] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5055"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787931250&installation_model_id=20193&pr_number=5055&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5055&signature=5d99f75da7c4ffe78f653138db3c0fc39b764a9ae37b315719c58aab7eccc348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->