### PR TITLE
fix(core): Check every element in isTranslatable, harden translateDeep against holes

### DIFF
--- a/packages/core/e2e/entity-hydrator.e2e-spec.ts
+++ b/packages/core/e2e/entity-hydrator.e2e-spec.ts
@@ -10,6 +10,7 @@ import {
     OrderLine,
     OrderService,
     Product,
+    ProductVariant,
     RequestContext,
     RequestContextService,
     TransactionalConnection,
@@ -522,6 +523,44 @@ describe('Entity hydration', () => {
         const child = entity.childrenPropertyWithAVeryLongNameThatExceedsPostgresLimitsEasilyByItself[0];
         expect(child.image1).toBeDefined();
         expect(child.image2).toBeDefined();
+    });
+
+    // Follow-up to #4986: isTranslatable() decided from element [0] whether an entire relation
+    // array was translatable. With a null featuredAsset at [0], nothing in the array was
+    // translated (Asset.name is a LocaleString, so it stayed undefined); with the asset at [0],
+    // translation ran but every other element's null featuredAsset was rewritten to undefined.
+    // The assertions below fail under either ordering, so the test does not depend on DB row
+    // order or on the id strategy.
+    it('translates a relation reached past a null array element', async () => {
+        const ctx = await server.app.get(RequestContextService).create({ apiType: 'admin' });
+        const connection = server.app.get(TransactionalConnection).rawConnection;
+        const asset = await connection.getRepository(Asset).findOne({ where: {} });
+        const assetName = asset!.translations.find(t => t.languageCode === ctx.languageCode)!.name;
+
+        const laptop = await connection
+            .getRepository(Product)
+            .findOne({ where: { id: 1 }, relations: ['variants'] });
+        // Give exactly one of the four variants a featuredAsset; the other three keep the
+        // featuredAsset that is null in the database.
+        await connection
+            .getRepository(ProductVariant)
+            .update(laptop!.variants[laptop!.variants.length - 1].id, { featuredAsset: asset! });
+
+        const product = await connection
+            .getRepository(Product)
+            .findOne({ where: { id: 1 }, relations: ['variants'] });
+
+        await server.app.get(EntityHydrator).hydrate(ctx, product!, {
+            relations: ['variants.featuredAsset'],
+        });
+
+        const withAsset = product!.variants.filter(v => v.featuredAsset != null);
+        expect(withAsset.length).toBe(1);
+        expect(withAsset[0].featuredAsset.name).toBe(assetName);
+        // The other three were null in the database and must still be null, not undefined:
+        // getMissingRelations() treats undefined as never-fetched, so hydrate() would re-query
+        // them on every subsequent call.
+        expect(product!.variants.filter(v => v.featuredAsset === null).length).toBe(3);
     });
 });
 

--- a/packages/core/e2e/entity-hydrator.e2e-spec.ts
+++ b/packages/core/e2e/entity-hydrator.e2e-spec.ts
@@ -534,33 +534,45 @@ describe('Entity hydration', () => {
     it('translates a relation reached past a null array element', async () => {
         const ctx = await server.app.get(RequestContextService).create({ apiType: 'admin' });
         const connection = server.app.get(TransactionalConnection).rawConnection;
-        const asset = await connection.getRepository(Asset).findOne({ where: {} });
-        const assetName = asset!.translations.find(t => t.languageCode === ctx.languageCode)!.name;
+        // The expected name is the known fixture literal (also asserted near the top of this
+        // file), so the expectation is independent of the data the translation path reads
+        const assetName = 'derick-david-409858-unsplash.jpg';
+        const assets = await connection.getRepository(Asset).find();
+        const asset = assets.find(a => a.translations.some(t => t.name === assetName));
 
+        // Raw-connection queries take the numeric DB id; 'T_1' exists only at the API layer
         const laptop = await connection
             .getRepository(Product)
             .findOne({ where: { id: 1 }, relations: ['variants'] });
-        // Give exactly one of the four variants a featuredAsset; the other three keep the
+        const variantWithAssetId = laptop!.variants[laptop!.variants.length - 1].id;
+        const nullAssetVariantCount = laptop!.variants.length - 1;
+        // Give exactly one of the variants a featuredAsset; the others keep the
         // featuredAsset that is null in the database.
-        await connection
-            .getRepository(ProductVariant)
-            .update(laptop!.variants[laptop!.variants.length - 1].id, { featuredAsset: asset! });
+        await connection.getRepository(ProductVariant).update(variantWithAssetId, { featuredAsset: asset! });
+        try {
+            const product = await connection
+                .getRepository(Product)
+                .findOne({ where: { id: 1 }, relations: ['variants'] });
 
-        const product = await connection
-            .getRepository(Product)
-            .findOne({ where: { id: 1 }, relations: ['variants'] });
+            await server.app.get(EntityHydrator).hydrate(ctx, product!, {
+                relations: ['variants.featuredAsset'],
+            });
 
-        await server.app.get(EntityHydrator).hydrate(ctx, product!, {
-            relations: ['variants.featuredAsset'],
-        });
-
-        const withAsset = product!.variants.filter(v => v.featuredAsset != null);
-        expect(withAsset.length).toBe(1);
-        expect(withAsset[0].featuredAsset.name).toBe(assetName);
-        // The other three were null in the database and must still be null, not undefined:
-        // getMissingRelations() treats undefined as never-fetched, so hydrate() would re-query
-        // them on every subsequent call.
-        expect(product!.variants.filter(v => v.featuredAsset === null).length).toBe(3);
+            const withAsset = product!.variants.filter(v => v.featuredAsset != null);
+            expect(withAsset.length).toBe(1);
+            expect(withAsset[0].featuredAsset.name).toBe(assetName);
+            // The others were null in the database and must still be null, not undefined:
+            // getMissingRelations() treats undefined as never-fetched, so hydrate() would
+            // re-query them on every subsequent call.
+            expect(product!.variants.filter(v => v.featuredAsset === null).length).toBe(
+                nullAssetVariantCount,
+            );
+        } finally {
+            // Restore the shared fixture so tests added after this one do not inherit it
+            await connection
+                .getRepository(ProductVariant)
+                .update(variantWithAssetId, { featuredAsset: null });
+        }
     });
 });
 

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
@@ -242,4 +242,34 @@ describe('EntityHydrator', () => {
             expect(result).toEqual([translation, undefined]);
         });
     });
+
+    describe('isTranslatable()', () => {
+        function isTranslatable(input: any): boolean {
+            const hydrator = new EntityHydrator(undefined as any, undefined as any, undefined as any);
+            return (hydrator as any).isTranslatable(input);
+        }
+        const translatable = { translations: [{ languageCode: 'en', name: 'Laptop' }] };
+
+        // A relation array can contain `null` (fetched but null on that element) or `undefined`
+        // (never fetched) entries — getRelationEntityAtPath() pushes both deliberately — so
+        // whether the relation is translatable cannot be decided from element [0] alone.
+        it('detects a translatable entity after a null leading element', () => {
+            expect(isTranslatable([null, translatable])).toBe(true);
+        });
+
+        it('detects a translatable entity after an undefined leading hole', () => {
+            expect(isTranslatable([undefined, translatable])).toBe(true);
+        });
+
+        // Pins `some` semantics: nothing to translate must stay false. These pass before and
+        // after the fix.
+        it('reports false for an empty array', () => {
+            expect(isTranslatable([])).toBe(false);
+        });
+
+        it('reports false when no element is translatable', () => {
+            expect(isTranslatable([null, null])).toBe(false);
+            expect(isTranslatable([{ id: 1 }, null])).toBe(false);
+        });
+    });
 });

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.spec.ts
@@ -261,8 +261,7 @@ describe('EntityHydrator', () => {
             expect(isTranslatable([undefined, translatable])).toBe(true);
         });
 
-        // Pins `some` semantics: nothing to translate must stay false. These pass before and
-        // after the fix.
+        // The falsy side: an array with nothing translatable must report false
         it('reports false for an empty array', () => {
             expect(isTranslatable([])).toBe(false);
         });

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -384,9 +384,17 @@ export class EntityHydrator {
         return translationRelations;
     }
 
+    /**
+     * Whether the entity, or any entity of an array-valued relation, is translatable. An array
+     * relation can contain `null` (the relation was fetched but is null on that element) or
+     * `undefined` (never fetched) entries — getRelationEntityAtPath() deliberately pushes both
+     * into its result — so every element must be considered rather than just the first. Sampling
+     * element [0] meant e.g. a null `variants[0].featuredAsset` suppressed translation of
+     * `variants[1].featuredAsset`.
+     */
     private isTranslatable<T extends VendureEntity>(input: T | T[] | undefined): boolean {
-        return Array.isArray(input)
-            ? (input[0]?.hasOwnProperty('translations') ?? false)
-            : (input?.hasOwnProperty('translations') ?? false);
+        const hasTranslations = (entity: T | undefined): boolean =>
+            entity?.hasOwnProperty('translations') ?? false;
+        return Array.isArray(input) ? input.some(hasTranslations) : hasTranslations(input);
     }
 }

--- a/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
+++ b/packages/core/src/service/helpers/entity-hydrator/entity-hydrator.service.ts
@@ -388,9 +388,7 @@ export class EntityHydrator {
      * Whether the entity, or any entity of an array-valued relation, is translatable. An array
      * relation can contain `null` (the relation was fetched but is null on that element) or
      * `undefined` (never fetched) entries — getRelationEntityAtPath() deliberately pushes both
-     * into its result — so every element must be considered rather than just the first. Sampling
-     * element [0] meant e.g. a null `variants[0].featuredAsset` suppressed translation of
-     * `variants[1].featuredAsset`.
+     * into its result — so every element must be considered rather than just the first.
      */
     private isTranslatable<T extends VendureEntity>(input: T | T[] | undefined): boolean {
         const hasTranslations = (entity: T | undefined): boolean =>

--- a/packages/core/src/service/helpers/utils/translate-entity.spec.ts
+++ b/packages/core/src/service/helpers/utils/translate-entity.spec.ts
@@ -2,6 +2,8 @@ import { LanguageCode } from '@vendure/common/lib/generated-types';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import { Translatable, Translation } from '../../../common/types/locale-types';
+import { AssetTranslation } from '../../../entity/asset/asset-translation.entity';
+import { Asset } from '../../../entity/asset/asset.entity';
 import { VendureEntity } from '../../../entity/base/base.entity';
 import { CollectionTranslation } from '../../../entity/collection/collection-translation.entity';
 import { Collection } from '../../../entity/collection/collection.entity';
@@ -448,6 +450,67 @@ describe('translateDeep()', () => {
                 [['singleRealVariant', 'options']],
             ),
         ).not.toThrow();
+    });
+
+    // A relation array can contain `undefined` (an element that was never fetched) or `null`
+    // (fetched, but null in the database) entries — EntityHydrator's getRelationEntityAtPath()
+    // produces both deliberately. Translation must skip such elements rather than dereference
+    // them, and must not rewrite a `null` into `undefined`, because getMissingRelations()
+    // relies on that distinction to decide whether a relation still needs to be fetched.
+    it('does not throw when a relation array contains an undefined hole', () => {
+        product.variants = [productVariant, undefined] as any;
+
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], ['variants']);
+
+        expect(result.variants).toHaveLength(2);
+        expect(result.variants[0]).toHaveProperty('name', VARIANT_NAME_EN);
+        expect(result.variants[1]).toBeUndefined();
+    });
+
+    it('does not throw when a relation array contains a null element', () => {
+        product.variants = [null, productVariant] as any;
+
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], ['variants']);
+
+        expect(result.variants).toHaveLength(2);
+        expect(result.variants[0]).toBeNull();
+        expect(result.variants[1]).toHaveProperty('name', VARIANT_NAME_EN);
+    });
+
+    it('does not throw when a first-level array element is a hole', () => {
+        product.variants = [undefined, productVariant] as any;
+
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], [
+            ['variants', 'options'],
+        ] as any);
+
+        expect(result.variants[0]).toBeUndefined();
+        expect(result.variants[1].options[0]).toHaveProperty('name', OPTION_NAME_EN);
+    });
+
+    it('leaves a null nested relation as null', () => {
+        const ASSET_NAME_EN = 'English Asset';
+        const assetTranslation = new AssetTranslation();
+        assetTranslation.id = '51';
+        assetTranslation.languageCode = LANGUAGE_CODE;
+        assetTranslation.name = ASSET_NAME_EN;
+        const asset = new Asset();
+        asset.id = '5';
+        asset.translations = [assetTranslation];
+
+        const secondVariant = new ProductVariant();
+        secondVariant.id = '4';
+        secondVariant.translations = [productVariantTranslation];
+        (productVariant as any).featuredAsset = null;
+        secondVariant.featuredAsset = asset;
+        product.variants = [productVariant, secondVariant];
+
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], [
+            ['variants', 'featuredAsset'],
+        ] as any);
+
+        expect(result.variants[0].featuredAsset).toBeNull();
+        expect(result.variants[1].featuredAsset).toHaveProperty('name', ASSET_NAME_EN);
     });
 
     it('should translate a first-level nested non-array entity', () => {

--- a/packages/core/src/service/helpers/utils/translate-entity.spec.ts
+++ b/packages/core/src/service/helpers/utils/translate-entity.spec.ts
@@ -513,6 +513,30 @@ describe('translateDeep()', () => {
         expect(result.variants[1].featuredAsset).toHaveProperty('name', ASSET_NAME_EN);
     });
 
+    // The single-segment and two-segment non-array branches feed the shared
+    // `object[property] = value` assignment at the end of the loop, so they must preserve a
+    // null relation for the same reason as the array branch above — e.g.
+    // translate(collection, ctx, ['parent']) reaches the single-segment branch with a null
+    // parent on the root collection.
+    it('leaves a null relation as null for a single-segment path', () => {
+        (product as any).featuredAsset = null;
+
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], ['featuredAsset'] as any);
+
+        expect((result as any).featuredAsset).toBeNull();
+    });
+
+    it('leaves a null nested relation as null when the first level is not an array', () => {
+        (productVariant as any).featuredAsset = null;
+        testProduct.singleRealVariant = productVariant;
+
+        const result = translateDeep(testProduct, [LanguageCode.en, LanguageCode.en], [
+            ['singleRealVariant', 'featuredAsset'],
+        ] as any);
+
+        expect((result.singleRealVariant as any).featuredAsset).toBeNull();
+    });
+
     it('should translate a first-level nested non-array entity', () => {
         const result = translateDeep(testProduct, [LanguageCode.en, LanguageCode.en], ['singleRealVariant']);
 

--- a/packages/core/src/service/helpers/utils/translate-entity.spec.ts
+++ b/packages/core/src/service/helpers/utils/translate-entity.spec.ts
@@ -457,7 +457,7 @@ describe('translateDeep()', () => {
     // produces both deliberately. Translation must skip such elements rather than dereference
     // them, and must not rewrite a `null` into `undefined`, because getMissingRelations()
     // relies on that distinction to decide whether a relation still needs to be fetched.
-    it('does not throw when a relation array contains an undefined hole', () => {
+    it('preserves an undefined hole and translates the real elements of a relation array', () => {
         product.variants = [productVariant, undefined] as any;
 
         const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], ['variants']);
@@ -467,7 +467,7 @@ describe('translateDeep()', () => {
         expect(result.variants[1]).toBeUndefined();
     });
 
-    it('does not throw when a relation array contains a null element', () => {
+    it('preserves a null element and translates the real elements of a relation array', () => {
         product.variants = [null, productVariant] as any;
 
         const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], ['variants']);
@@ -477,12 +477,10 @@ describe('translateDeep()', () => {
         expect(result.variants[1]).toHaveProperty('name', VARIANT_NAME_EN);
     });
 
-    it('does not throw when a first-level array element is a hole', () => {
+    it('preserves a first-level hole and translates nested relations of later elements', () => {
         product.variants = [undefined, productVariant] as any;
 
-        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], [
-            ['variants', 'options'],
-        ] as any);
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], [['variants', 'options']]);
 
         expect(result.variants[0]).toBeUndefined();
         expect(result.variants[1].options[0]).toHaveProperty('name', OPTION_NAME_EN);
@@ -505,9 +503,11 @@ describe('translateDeep()', () => {
         secondVariant.featuredAsset = asset;
         product.variants = [productVariant, secondVariant];
 
-        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], [
-            ['variants', 'featuredAsset'],
-        ] as any);
+        const result = translateDeep(
+            product,
+            [LanguageCode.en, LanguageCode.en],
+            [['variants', 'featuredAsset']],
+        );
 
         expect(result.variants[0].featuredAsset).toBeNull();
         expect(result.variants[1].featuredAsset).toHaveProperty('name', ASSET_NAME_EN);
@@ -521,7 +521,7 @@ describe('translateDeep()', () => {
     it('leaves a null relation as null for a single-segment path', () => {
         (product as any).featuredAsset = null;
 
-        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], ['featuredAsset'] as any);
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], ['featuredAsset']);
 
         expect((result as any).featuredAsset).toBeNull();
     });
@@ -530,11 +530,23 @@ describe('translateDeep()', () => {
         (productVariant as any).featuredAsset = null;
         testProduct.singleRealVariant = productVariant;
 
-        const result = translateDeep(testProduct, [LanguageCode.en, LanguageCode.en], [
-            ['singleRealVariant', 'featuredAsset'],
-        ] as any);
+        const result = translateDeep(
+            testProduct,
+            [LanguageCode.en, LanguageCode.en],
+            [['singleRealVariant', 'featuredAsset']],
+        );
 
         expect((result.singleRealVariant as any).featuredAsset).toBeNull();
+    });
+
+    // A path deeper than two segments is outside what translateDeep() handles; it must fall
+    // through without creating a junk own-property from the stringified path array
+    it('does not create a junk own-property for a three-segment path', () => {
+        const result = translateDeep(product, [LanguageCode.en, LanguageCode.en], [
+            ['variants', 'featuredAsset', 'x'],
+        ] as any);
+
+        expect(Object.keys(result)).not.toContain('variants,featuredAsset,x');
     });
 
     it('should translate a first-level nested non-array entity', () => {

--- a/packages/core/src/service/helpers/utils/translate-entity.ts
+++ b/packages/core/src/service/helpers/utils/translate-entity.ts
@@ -215,8 +215,21 @@ export function translateDeep<T extends Translatable & VendureEntity>(
             if (Array.isArray(valueLevel0)) {
                 valueLevel0.forEach((nested1, index) => {
                     object = (translatedEntity as any)[path0][index];
+                    // An array-valued relation can contain `null`/`undefined` entries, so there
+                    // may be no entity here to assign to.
+                    if (object == null) {
+                        return;
+                    }
                     property = path1;
-                    object[property] = translateLeaf(object, property, languageCode);
+                    const translated = translateLeaf(object, property, languageCode);
+                    // translateLeaf() returns undefined when the relation is null. Assigning that
+                    // unconditionally would rewrite a relation that is null in the database into
+                    // one that looks like it was never fetched — a distinction
+                    // getMissingRelations() relies on, so hydrate() would stop being idempotent
+                    // and re-query the relation on every subsequent call.
+                    if (translated !== undefined) {
+                        object[property] = translated;
+                    }
                 });
                 property = '';
                 object = null;
@@ -247,6 +260,14 @@ function translateLeaf(
     if (object && object[property]) {
         if (Array.isArray(object[property])) {
             return object[property].map((nested2: any) => {
+                // A relation array can contain `null`/`undefined` entries: an element that was
+                // never fetched, or a relation that is null on that element. translateEntity()
+                // dereferences `.translations`, so a hole throws a TypeError — which would be
+                // re-thrown below rather than swallowed like InternalServerError. Leave holes
+                // untouched.
+                if (nested2 == null) {
+                    return nested2;
+                }
                 try {
                     return translateEntity(nested2, languageCode);
                 } catch (e: any) {

--- a/packages/core/src/service/helpers/utils/translate-entity.ts
+++ b/packages/core/src/service/helpers/utils/translate-entity.ts
@@ -244,11 +244,8 @@ export function translateDeep<T extends Translatable & VendureEntity>(
             value = translateLeaf(object, property, languageCode);
         }
 
-        // translateLeaf() returns undefined exactly when there is nothing to translate at the
-        // property — including when the relation is null in the database. Writing that back
-        // would rewrite null to undefined, destroying the distinction getMissingRelations()
-        // relies on (undefined = never fetched, null = fetched and null), same as in the
-        // array branch above.
+        // Shared by the non-array branches above: skip the assignment when there is nothing
+        // to translate, preserving null relations for the same reason as in the array branch.
         if (object && property && value !== undefined) {
             object[property] = value;
         }

--- a/packages/core/src/service/helpers/utils/translate-entity.ts
+++ b/packages/core/src/service/helpers/utils/translate-entity.ts
@@ -244,7 +244,12 @@ export function translateDeep<T extends Translatable & VendureEntity>(
             value = translateLeaf(object, property, languageCode);
         }
 
-        if (object && property) {
+        // translateLeaf() returns undefined exactly when there is nothing to translate at the
+        // property — including when the relation is null in the database. Writing that back
+        // would rewrite null to undefined, destroying the distinction getMissingRelations()
+        // relies on (undefined = never fetched, null = fetched and null), same as in the
+        // array branch above.
+        if (object && property && value !== undefined) {
             object[property] = value;
         }
     }


### PR DESCRIPTION
# Description

This is the second half of the follow-up agreed in #4986 — the `isTranslatable()` half of what @michaelbromley described there:

> Separate follow-up (not this PR): `isTranslatable()` and the price applicator still sample element `[0]`, so e.g. a null `variants[0].featuredAsset` suppresses translation of the newly-hydrated `variants[1].featuredAsset`.

The price-applicator half is #5058. This one is separate because fixing `isTranslatable()` correctly requires changes in `translate-entity.ts` — shared code with five call sites (`translator.service.ts`, `facet.service.ts` ×2, `facet-value.service.ts`, plus the hydrator) — and that scope deserves its own review rather than riding along with two mechanical single-file fixes.

## Why the gate change alone would be a regression (commit order)

Making `isTranslatable()` element-aware sends relation arrays that contain `null`/`undefined` entries into `translateDeep()` — which is exactly the case it was never asked to handle before. On master, `translateDeep()`/`translateLeaf()` have three defects on such arrays, each reproducible today **without** the hydrator change (unit tests for all three are RED on clean master):

1. `translateLeaf()` maps a relation array straight into `translateEntity()`, which dereferences `.translations` — an `undefined`/`null` element throws a `TypeError` out of `translateDeep()`.
2. The two-segment array branch assigns `object[property]` where `object` is the array element itself — a hole there throws `Cannot set properties of undefined`. Not reachable via `hydrate()` (`getRelationEntityAtPath()` throws first on that shape — verified by driving it), but `facet.service.ts` passes exactly this shape (`[['values', 'facet']]`) with plain TypeORM query results.
3. The same branch writes the result of `translateLeaf()` back unconditionally. `translateLeaf()` returns `undefined` for a `null` relation, so a relation that is **null in the database gets rewritten to `undefined`** — destroying the `undefined` = never-fetched / `null` = fetched-and-null distinction that `getMissingRelations()` relies on since #4986, which makes `hydrate()` lose idempotency and re-query such relations on every call. This one is live on master right now whenever the asset sits at element `[0]`.

So the PR is structured as two commits in dependency order: **commit 1** hardens `translateDeep()`/`translateLeaf()` (fixes the three defects above, independently valuable), **commit 2** makes `isTranslatable()` check every element (`.some()` over loaded `translations`), which is only safe on top of commit 1. If you'd rather land them separately, they split cleanly at the commit boundary.

**Updated after review (third commit):** I originally left the shared `if (object && property)` assignment guard at the end of `translateDeep()`'s loop untouched, reasoning that the non-array branches only ever receive defined values. That holds inside `hydrate()`, whose `isTranslatable()` gate filters null leaves — but not for the other four callers: `translate(collection, ctx, ['parent'])` reaches the single-segment branch with a `null` parent on the root collection and rewrote it to `undefined`. Coderabbit's review flagged this; I confirmed both non-array shapes with failing tests and applied the one-line guard (`value !== undefined`) — the same null-preservation rule the array branch already follows — pinned by two regression tests.

**Scope and perf notes (added per review):**

- The hardening stops at two path segments, which is all `DeepTranslatableRelations` can express: a three-segment path like `lines.productVariant.featuredAsset` is not translated by `translateDeep()`, before or after this PR.
- An incidental fix that fell out of the guard: a three-segment path used to leave a junk own-property on the entity (the stringified path array as key, e.g. `"variants,featuredAsset,x"`), because the fall-through branch assigned `undefined` under that key. Now pinned by a small test.
- Preserving `null` is a perf fix as well as a correctness one. `getMissingRelations()` treats `undefined` as never-fetched, so the old null-to-undefined rewrite made every subsequent `hydrate()` call re-query that relation. On master this fires whenever a relation is null at element `[0]`, i.e. on hot paths like order lines and variant lists.

# Breaking changes

None. Arrays whose element `[0]` was a hole now get their real entities translated (the documented behavior); `null` relations stay `null` instead of flipping to `undefined`; and `translateDeep()` no longer throws on arrays containing holes — every call site keeps its current behavior for fully-populated arrays, pinned by the existing 31 tests in `translate-entity.spec.ts` which all still pass.

# Testing

**Unit — `translate-entity.spec.ts` (6 new cases).** The last two (third commit) pin null-preservation for the single-segment and two-segment non-array paths — RED before the shared-assignment guard. The first four RED on clean master, one per defect plus one per failure direction: `TypeError (reading 'translations')` on an `undefined` hole and on a `null` element; `TypeError (setting 'options')` on a level-0 hole; and `null` featuredAsset rewritten to `undefined`. GREEN with commit 1 alone — they document live bugs independent of the `isTranslatable()` change, which is why they sit in the first commit.

**Unit — `entity-hydrator.service.spec.ts` (4 new cases).** Two are the regression guards for `isTranslatable()` (translatable entity behind a `null` / behind an `undefined` leading element — RED on master, `false` instead of `true`); two pin the `some` semantics (`[]` and no-translatable-element stay `false`) and pass before and after, stated so the coverage isn't overread.

**e2e — `entity-hydrator.e2e-spec.ts` (1 new case), run against a rebuilt dist.** No fixture changes: the full-products CSV gives Laptop four variants whose `featuredAsset` is null; the test gives exactly one variant the fixture asset, hydrates `variants.featuredAsset`, and asserts (a) the asset's `LocaleString` name is translated and (b) the other three variants are still `null`, not `undefined`. RED on master — on the sqlite row order the asset lands at the end of the array, so the `[0]` sample sees `null` and skips translation entirely (`name` stays `undefined`, the exact symptom from the quote above). The other ordering (asset at `[0]`, nulls rewritten to `undefined`) is covered deterministically by the unit tests. The shared-fixture mutation is restored in a `finally` block, the expected counts are derived from the fixture rather than hard-coded, and the expected asset name is the fixture literal, so the test is self-contained regardless of what runs after it.

What I ran:

| | Result |
|---|---|
| `translate-entity.spec.ts` before commit 1 | 4 failed / 31 passed |
| `entity-hydrator.service.spec.ts` before commit 2 | 2 failed / 17 passed |
| non-array null-preservation tests before commit 3's guard | 2 failed / 35 passed |
| All after (incl. the junk-own-property pin added in review) | 57 passed |
| Full core unit suite | 75 files, 1148 passed |
| `entity-hydrator.e2e-spec.ts` on master dist + new test | 1 failed (the new test) / 25 passed |
| `entity-hydrator.e2e-spec.ts` on fixed dist | 26 passed |

The pre-existing type error in `order.service.ts:1460` that stops `npm run build` locally is unrelated (reproduces on clean master); the import-order and require-await eslint warnings in the touched files reproduce identically on the master versions of those files.

### 🤖 AI assistance

I used Claude Code while working on this. I have reviewed every line of the change myself, and the testing table above reflects test runs I actually performed and observed — including verifying that each new regression test fails without its fix and passes with it.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [x] I have added or updated test cases
- [ ] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5059"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787968901&installation_model_id=20193&pr_number=5059&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5059&signature=0bb3222119610abca134f56284dc44dda787cb298f4bc1bec90b6e2dd0fbbe5d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

