### PR TITLE
fix(core): Scope customFields auto-init to this server's entities

### DIFF
--- a/packages/core/src/bootstrap.spec.ts
+++ b/packages/core/src/bootstrap.spec.ts
@@ -5,9 +5,9 @@ import { runPluginConfigurations } from './bootstrap';
 import { CustomFieldConfig } from './config/custom-field/custom-field-types';
 import { RuntimeVendureConfig } from './config/vendure-config';
 // Importing the core entities registers their `customFields` embedded columns in the
-// TypeORM metadata; `coreEntitiesMap` also provides the concrete entity list a real server
-// is configured with, which getEntityNamesWithCustomFields() now scopes its seeding to.
-import { coreEntitiesMap } from './entity/entities';
+// TypeORM metadata, and populates `coreEntitiesMap` (which `getAllEntities`, and therefore the
+// auto-init seeding, reads). Imported for its side effect only.
+import './entity/entities';
 import { registerCustomEntityFields } from './entity/register-custom-entity-fields';
 import { VendurePlugin } from './plugin/vendure-plugin';
 
@@ -46,12 +46,7 @@ function makeConfig(partial: {
     plugins?: RuntimeVendureConfig['plugins'];
     customFields?: Record<string, CustomFieldConfig[]>;
 }): RuntimeVendureConfig {
-    return {
-        plugins: [],
-        customFields: {},
-        dbConnectionOptions: { entities: Object.values(coreEntitiesMap) },
-        ...partial,
-    } as unknown as RuntimeVendureConfig;
+    return { plugins: [], customFields: {}, ...partial } as unknown as RuntimeVendureConfig;
 }
 
 describe('runPluginConfigurations()', () => {
@@ -62,6 +57,17 @@ describe('runPluginConfigurations()', () => {
         await runPluginConfigurations(config);
         expect(config.customFields.Product).toEqual([]);
         expect(config.customFields.Customer).toEqual([]);
+    });
+
+    // OSS-653: runPluginConfigurations is also called directly (CLI/dashboard schema generators,
+    // codegen) with a config that never passed through preBootstrapConfig, so `dbConnectionOptions`
+    // carries no `entities`. Seeding must still work there — the entity list is derived from
+    // `config` (core entities + plugin entities) via getAllEntities, not from dbConnectionOptions.
+    it('seeds core entities when the config has no dbConnectionOptions.entities', async () => {
+        const config = makeConfig({});
+        expect((config as any).dbConnectionOptions?.entities).toBeUndefined();
+        await runPluginConfigurations(config);
+        expect(config.customFields.Product).toEqual([]);
     });
 
     // OSS-408: translation entities also declare a `customFields` embedded (for localized

--- a/packages/core/src/bootstrap.spec.ts
+++ b/packages/core/src/bootstrap.spec.ts
@@ -106,6 +106,33 @@ describe('runPluginConfigurations()', () => {
         }
     });
 
+    // OSS-408: the core point of the feature — a plugin's OWN entity that supports custom fields
+    // gets a seeded key too, so the plugin's `configuration` callback can extend it without a
+    // defensive guard. Contrast with the phantom-entity test above: seeding happens here because
+    // the entity is registered with this server (via the plugin's `entities`), not merely present
+    // in the global metadata.
+    it('seeds customFields for a plugin-registered entity', async () => {
+        const storage = getMetadataArgsStorage();
+        class Oss408PluginEntity {}
+        storage.embeddeds.push({
+            target: Oss408PluginEntity,
+            propertyName: 'customFields',
+            prefix: undefined,
+            type: () => Oss408PluginEntity,
+        } as any);
+
+        @VendurePlugin({ entities: [Oss408PluginEntity] })
+        class TestPlugin {}
+
+        try {
+            const config = makeConfig({ plugins: [TestPlugin] });
+            await runPluginConfigurations(config);
+            expect(config.customFields.Oss408PluginEntity).toEqual([]);
+        } finally {
+            storage.embeddeds.pop();
+        }
+    });
+
     it('does not overwrite an existing customFields entry', async () => {
         const existing: CustomFieldConfig[] = [{ name: 'foo', type: 'string' }];
         const config = makeConfig({ customFields: { Product: existing } });

--- a/packages/core/src/bootstrap.spec.ts
+++ b/packages/core/src/bootstrap.spec.ts
@@ -5,9 +5,9 @@ import { runPluginConfigurations } from './bootstrap';
 import { CustomFieldConfig } from './config/custom-field/custom-field-types';
 import { RuntimeVendureConfig } from './config/vendure-config';
 // Importing the core entities registers their `customFields` embedded columns in the
-// TypeORM metadata, which is how getEntityNamesWithCustomFields() detects the entities
-// that support custom fields. Imported for its side effect only.
-import './entity/entities';
+// TypeORM metadata; `coreEntitiesMap` also provides the concrete entity list a real server
+// is configured with, which getEntityNamesWithCustomFields() now scopes its seeding to.
+import { coreEntitiesMap } from './entity/entities';
 import { registerCustomEntityFields } from './entity/register-custom-entity-fields';
 import { VendurePlugin } from './plugin/vendure-plugin';
 
@@ -46,7 +46,12 @@ function makeConfig(partial: {
     plugins?: RuntimeVendureConfig['plugins'];
     customFields?: Record<string, CustomFieldConfig[]>;
 }): RuntimeVendureConfig {
-    return { plugins: [], customFields: {}, ...partial } as unknown as RuntimeVendureConfig;
+    return {
+        plugins: [],
+        customFields: {},
+        dbConnectionOptions: { entities: Object.values(coreEntitiesMap) },
+        ...partial,
+    } as unknown as RuntimeVendureConfig;
 }
 
 describe('runPluginConfigurations()', () => {
@@ -68,6 +73,31 @@ describe('runPluginConfigurations()', () => {
         await runPluginConfigurations(config);
         expect(config.customFields.ProductTranslation).toBeUndefined();
         expect(config.customFields.CollectionTranslation).toBeUndefined();
+    });
+
+    // OSS-653: seeding must be scoped to the entities registered with THIS server, not the global
+    // TypeORM metadata storage. An entity whose `customFields` embedded is present in the process
+    // (e.g. a second test server in the same process, or an imported-but-uninstalled plugin) but
+    // is not in this server's entity list must not produce a phantom `config.customFields` key.
+    it('does not seed customFields for entities not registered with this server', async () => {
+        const storage = getMetadataArgsStorage();
+        class Oss653PhantomEntity {}
+        storage.embeddeds.push({
+            target: Oss653PhantomEntity,
+            propertyName: 'customFields',
+            prefix: undefined,
+            type: () => Oss653PhantomEntity,
+        } as any);
+        try {
+            const config = makeConfig({});
+            await runPluginConfigurations(config);
+            // a real, registered entity is still seeded…
+            expect(config.customFields.Product).toEqual([]);
+            // …but the phantom entity present only in the global metadata is not
+            expect(config.customFields.Oss653PhantomEntity).toBeUndefined();
+        } finally {
+            storage.embeddeds.pop();
+        }
     });
 
     it('does not overwrite an existing customFields entry', async () => {

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -384,10 +384,12 @@ export async function runPluginConfigurations(config: RuntimeVendureConfig): Pro
     // `if (!config.customFields.SomeEntity) config.customFields.SomeEntity = []` guard.
     // Empty arrays are ignored by `registerCustomEntityFields`, so this is inert for
     // entities nobody extends. See OSS-408. Seeding is scoped to this server's entities
-    // (set on `dbConnectionOptions.entities` by `preBootstrapConfig` via `getAllEntities`)
-    // rather than the global TypeORM metadata, to avoid phantom keys from entities that are
-    // imported into the process but not registered with this server (OSS-653).
-    const entities = (config.dbConnectionOptions?.entities ?? []) as Array<Type<any>>;
+    // (core entities plus this config's plugin entities, via `getAllEntities`) rather than the
+    // global TypeORM metadata, to avoid phantom keys from entities imported into the process but
+    // not registered with this server — a second server in the same process, or an
+    // imported-but-uninstalled plugin (OSS-653). Derived from `config` so every caller of
+    // `runPluginConfigurations` is covered, not only the `preBootstrapConfig` path.
+    const entities = getAllEntities(config);
     for (const entityName of getEntityNamesWithCustomFields(entities)) {
         if (!Object.prototype.hasOwnProperty.call(config.customFields, entityName)) {
             config.customFields[entityName] = [];

--- a/packages/core/src/bootstrap.ts
+++ b/packages/core/src/bootstrap.ts
@@ -383,8 +383,12 @@ export async function runPluginConfigurations(config: RuntimeVendureConfig): Pro
     // `config.customFields.SomeEntity.push(...)` without the defensive
     // `if (!config.customFields.SomeEntity) config.customFields.SomeEntity = []` guard.
     // Empty arrays are ignored by `registerCustomEntityFields`, so this is inert for
-    // entities nobody extends. See OSS-408.
-    for (const entityName of getEntityNamesWithCustomFields()) {
+    // entities nobody extends. See OSS-408. Seeding is scoped to this server's entities
+    // (set on `dbConnectionOptions.entities` by `preBootstrapConfig` via `getAllEntities`)
+    // rather than the global TypeORM metadata, to avoid phantom keys from entities that are
+    // imported into the process but not registered with this server (OSS-653).
+    const entities = (config.dbConnectionOptions?.entities ?? []) as Array<Type<any>>;
+    for (const entityName of getEntityNamesWithCustomFields(entities)) {
         if (!Object.prototype.hasOwnProperty.call(config.customFields, entityName)) {
             config.customFields[entityName] = [];
         }

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { CustomFieldType } from '@vendure/common/lib/shared-types';
+import { CustomFieldType, Type } from '@vendure/common/lib/shared-types';
 import { assertNever } from '@vendure/common/lib/shared-utils';
 import {
     Column,
@@ -47,7 +47,12 @@ const MAX_STRING_LENGTH = 65535;
  * translation entities as the target of a `translations` relation, the same signal
  * `registerCustomEntityFields` uses to locate the translation type.
  */
-export function getEntityNamesWithCustomFields(): string[] {
+export function getEntityNamesWithCustomFields(entities: Array<Type<any>>): string[] {
+    // Scope to the entities actually registered with this server. The global metadata storage
+    // holds every entity imported anywhere in the process — including ones not registered here
+    // (a second server in the same process, or an imported-but-uninstalled plugin) — which would
+    // otherwise seed phantom `config.customFields` keys.
+    const registeredEntityNames = new Set(entities.map(entity => entity.name));
     const metadataArgsStorage = getMetadataArgsStorage();
     const translationEntityNames = new Set(
         metadataArgsStorage.relations
@@ -58,6 +63,7 @@ export function getEntityNamesWithCustomFields(): string[] {
     const names = metadataArgsStorage.embeddeds
         .filter(embedded => embedded.propertyName === 'customFields')
         .map(embedded => (typeof embedded.target === 'string' ? embedded.target : embedded.target.name))
+        .filter(name => registeredEntityNames.has(name))
         .filter(name => !translationEntityNames.has(name));
     return Array.from(new Set(names));
 }

--- a/packages/core/src/entity/register-custom-entity-fields.ts
+++ b/packages/core/src/entity/register-custom-entity-fields.ts
@@ -54,6 +54,9 @@ export function getEntityNamesWithCustomFields(entities: Array<Type<any>>): stri
     // otherwise seed phantom `config.customFields` keys.
     const registeredEntityNames = new Set(entities.map(entity => entity.name));
     const metadataArgsStorage = getMetadataArgsStorage();
+    // The translation-entity exclusion set is intentionally built from the process-global metadata:
+    // it is only ever used to exclude, and the candidate names are already filtered to
+    // `registeredEntityNames` below, so a superset here is harmless.
     const translationEntityNames = new Set(
         metadataArgsStorage.relations
             .filter(relation => relation.propertyName === 'translations')


### PR DESCRIPTION
## Summary

Scopes the `config.customFields` auto-initialisation (added in #4965 / OSS-408) to the entities actually registered with this server, instead of every entity present in the process-global TypeORM metadata.

## Root cause

`getEntityNamesWithCustomFields()` read the global `getMetadataArgsStorage()`, which holds every entity imported *anywhere* in the process — including entities not registered with this server (a second server in the same process, or an imported-but-uninstalled plugin). Those produced phantom `config.customFields[EntityName]` keys, which surface as fields on the deprecated `ServerConfig.customFieldConfig` type.

## Change

- `getEntityNamesWithCustomFields(entities)` now takes the server's entity list and only seeds names present in it (the translation-entity exclusion is unchanged; its set stays process-global as it is only used to exclude).
- `runPluginConfigurations()` derives that list with `getAllEntities(config)` (core entities + this config's plugin entities). This is done from `config` rather than `dbConnectionOptions.entities` so **every** caller is covered — not only the `preBootstrapConfig`/`bootstrap()` path, but also the CLI/dashboard schema generators and codegen, which call `runPluginConfigurations` with a config that never set `dbConnectionOptions.entities`. `getEntityNamesWithCustomFields` is internal (not re-exported), so its signature change is safe.

## Test plan

**Automated** — `bootstrap.spec.ts`:
- New: an entity whose `customFields` embedded is present only in the global metadata (not in the server's list) must **not** get a phantom key, while a real entity (Product) still does. Fails without the fix.
- New: a config with no `dbConnectionOptions.entities` (the schema-generator/codegen caller shape) still seeds core entities — locks out the regression of reading the list from `dbConnectionOptions`.

```
✓ src/bootstrap.spec.ts (10 tests)   # RED→GREEN on the two new cases
eslint: 0 errors
```

**Manual** — no runtime behaviour change for a normal single-server bootstrap beyond the removal of phantom `customFieldConfig` fields for unregistered entities.

Relates to #4965


## Behaviour change (CLI / codegen callers)

`runPluginConfigurations` now derives its entity list via `getAllEntities(config)`, which throws `error.entity-name-conflict` when a plugin declares an entity whose name collides with an existing (core or other-plugin) entity. The direct callers — CLI/dashboard schema generators and codegen — previously did not go through this path, so a config with such a name conflict could still generate a schema; it now fails fast on those configs. Only already-ambiguous configs are affected.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5068"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788008513&installation_model_id=20193&pr_number=5068&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5068&signature=d7d258f622cfd682cc6a2382d4cf62375d16c17d0302fa208bf005f88cb498ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
