### PR TITLE
fix(core): Enforce channel permission check on Promotion assign/remove

### DIFF
--- a/packages/core/e2e/promotion.e2e-spec.ts
+++ b/packages/core/e2e/promotion.e2e-spec.ts
@@ -1,4 +1,10 @@
-import { CurrencyCode, DeletionResult, ErrorCode, LanguageCode } from '@vendure/common/lib/generated-types';
+import {
+    CurrencyCode,
+    DeletionResult,
+    ErrorCode,
+    LanguageCode,
+    Permission,
+} from '@vendure/common/lib/generated-types';
 import { pick } from '@vendure/common/lib/pick';
 import { ConfigService, type PromotionAction, PromotionCondition, PromotionOrderAction } from '@vendure/core';
 import {
@@ -17,8 +23,10 @@ import { TEST_SETUP_TIMEOUT_MS, testConfig } from '../../../e2e-common/test-conf
 
 import {
     assignPromotionsToChannelDocument,
+    createAdministratorDocument,
     createChannelDocument,
     createPromotionDocument,
+    createRoleDocument,
     deletePromotionDocument,
     getAdjustmentOperationsDocument,
     getPromotionDocument,
@@ -384,6 +392,63 @@ describe('Promotion resolver', () => {
                 id: promotion.id,
             });
             expect(result?.name).toBe('test promotion');
+        });
+
+        describe('cannot assign/remove without permission on the target channel', () => {
+            const RESTRICTED_ADMIN_EMAIL = 'promotion-channel-permission-test@e2e.com';
+            const RESTRICTED_ADMIN_PASSWORD = 'test';
+
+            beforeAll(async () => {
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                await adminClient.asSuperAdmin();
+                const { createRole } = await adminClient.query(createRoleDocument, {
+                    input: {
+                        code: 'promotion-channel-permission-test-role',
+                        description: '',
+                        channelIds: [secondChannel.id],
+                        permissions: [Permission.UpdatePromotion],
+                    },
+                });
+                await adminClient.query(createAdministratorDocument, {
+                    input: {
+                        firstName: 'Restricted',
+                        lastName: 'Admin',
+                        emailAddress: RESTRICTED_ADMIN_EMAIL,
+                        password: RESTRICTED_ADMIN_PASSWORD,
+                        roleIds: [createRole.id],
+                    },
+                });
+                adminClient.setChannelToken(SECOND_CHANNEL_TOKEN);
+                await adminClient.asUserWithCredentials(RESTRICTED_ADMIN_EMAIL, RESTRICTED_ADMIN_PASSWORD);
+            });
+
+            afterAll(async () => {
+                await adminClient.asSuperAdmin();
+                adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+            });
+
+            it('cannot assign a Promotion to a channel it has no permission on', async () => {
+                // the restricted admin only has UpdatePromotion on secondChannel, not on the default channel
+                await expect(
+                    adminClient.query(assignPromotionsToChannelDocument, {
+                        input: {
+                            channelId: 'T_1',
+                            promotionIds: [promotion.id],
+                        },
+                    }),
+                ).rejects.toThrow(/not currently authorized/);
+            });
+
+            it('cannot remove a Promotion from a channel it has no permission on', async () => {
+                await expect(
+                    adminClient.query(removePromotionsFromChannelDocument, {
+                        input: {
+                            channelId: 'T_1',
+                            promotionIds: [promotion.id],
+                        },
+                    }),
+                ).rejects.toThrow(/not currently authorized/);
+            });
         });
     });
 

--- a/packages/core/e2e/promotion.e2e-spec.ts
+++ b/packages/core/e2e/promotion.e2e-spec.ts
@@ -401,6 +401,18 @@ describe('Promotion resolver', () => {
             beforeAll(async () => {
                 adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
                 await adminClient.asSuperAdmin();
+
+                // The restricted admin can only act on Promotions it can already see in its
+                // own active channel (secondChannel). Put the Promotion there first, as
+                // SuperAdmin, so the tests below exercise the real assign/remove logic
+                // instead of being stopped earlier by the channel-visibility filter.
+                await adminClient.query(assignPromotionsToChannelDocument, {
+                    input: {
+                        channelId: secondChannel.id,
+                        promotionIds: [promotion.id],
+                    },
+                });
+
                 const { createRole } = await adminClient.query(createRoleDocument, {
                     input: {
                         code: 'promotion-channel-permission-test-role',
@@ -425,6 +437,25 @@ describe('Promotion resolver', () => {
             afterAll(async () => {
                 await adminClient.asSuperAdmin();
                 adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
+                await adminClient.query(removePromotionsFromChannelDocument, {
+                    input: {
+                        channelId: secondChannel.id,
+                        promotionIds: [promotion.id],
+                    },
+                });
+            });
+
+            it('can assign a Promotion to a channel it has permission on', async () => {
+                // Positive control: proves the restricted admin's permissions genuinely work,
+                // so the rejections below can be trusted to be specifically about the target
+                // channel, not some other authorization gate.
+                const { assignPromotionsToChannel } = await adminClient.query(assignPromotionsToChannelDocument, {
+                    input: {
+                        channelId: secondChannel.id,
+                        promotionIds: [promotion.id],
+                    },
+                });
+                expect(assignPromotionsToChannel).toEqual([{ id: promotion.id, name: promotion.name }]);
             });
 
             it('cannot assign a Promotion to a channel it has no permission on', async () => {

--- a/packages/core/e2e/promotion.e2e-spec.ts
+++ b/packages/core/e2e/promotion.e2e-spec.ts
@@ -402,10 +402,8 @@ describe('Promotion resolver', () => {
                 adminClient.setChannelToken(E2E_DEFAULT_CHANNEL_TOKEN);
                 await adminClient.asSuperAdmin();
 
-                // The restricted admin can only act on Promotions it can already see in its
-                // own active channel (secondChannel). Put the Promotion there first, as
-                // SuperAdmin, so the tests below exercise the real assign/remove logic
-                // instead of being stopped earlier by the channel-visibility filter.
+                // Make the Promotion visible in secondChannel so the restricted admin can
+                // reach it below, rather than being stopped by the visibility filter.
                 await adminClient.query(assignPromotionsToChannelDocument, {
                     input: {
                         channelId: secondChannel.id,
@@ -446,9 +444,7 @@ describe('Promotion resolver', () => {
             });
 
             it('can assign a Promotion to a channel it has permission on', async () => {
-                // Positive control: proves the restricted admin's permissions genuinely work,
-                // so the rejections below can be trusted to be specifically about the target
-                // channel, not some other authorization gate.
+                // Positive control for the rejections below.
                 const { assignPromotionsToChannel } = await adminClient.query(assignPromotionsToChannelDocument, {
                     input: {
                         channelId: secondChannel.id,

--- a/packages/core/src/service/services/promotion.service.ts
+++ b/packages/core/src/service/services/promotion.service.ts
@@ -213,11 +213,9 @@ export class PromotionService {
         ctx: RequestContext,
         input: AssignPromotionsToChannelInput,
     ): Promise<Promotion[]> {
-        const hasPermission = await this.roleService.userHasPermissionOnChannel(
-            ctx,
-            input.channelId,
+        const hasPermission = await this.roleService.userHasAnyPermissionsOnChannel(ctx, input.channelId, [
             Permission.UpdatePromotion,
-        );
+        ]);
         if (!hasPermission) {
             throw new ForbiddenError();
         }
@@ -235,11 +233,9 @@ export class PromotionService {
     }
 
     async removePromotionsFromChannel(ctx: RequestContext, input: RemovePromotionsFromChannelInput) {
-        const hasPermission = await this.roleService.userHasPermissionOnChannel(
-            ctx,
-            input.channelId,
+        const hasPermission = await this.roleService.userHasAnyPermissionsOnChannel(ctx, input.channelId, [
             Permission.UpdatePromotion,
-        );
+        ]);
         if (!hasPermission) {
             throw new ForbiddenError();
         }

--- a/packages/core/src/service/services/promotion.service.ts
+++ b/packages/core/src/service/services/promotion.service.ts
@@ -9,6 +9,7 @@ import {
     DeletionResponse,
     DeletionResult,
     OrderType,
+    Permission,
     RemovePromotionsFromChannelInput,
     UpdatePromotionInput,
     UpdatePromotionResult,
@@ -20,7 +21,7 @@ import { In, IsNull, Raw } from 'typeorm';
 import { RequestContext } from '../../api/common/request-context';
 import { RelationPaths } from '../../api/decorators/relations.decorator';
 import { ErrorResultUnion, JustErrorResults } from '../../common/error/error-result';
-import { UserInputError } from '../../common/error/errors';
+import { ForbiddenError, UserInputError } from '../../common/error/errors';
 import { MissingConditionsError } from '../../common/error/generated-graphql-admin-errors';
 import {
     CouponCodeExpiredError,
@@ -48,6 +49,7 @@ import { TranslatableSaver } from '../helpers/translatable-saver/translatable-sa
 import { TranslatorService } from '../helpers/translator/translator.service';
 
 import { ChannelService } from './channel.service';
+import { RoleService } from './role.service';
 
 /**
  * @description
@@ -71,6 +73,7 @@ export class PromotionService {
         private eventBus: EventBus,
         private translatableSaver: TranslatableSaver,
         private translator: TranslatorService,
+        private roleService: RoleService,
     ) {
         this.availableConditions = this.configService.promotionOptions.promotionConditions || [];
         this.availableActions = this.configService.promotionOptions.promotionActions || [];
@@ -210,6 +213,14 @@ export class PromotionService {
         ctx: RequestContext,
         input: AssignPromotionsToChannelInput,
     ): Promise<Promotion[]> {
+        const hasPermission = await this.roleService.userHasPermissionOnChannel(
+            ctx,
+            input.channelId,
+            Permission.UpdatePromotion,
+        );
+        if (!hasPermission) {
+            throw new ForbiddenError();
+        }
         const promotions = await this.connection.findByIdsInChannel(
             ctx,
             Promotion,
@@ -224,6 +235,14 @@ export class PromotionService {
     }
 
     async removePromotionsFromChannel(ctx: RequestContext, input: RemovePromotionsFromChannelInput) {
+        const hasPermission = await this.roleService.userHasPermissionOnChannel(
+            ctx,
+            input.channelId,
+            Permission.UpdatePromotion,
+        );
+        if (!hasPermission) {
+            throw new ForbiddenError();
+        }
         const promotions = await this.connection.findByIdsInChannel(
             ctx,
             Promotion,


### PR DESCRIPTION
Fixes #5071

An administrator who only manages one shop could push their own promotion into a completely different shop, or pull an existing promotion out of it, even with zero permission there. The action never checked whether the person doing it was actually allowed to touch that other shop, it only checked that they were allowed to manage promotions somewhere.

What this fix does

Adds one check before either action runs: does the person making the request actually have permission in the specific shop they're trying to push into or pull from. If not, it's rejected. Same idea already used correctly elsewhere in the codebase for similar actions on other entity types, just applied here too.

Tests

Added two tests that create a real, narrowly scoped staff account (not a superadmin) and confirm it gets correctly blocked when trying to touch a shop it has no permission on. Confirmed these tests actually fail without the fix and pass with it, and nothing else in the existing test file broke.

Breaking changes

None. Nothing changes for anyone acting within a shop they're already allowed to manage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/vendurehq/codesmith/vendure/pr/5072"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1788026438&installation_model_id=20193&pr_number=5072&repository=vendurehq%2Fvendure&return_to=https%3A%2F%2Fgithub.com%2Fvendurehq%2Fvendure%2Fpull%2F5072&signature=91ed6b7a1e2c38bf73112de66dd03c8c24ffaac80a0fe967442fc61ba5b77fc2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->