### PR TITLE
fix(dashboard): treat readonly custom fields as optional in Zod schema

### DIFF
--- a/packages/dashboard/src/lib/framework/form-engine/form-schema-tools.spec.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/form-schema-tools.spec.ts
@@ -41,6 +41,7 @@ const createMockCustomField = (
         datetimeMax?: string;
         list?: boolean;
         nullable?: boolean;
+        readonly?: boolean;
     } = {},
 ) => ({
     name,
@@ -303,6 +304,53 @@ describe('form-schema-tools', () => {
 
             const undefinedData = { customFields: { optionalField: undefined } };
             expect(() => schema.parse(undefinedData)).not.toThrow();
+        });
+
+        // Readonly custom fields with nullable: false should not block form submission.
+        // The server excludes readonly fields from Create/Update GraphQL input types,
+        // and the dashboard strips them from the mutation payload before submitting.
+        // So the Zod schema must treat them as optional.
+        it('should treat readonly custom fields as optional even when nullable is false', () => {
+            const fields = [createMockField('customFields', 'Object', false, false, [])];
+            const customFields = [
+                createMockCustomField('type', 'string', { nullable: false, readonly: true }),
+            ];
+
+            const schema = createFormSchemaFromFields(fields, customFields, false);
+
+            // Should accept null/undefined since readonly fields cannot be submitted
+            const nullData = { customFields: { type: null } };
+            expect(() => schema.parse(nullData)).not.toThrow();
+
+            const undefinedData = { customFields: { type: undefined } };
+            expect(() => schema.parse(undefinedData)).not.toThrow();
+
+            const emptyData = { customFields: {} };
+            expect(() => schema.parse(emptyData)).not.toThrow();
+
+            // Should still accept a value if one happens to be present
+            const withValue = { customFields: { type: 'manually-created' } };
+            expect(() => schema.parse(withValue)).not.toThrow();
+        });
+
+        // Guards against the readonly fix accidentally making every field optional.
+        // A plain nullable: false field (no readonly) must still reject null/undefined.
+        it('should reject null/undefined for non-readonly custom fields with nullable false', () => {
+            const fields = [createMockField('customFields', 'Object', false, false, [])];
+            const customFields = [
+                createMockCustomField('sku', 'string', { nullable: false }),
+            ];
+
+            const schema = createFormSchemaFromFields(fields, customFields, false);
+
+            const validData = { customFields: { sku: 'AB-123' } };
+            expect(() => schema.parse(validData)).not.toThrow();
+
+            const nullData = { customFields: { sku: null } };
+            expect(() => schema.parse(nullData)).toThrow();
+
+            const undefinedData = { customFields: { sku: undefined } };
+            expect(() => schema.parse(undefinedData)).toThrow();
         });
 
         it('should only include non-translatable fields in root context', () => {

--- a/packages/dashboard/src/lib/framework/form-engine/form-schema-tools.ts
+++ b/packages/dashboard/src/lib/framework/form-engine/form-schema-tools.ts
@@ -257,7 +257,7 @@ function applyCustomFieldModifiers(zodType: ZodType, customField: CustomFieldCon
     if (customField.list) {
         modifiedType = z.array(modifiedType);
     }
-    if (customField.nullable !== false) {
+    if (customField.nullable !== false || customField.readonly) {
         modifiedType = modifiedType.optional().nullable();
     }
     if (customField.readonly) {


### PR DESCRIPTION
## Breaking changes

No breaking changes. This is a purely additive fix — the only behavioral change is that readonly custom fields with `nullable: false` no longer block form submission. All existing validation behavior for non-readonly fields is unchanged.

## Summary

Fixes #5045

When a custom field is configured with both `readonly: true` and `nullable: false`, the Dashboard's Zod validation schema treats it as **required**. But readonly fields can never receive a value from the form:

- The server excludes them from `Create*Input` / `Update*Input` GraphQL types
- The Dashboard strips them via `removeReadonlyAndLocalizedCustomFields()` before submitting
- The input is rendered disabled

The result is an unsatisfiable schema — the form is permanently invalid and the Create/Update button stays disabled.

**Fix:** A single-condition change in `applyCustomFieldModifiers()` — readonly fields are now always treated as optional regardless of their `nullable` setting.

```diff
- if (customField.nullable !== false) {
+ if (customField.nullable !== false || customField.readonly) {
```

## Checklist

- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have checked my own PR
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787948570&installation_model_id=20193&pr_number=5057&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5057&signature=5c0e1971205dee60f87f5655105b4970075f70d55c4fe6c18aa790b212919b6b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->