### PR TITLE
feat(core): Expose previous entity state on CollectionEvent updates

### DIFF
--- a/packages/core/e2e/entity-event-update-state.e2e-spec.ts
+++ b/packages/core/e2e/entity-event-update-state.e2e-spec.ts
@@ -1,5 +1,6 @@
 import {
     AdministratorEvent,
+    CollectionEvent,
     defaultShippingCalculator,
     defaultShippingEligibilityChecker,
     dummyPaymentHandler,
@@ -22,10 +23,12 @@ import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-conf
 
 import {
     createAdministratorDocument,
+    createCollectionDocument,
     createPromotionDocument,
     createRoleDocument,
     createShippingMethodDocument,
     updateAdministratorDocument,
+    updateCollectionDocument,
     updatePromotionDocument,
     updateShippingMethodDocument,
 } from './graphql/shared-definitions';
@@ -362,6 +365,54 @@ describe('Entity event updated state', () => {
 
             expect(event.type).toBe('updated');
             expect(event.entity.enabled).toBe(false);
+        });
+    });
+
+    describe('CollectionEvent', () => {
+        let collectionId: string;
+
+        it('setup: create collection', async () => {
+            const { createCollection } = await adminClient.query(createCollectionDocument, {
+                input: {
+                    filters: [],
+                    translations: [
+                        {
+                            languageCode: LanguageCode.en,
+                            name: 'Event Test Collection',
+                            description: '',
+                            slug: 'event-test-collection',
+                        },
+                    ],
+                },
+            });
+            collectionId = createCollection.id;
+            expect(collectionId).toBeDefined();
+        });
+
+        it('exposes the previous entity state on update', async () => {
+            const eventPromise = firstValueFrom(eventBus.ofType(CollectionEvent));
+
+            await adminClient.query(updateCollectionDocument, {
+                input: {
+                    id: collectionId,
+                    translations: [
+                        {
+                            languageCode: LanguageCode.en,
+                            name: 'Updated Collection Name',
+                            slug: 'event-test-collection',
+                        },
+                    ],
+                },
+            });
+
+            const event = await eventPromise;
+
+            expect(event.type).toBe('updated');
+            const current = event.entity.translations.find(t => t.languageCode === LanguageCode.en);
+            expect(current?.name).toBe('Updated Collection Name');
+            // previousEntity carries the pre-update state (#4402)
+            const previous = event.previousEntity?.translations.find(t => t.languageCode === LanguageCode.en);
+            expect(previous?.name).toBe('Event Test Collection');
         });
     });
 });

--- a/packages/core/e2e/entity-event-update-state.e2e-spec.ts
+++ b/packages/core/e2e/entity-event-update-state.e2e-spec.ts
@@ -413,6 +413,10 @@ describe('Entity event updated state', () => {
             // previousEntity carries the pre-update state (#4402)
             const previous = event.previousEntity?.translations.find(t => t.languageCode === LanguageCode.en);
             expect(previous?.name).toBe('Event Test Collection');
+            // previousEntity is loaded with its relation set (not just translations), so a
+            // non-translation relation must be present too — guards against silently dropping one.
+            expect(event.previousEntity?.channels).toBeDefined();
+            expect(event.previousEntity?.parent).toBeDefined();
         });
     });
 });

--- a/packages/core/src/event-bus/events/collection-event.ts
+++ b/packages/core/src/event-bus/events/collection-event.ts
@@ -21,6 +21,7 @@ export class CollectionEvent extends VendureEntityEvent<Collection, CollectionIn
         entity: Collection,
         type: 'created' | 'updated' | 'deleted',
         input?: CollectionInputTypes,
+        public readonly previousEntity?: Collection,
     ) {
         super(entity, type, ctx, input);
     }

--- a/packages/core/src/event-bus/events/collection-event.ts
+++ b/packages/core/src/event-bus/events/collection-event.ts
@@ -24,8 +24,10 @@ export class CollectionEvent extends VendureEntityEvent<Collection, CollectionIn
         /**
          * @description
          * The state of the Collection prior to the update, populated for `updated` events so that
-         * subscribers can diff against the previous values. It is loaded with the same relations
-         * (`featuredAsset`, `assets`, `channels`, `parent`, `translations`) as the updated entity.
+         * subscribers can diff against the previous values. It is loaded with the `featuredAsset`,
+         * `assets`, `channels`, `parent` and `translations` relations. Note this relation set is not
+         * identical to that of `entity` (the post-update collection), so reliable diffing is limited
+         * to `translations`, `featuredAsset`, `assets` and scalar columns.
          *
          * @since 3.8.0
          */

--- a/packages/core/src/event-bus/events/collection-event.ts
+++ b/packages/core/src/event-bus/events/collection-event.ts
@@ -21,6 +21,14 @@ export class CollectionEvent extends VendureEntityEvent<Collection, CollectionIn
         entity: Collection,
         type: 'created' | 'updated' | 'deleted',
         input?: CollectionInputTypes,
+        /**
+         * @description
+         * The state of the Collection prior to the update, populated for `updated` events so that
+         * subscribers can diff against the previous values. It is loaded with the same relations
+         * (`featuredAsset`, `assets`, `channels`, `parent`, `translations`) as the updated entity.
+         *
+         * @since 3.8.0
+         */
         public readonly previousEntity?: Collection,
     ) {
         super(entity, type, ctx, input);

--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -562,7 +562,16 @@ export class CollectionService implements OnModuleInit {
         // Ensure the entity belongs to the active channel before updating.
         await this.connection.getEntityOrThrow(ctx, Collection, input.id, { channelId: ctx.channelId });
         await this.slugValidator.validateSlugs(ctx, input, CollectionTranslation);
-        const collection = await this.translatableSaver.update({
+        const existingCollection = await this.connection.getEntityOrThrow<Collection>(
+            ctx,
+            Collection,
+            input.id,
+            {
+                channelId: ctx.channelId,
+            },
+        );
+
+        const collection = await this.translatableSaver.update<Collection>({
             ctx,
             input,
             entityType: Collection,
@@ -585,7 +594,9 @@ export class CollectionService implements OnModuleInit {
             const affectedVariantIds = await this.getCollectionProductVariantIds(collection);
             await this.eventBus.publish(new CollectionModificationEvent(ctx, collection, affectedVariantIds));
         }
-        await this.eventBus.publish(new CollectionEvent(ctx, collection, 'updated', input));
+        await this.eventBus.publish(
+            new CollectionEvent(ctx, collection, 'updated', input, existingCollection),
+        );
         return assertFound(this.findOne(ctx, collection.id));
     }
 

--- a/packages/core/src/service/services/collection.service.ts
+++ b/packages/core/src/service/services/collection.service.ts
@@ -559,17 +559,14 @@ export class CollectionService implements OnModuleInit {
     }
 
     async update(ctx: RequestContext, input: UpdateCollectionInput): Promise<Translated<Collection>> {
-        // Ensure the entity belongs to the active channel before updating.
-        await this.connection.getEntityOrThrow(ctx, Collection, input.id, { channelId: ctx.channelId });
+        // Load the collection as it exists before the update. This both ensures the collection
+        // belongs to the active channel and captures its previous state, exposed as `previousEntity`
+        // on the CollectionEvent below so subscribers can diff against the pre-update values.
+        const previousEntity = await this.connection.getEntityOrThrow(ctx, Collection, input.id, {
+            channelId: ctx.channelId,
+            relations: ['featuredAsset', 'assets', 'channels', 'parent', 'translations'],
+        });
         await this.slugValidator.validateSlugs(ctx, input, CollectionTranslation);
-        const existingCollection = await this.connection.getEntityOrThrow<Collection>(
-            ctx,
-            Collection,
-            input.id,
-            {
-                channelId: ctx.channelId,
-            },
-        );
 
         const collection = await this.translatableSaver.update<Collection>({
             ctx,
@@ -595,7 +592,7 @@ export class CollectionService implements OnModuleInit {
             await this.eventBus.publish(new CollectionModificationEvent(ctx, collection, affectedVariantIds));
         }
         await this.eventBus.publish(
-            new CollectionEvent(ctx, collection, 'updated', input, existingCollection),
+            new CollectionEvent(ctx, collection, 'updated', input, previousEntity),
         );
         return assertFound(this.findOne(ctx, collection.id));
     }


### PR DESCRIPTION
## Summary

Adds a `previousEntity` to `CollectionEvent`, populated for `updated` events, so subscribers can diff a collection against its pre-update state. Builds on and supersedes #4402 by @flobacher (their original commit is preserved).

## Root cause / motivation

`CollectionEvent` only exposed the post-update entity, so a subscriber wanting to react to *what changed* on a collection update had no access to the previous values.

The original PR (#4402) added `previousEntity` but loaded it via a bare `getEntityOrThrow` with no relations, leaving `translations` (and the other relations) empty — so the previous snapshot was not actually usable for diffing. It also introduced a second collection load alongside the existing active-channel guard.

## Change

- `collection-event.ts` — new `previousEntity?: Collection` constructor field, documented with `@since 3.8.0`. The doc notes its relation set is not identical to `entity`, so reliable diffing is limited to `translations`, `featuredAsset`, `assets` and scalar columns.
- `collection.service.ts` — `update()` loads the pre-update collection **once**, with `relations: ['featuredAsset', 'assets', 'channels', 'parent', 'translations']`. This single load both enforces the active-channel guard (unchanged semantics — `findOneInChannel` still filters by channel) and captures the previous snapshot, which is passed to the `updated` `CollectionEvent`. The redundant second load is removed. `productVariants`/`children` are deliberately excluded (potentially huge).
- Mutation-safety: TypeORM has no persistent identity map and `translatableSaver.update` builds a brand-new entity for the save, so `previousEntity` is a detached pre-update snapshot in all update paths (including filter changes).

## Test plan

**Automated** — extends `entity-event-update-state.e2e-spec.ts` (the suite that already covers post-update state for Promotion/ShippingMethod/Administrator/PaymentMethod events) with a `CollectionEvent` case: update a collection's name, assert `event.type === 'updated'`, `event.entity` has the new name, `event.previousEntity` has the **old** name, and that a non-translation relation (`channels`, `parent`) is loaded on the snapshot (guards against silently dropping a relation).

Verified against a freshly-built core:
```
✓ entity-event-update-state.e2e-spec.ts (13 tests)   # incl. the new CollectionEvent case
✓ collection.e2e-spec.ts (78 tests)                  # update() path regression
```
Without the fix, `event.previousEntity` is undefined and the new assertions fail.

Closes #4402

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5067"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788005244&installation_model_id=20193&pr_number=5067&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5067&signature=2ad18335624c0d0ac3b58b42ec58795f5dcd7ceacb2419feb96f791244c30eb3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->