### PR TITLE
fix(dashboard): Use standard background for affixed inputs

### DIFF
--- a/packages/dashboard/src/lib/components/data-input/money-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/money-input.tsx
@@ -69,7 +69,6 @@ export function MoneyInput(props: Readonly<MoneyInputProps>) {
     return (
         <AffixedInput
             type="text"
-            className="bg-background"
             value={displayValue}
             disabled={readOnly}
             {...rest}

--- a/packages/dashboard/src/lib/components/data-input/number-input.tsx
+++ b/packages/dashboard/src/lib/components/data-input/number-input.tsx
@@ -64,7 +64,6 @@ export function NumberInput({
                 step={step}
                 prefix={prefix}
                 suffix={suffix}
-                className="bg-background"
                 disabled={readOnly}
             />
         );


### PR DESCRIPTION
# Description

Removes the explicit `bg-background` overrides from money and number inputs so affixed inputs use the same surface styling as standard inputs. The overrides applied the gray page-level background token instead of inheriting the containing surface. Focused ESLint and diff checks pass; the full dashboard type check is currently blocked by missing local `@vendure/common` and `@vendure/core` builds.

# Breaking changes

No.

# Screenshots

Not applicable.

# Checklist

📌 Always:
- [x] I have set a clear title
- [x] My PR is small and contains a single feature
- [x] I have [checked my own PR](## "Fix typo's and remove unused or commented out code")

👍 Most of the time:
- [ ] I have added or updated test cases
- [x] I have updated the README if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5060"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787987506&installation_model_id=20193&pr_number=5060&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5060&signature=4a4c0861af57a8673d239555bc01a9ac8a1bfe8f945af6bea6c87013a74a495b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->