### PR TITLE
fix(core): Price every ProductVariant in relation arrays, avoid spread RangeError

### DIFF
--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
+import { Asset } from '../../../entity/asset/asset.entity';
+import { ProductVariant } from '../../../entity/product-variant/product-variant.entity';
+import { ProductPriceApplicator } from '../product-price-applicator/product-price-applicator';
+
 import { EntityHydrator } from './entity-hydrator.service';
 
 describe('EntityHydrator', () => {
@@ -261,6 +265,157 @@ describe('EntityHydrator', () => {
 
             expect(result).toHaveLength(1_000_000);
             expect(result[5]).toBeUndefined();
+        });
+    });
+
+    describe('getProductVariantsToPrice()', () => {
+        function getProductVariantsToPrice(entity: any): ProductVariant[] {
+            const hydrator = new EntityHydrator(undefined as any, undefined as any, undefined as any);
+            return (hydrator as any).getProductVariantsToPrice(entity);
+        }
+
+        // These pin the semantics of the helper rather than guard a regression: they are also
+        // satisfied by the pre-helper code, which skipped all three shapes by other means.
+        it('returns an empty array for an empty array', () => {
+            expect(getProductVariantsToPrice([])).toEqual([]);
+        });
+
+        it('returns an empty array when the array contains only holes', () => {
+            expect(getProductVariantsToPrice([null, undefined])).toEqual([]);
+        });
+
+        it('returns an empty array for non-ProductVariant entities', () => {
+            const assets = [new Asset({ id: 1 }), new Asset({ id: 2 })];
+            expect(getProductVariantsToPrice(assets)).toEqual([]);
+        });
+    });
+
+    describe('hydrate() with applyProductVariantPrices', () => {
+        class TestOrder {
+            id = 1;
+            children?: any[];
+        }
+        class TestChild {}
+
+        /**
+         * Drives the real hydrate() against a stubbed query builder that returns a fixed
+         * hydrated result. The ProductPriceApplicator is the real implementation with stubbed
+         * strategies, so a crash in applyChannelPriceAndTax() is a real crash, not a mock
+         * artefact. A relation array can contain `null`/`undefined` elements —
+         * getRelationEntityAtPath() pushes them deliberately — and the price application at the
+         * hydrate() call site must neither skip the whole array because of one (the `[0]` sample
+         * did) nor pass one to applyChannelPriceAndTax(), which dereferences its argument.
+         */
+        function createHydrator(children: any[]) {
+            const variantMetadata = {
+                target: ProductVariant,
+                findRelationWithPropertyPath: () => undefined,
+            };
+            const childMetadata = {
+                target: TestChild,
+                findRelationWithPropertyPath: (path: string) =>
+                    path === 'variant' ? { inverseEntityMetadata: variantMetadata } : undefined,
+            };
+            const orderMetadata = {
+                target: TestOrder,
+                treeType: undefined,
+                relations: [],
+                findRelationWithPropertyPath: (path: string) =>
+                    path === 'children' ? { inverseEntityMetadata: childMetadata } : undefined,
+            };
+            const queryBuilder = {
+                alias: 'TestOrder',
+                connection: { getMetadata: () => orderMetadata },
+                expressionMap: { joinAttributes: [] },
+                setFindOptions: () => queryBuilder,
+                getOne: () => Promise.resolve({ children }),
+            };
+            const connection = {
+                rawConnection: { entityMetadatas: [orderMetadata] },
+                getRepository: () => ({ createQueryBuilder: () => queryBuilder }),
+            };
+            const configService = {
+                catalogOptions: {
+                    productVariantPriceSelectionStrategy: {
+                        selectPrice: (_ctx: any, prices: any[]) => Promise.resolve(prices[0]),
+                    },
+                    productVariantPriceCalculationStrategy: {
+                        calculate: ({ inputPrice }: any) =>
+                            Promise.resolve({ price: inputPrice, priceIncludesTax: false }),
+                    },
+                },
+                taxOptions: {
+                    taxZoneStrategy: { determineTaxZone: () => ({ id: 1 }) },
+                },
+            };
+            const priceApplicator = new ProductPriceApplicator(
+                configService as any,
+                { getApplicableTaxRate: () => Promise.resolve({ id: 1 }) } as any,
+                { getAllWithMembers: () => Promise.resolve([]) } as any,
+                { get: (_ctx: any, _key: any, getValue: () => any) => getValue() } as any,
+            );
+            const translator = { translate: (entity: any) => entity };
+            const hydrator = new EntityHydrator(connection as any, priceApplicator, translator as any);
+            const ctx = { channelId: 1, currencyCode: 'USD' } as any;
+            return { hydrator, ctx, target: new TestOrder() };
+        }
+
+        function createVariant(id: number): ProductVariant {
+            return new ProductVariant({
+                id,
+                productVariantPrices: [{ price: 4200, currencyCode: 'USD' }] as any,
+                taxCategory: { id: 1 } as any,
+            });
+        }
+
+        it('prices a variant that sits behind a null array element', async () => {
+            const variant = createVariant(1);
+            const { hydrator, ctx, target } = createHydrator([{ variant: null }, { variant }]);
+
+            await hydrator.hydrate(
+                ctx,
+                target as any,
+                {
+                    relations: ['children.variant'],
+                    applyProductVariantPrices: true,
+                } as any,
+            );
+
+            expect(variant.listPrice).toBe(4200);
+        });
+
+        it('does not pass a null array element to the price applicator', async () => {
+            const variant = createVariant(1);
+            const { hydrator, ctx, target } = createHydrator([{ variant }, { variant: null }]);
+
+            await hydrator.hydrate(
+                ctx,
+                target as any,
+                {
+                    relations: ['children.variant'],
+                    applyProductVariantPrices: true,
+                } as any,
+            );
+
+            expect(variant.listPrice).toBe(4200);
+        });
+
+        it('prices every element when the array is fully populated', async () => {
+            const variant1 = createVariant(1);
+            const variant2 = createVariant(2);
+            const { hydrator, ctx, target } = createHydrator([{ variant: variant1 }, { variant: variant2 }]);
+
+            await hydrator.hydrate(
+                ctx,
+                target as any,
+                {
+                    relations: ['children.variant'],
+                    applyProductVariantPrices: true,
+                } as any,
+            );
+
+            expect(variant1.listPrice).toBe(4200);
+            expect(variant2.listPrice).toBe(4200);
         });
     });
 });

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
@@ -216,9 +216,13 @@ describe('EntityHydrator', () => {
     });
 
     describe('getRelationEntityAtPath()', () => {
+        function getRelationEntityAtPath(target: any, path: string[]): any {
+            const hydrator = new EntityHydrator(undefined as any, undefined as any, undefined as any);
+            return (hydrator as any).getRelationEntityAtPath(target, path);
+        }
+
         // https://github.com/vendurehq/vendure/issues/4661
         it('treats undefined intermediate relations as terminal values', () => {
-            const hydrator = new EntityHydrator(undefined as any, undefined as any, undefined as any);
             const translation = { languageCode: 'en', name: 'Laptop' };
             const order = {
                 lines: [
@@ -233,13 +237,30 @@ describe('EntityHydrator', () => {
                 ],
             };
 
-            const result = (hydrator as any).getRelationEntityAtPath(order, [
-                'lines',
-                'productVariant',
-                'translations',
-            ]);
+            const result = getRelationEntityAtPath(order, ['lines', 'productVariant', 'translations']);
 
             expect(result).toEqual([translation, undefined]);
+        });
+
+        it('does not crash when a terminal relation array is very large', () => {
+            // A relation at the end of the path is collected element by element. `push(...target)`
+            // expands the array into call arguments, which exceeds V8's stack budget and throws a
+            // RangeError — the same failure fixed in getMissingRelations() in #4986. Reproduces
+            // e.g. `collection.productVariants` on a big catalog.
+            //
+            // The limit is a stack budget rather than a fixed count, so it moves with the Node
+            // version and the vitest pool (measured on Node 22: ~110k in a process, ~495k in a
+            // worker thread). The fixture is sized well above both. The hole is deliberate:
+            // `target.forEach(...)` would also avoid the RangeError but silently skips holes, and
+            // the walk must preserve them.
+            const variant = { id: 1 };
+            const productVariants = new Array(1_000_000).fill(variant);
+            delete productVariants[5];
+
+            const result = getRelationEntityAtPath({ productVariants }, ['productVariants']);
+
+            expect(result).toHaveLength(1_000_000);
+            expect(result[5]).toBeUndefined();
         });
     });
 });

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
@@ -288,6 +288,15 @@ describe('EntityHydrator', () => {
             const assets = [new Asset({ id: 1 }), new Asset({ id: 2 })];
             expect(getProductVariantsToPrice(assets)).toEqual([]);
         });
+
+        it('wraps a bare ProductVariant in an array', () => {
+            const variant = new ProductVariant({ id: 1 });
+            expect(getProductVariantsToPrice(variant)).toEqual([variant]);
+        });
+
+        it('returns an empty array for undefined', () => {
+            expect(getProductVariantsToPrice(undefined)).toEqual([]);
+        });
     });
 
     describe('hydrate() with applyProductVariantPrices', () => {

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -314,7 +314,13 @@ export class EntityHydrator {
             if (Array.isArray(target)) {
                 isArrayResult = true;
                 if (parts.length === 0) {
-                    result.push(...target);
+                    // Use a plain loop rather than push(...target): spreading a very large array
+                    // (e.g. `collection.productVariants` on a big catalog) expands it into call
+                    // arguments, which exceeds V8's stack budget and throws a RangeError. Same
+                    // fix as in getMissingRelations() above.
+                    for (const item of target) {
+                        result.push(item);
+                    }
                 } else {
                     for (const item of target) {
                         visit(item, parts.slice());

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -151,22 +151,11 @@ export class EntityHydrator {
 
                 if (options.applyProductVariantPrices === true) {
                     for (const relationWithEntities of relationsWithEntities) {
-                        const entity = relationWithEntities.entity;
-                        if (entity) {
-                            if (Array.isArray(entity)) {
-                                if (entity[0] instanceof ProductVariant) {
-                                    await Promise.all(
-                                        entity.map((e: any) =>
-                                            this.productPriceApplicator.applyChannelPriceAndTax(e, ctx),
-                                        ),
-                                    );
-                                }
-                            } else {
-                                if (entity instanceof ProductVariant) {
-                                    await this.productPriceApplicator.applyChannelPriceAndTax(entity, ctx);
-                                }
-                            }
-                        }
+                        await Promise.all(
+                            this.getProductVariantsToPrice(relationWithEntities.entity).map(variant =>
+                                this.productPriceApplicator.applyChannelPriceAndTax(variant, ctx),
+                            ),
+                        );
                     }
                 }
 
@@ -338,6 +327,20 @@ export class EntityHydrator {
         }
         visit(entity, path.slice());
         return isArrayResult ? result : result[0];
+    }
+
+    /**
+     * Returns the ProductVariants found at a relation path, to which Channel prices should be
+     * applied. A relation array can contain `null`/`undefined` entries — getRelationEntityAtPath()
+     * pushes them deliberately — and only some of its elements may be ProductVariants, so the type
+     * is tested per element rather than sampled from element [0]. Sampling [0] was wrong in both
+     * directions: a hole at [0] suppressed pricing for every real ProductVariant in the array, and
+     * a ProductVariant at [0] passed the holes behind it straight into applyChannelPriceAndTax(),
+     * which dereferences `variant.productVariantPrices` and throws.
+     */
+    private getProductVariantsToPrice(entity: VendureEntity | VendureEntity[] | undefined): ProductVariant[] {
+        const candidates = Array.isArray(entity) ? entity : [entity];
+        return candidates.filter((e): e is ProductVariant => e instanceof ProductVariant);
     }
 
     private getRelationEntityTypeAtPath(entity: VendureEntity, path: string): Type<VendureEntity> {

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -151,11 +151,12 @@ export class EntityHydrator {
 
                 if (options.applyProductVariantPrices === true) {
                     for (const relationWithEntities of relationsWithEntities) {
-                        await Promise.all(
-                            this.getProductVariantsToPrice(relationWithEntities.entity).map(variant =>
-                                this.productPriceApplicator.applyChannelPriceAndTax(variant, ctx),
-                            ),
-                        );
+                        // Applied sequentially rather than with Promise.all: relation arrays are
+                        // unbounded in size, and applyChannelPriceAndTax() is applied per variant
+                        // the same way in ProductVariantService.assignProductVariantsToChannel()
+                        for (const variant of this.getProductVariantsToPrice(relationWithEntities.entity)) {
+                            await this.productPriceApplicator.applyChannelPriceAndTax(variant, ctx);
+                        }
                     }
                 }
 


### PR DESCRIPTION
# Description

This is the first half of the follow-up agreed in [#4986](<https://github.com/vendurehq/vendure/issues/4986>). @michaelbromley wrote there:

> Separate follow-up (not this PR): `isTranslatable()` and the price applicator still sample element `[0]`, so e.g. a null `variants[0].featuredAsset` suppresses translation of the newly-hydrated `variants[1].featuredAsset`.

and @biggamesmallworld added a note on reachability:

> The `undefined`-hole change in this PR widens who can hit it. If element `[0]` of a relation array is a hole or `null`, `getRelationEntityAtPath()` pushes it into the result, and the `entity[0] instanceof ProductVariant` sample then skips pricing (and `isTranslatable()` skips translation) for the **entire** array, not just that element. Same root cause, more reachable now.

**This PR covers the price-applicator half, plus a sibling spread overflow in the same class.** The `isTranslatable()` half needs a change in `translate-entity.ts` to avoid regressing `null` relations into `undefined`, so it goes in companion PR vendurehq/vendure#5059 to keep each review focused.

## Fix 1: `[0]` sampling in the price application (second commit)

Whether an array-valued relation received prices was decided by `entity[0] instanceof ProductVariant`, but `entity.map(...)` then called `applyChannelPriceAndTax()` on **every** element — and `applyChannelPriceAndTax()` dereferences its argument on its first statement (`variant.productVariantPrices`). Since `getRelationEntityAtPath()` deliberately pushes `null`/`undefined` elements into its result, the `[0]` sample was wrong in both directions:

<!-- linear:table-colwidths:266,266,266 -->
| relation array | master | this PR |
| -- | -- | -- |
| `[null, variant]` | silently prices nothing | prices `variant` |
| `[variant, null]` | `TypeError` out of `hydrate()` | prices `variant` |
| `[variant, variant]` | prices both | prices both (unchanged) |

So `[0]` was not acting as a guard — it was a coin flip on where the hole sits. The variants to price are now selected with a per-element type-guard filter (new `getProductVariantsToPrice()` helper), which fixes both directions at once. Note that widening the gate alone (e.g. `entity.some(e => e instanceof ProductVariant)`) would have made things *worse*: it converts both silent-skip rows above into crashes because the body still maps over every element. I verified that variant against the new tests and it fails both of them.

On reachability, to be precise: every core `@ManyToOne` into `ProductVariant` is non-nullable, so pure core code mostly cannot produce the mixed array; the live path is the `undefined` hole on entities held in plugin/event-handler code (the vendurehq/vendure#4955 lineage), which [#4986](<https://github.com/vendurehq/vendure/issues/4986>)'s hole-preservation made more visible, as noted in the quote above.

## Fix 2: spread `RangeError` in `getRelationEntityAtPath()` (first commit)

`getRelationEntityAtPath()` collects a terminal relation array with `result.push(...target)` — the exact defect you had me fix in `getMissingRelations()` in [#4986](<https://github.com/vendurehq/vendure/issues/4986>) (spreading a very large array into call arguments exceeds V8's stack budget and throws `RangeError: Maximum call stack size exceeded`). **I missed this sibling occurrence in the same class when writing that fix**; found it while scoping this follow-up. Replaced with the same `for...of` loop merged in [#4986](<https://github.com/vendurehq/vendure/issues/4986>). `forEach` would also avoid the `RangeError` but silently skips holes (measured: 999,999 elements collected instead of 1,000,000), which matters precisely because downstream code now handles those holes per element.

The two fixes are in one PR because they are causally linked: fix 2 un-blocks arrays above \~110k elements so they now *reach* the price application instead of aborting `hydrate()` — landing them together means the path fix 2 opens is already safe on arrival.

# Breaking changes

None. Arrays whose element `[0]` was a hole now get their real ProductVariants priced (the documented intent of `applyProductVariantPrices`), and very large terminal relation arrays no longer throw. A variant that master's `[0]` sample skipped and this PR now prices takes exactly the exposure master already takes today on every array whose `[0]` is a variant — `getRequiredProductVariantRelations()` appends `.taxCategory`/`.productVariantPrices` for those paths under the same option flag. Cost-wise, the filter adds one `instanceof` check per element, only under `applyProductVariantPrices: true`, on an array the code already walks to price.

# Testing

**Unit** (`entity-hydrator.service.spec.ts`, 7 new cases, no DB):

* 2 call-site tests drive the real `hydrate()` (stubbed query builder, real `ProductPriceApplicator` with stubbed strategies) and are the regression guards for fix 1 — one per failure direction. RED on master: `[null, variant]` leaves `listPrice` unset; `[variant, null]` rejects with `TypeError: Cannot read properties of null (reading 'productVariantPrices')`.
* 1 pins the fully-populated `[variant, variant]` case; passes before and after.
* 3 pin the semantic edges of the new helper (`[]`, `[null, undefined]`, non-ProductVariant entities). These are spec-locks for the helper, not regression proofs — stated here so the coverage isn't overread.
* 1 guards fix 2: a 1M-element terminal relation array with a deliberate hole. RED on master with `RangeError` at the `push(...target)` line; the hole assertion is what rules out a `forEach`-based fix. Costs \~35 ms / \~58 MB transient on an M-series Mac (measured), cheaper than the neighbouring 200k-distinct-objects fixture.

**Robustness checks on the tests themselves**: I mutation-tested the suite — reverting each fix individually, substituting the `.some()` gate for fix 1 and `forEach` for fix 2 — and confirmed every mutant turns at least one of the new tests red (after asserting the mutant actually applied).

What I ran:

<!-- linear:table-colwidths:400,400 -->
|  | Result |
| -- | -- |
| `entity-hydrator.service.spec.ts` before the fixes | 6 failed / 16 passed |
| `entity-hydrator.service.spec.ts` after | 22 passed |
| Full core unit suite | 75 files, 1144 passed |
| `entity-hydrator.e2e-spec.ts` (rebuilt dist) | 25 passed |

No new e2e: no core relation can produce the mixed array (non-nullable FKs, see reachability note), so an e2e would need a permanent nullable-FK fixture change purely to demonstrate a shape core cannot produce, and would only exercise one failure direction per run depending on row order. The DB-free call-site tests cover both directions deterministically. The pre-existing type error in `order.service.ts:1460` that stops `npm run build` locally is unrelated (file untouched, reproduces on clean master).

### 🤖 AI assistance

I used Claude Code while working on this. I have reviewed every line of the change myself, and the testing table above reflects test runs I actually performed and observed — including verifying that each new regression test fails without its fix and passes with it.

# Checklist

📌 Always:

- [X] I have set a clear title
- [X] My PR is small and contains a single feature
- [X] I have [checked my own PR](<##>)

👍 Most of the time:

- [X] I have added or updated test cases
- [ ] I have updated the README if needed

---

![View with \[code\]smith](https://camo.githubusercontent.com/6e22944985996f6a1201f1d35788e9dc855f2e6b7b781e7ed1c22d7fb14217e8/68747470733a2f2f70722d636f6d6d656e74732d6173736574732e626c61636b736d6974682e73682f636f6465736d6974682f766965772d776974682d636f6465736d6974682d6461726b2d76322e737667) ![Autofix with \[code\]smith](https://camo.githubusercontent.com/8e7d836069a9e09b18eb0f68d9afc9beb6c2b13211745830b36a5d88a500d653/68747470733a2f2f70722d636f6d6d656e74732d6173736574732e626c61636b736d6974682e73682f636f6465736d6974682f6175746f6669782d776974682d636f6465736d6974682d6461726b2e737667) Need help on this PR? Tag `@codesmith-bot` with what you need. Autofix is disabled.